### PR TITLE
Notebook tests

### DIFF
--- a/shippable.yml
+++ b/shippable.yml
@@ -146,4 +146,5 @@ script:
 
 # commands to run after tests are done
 after_script:
+  - pwd
   - ls -alh


### PR DESCRIPTION
These commits add tests to the test suite which make sure the two iPython notebooks can be converted into python scripts and successfully run in ipython.

In order to do this, the plotting requirements are also installed on the server.

@swkeemink Do you have any thoughts on this before I merge into into the develop branch?

I think it might be a good idea to run the non-notebook tests without installing the contents of requirements_plots.txt. I could set it up to do this if we have the notebook tests defined in shippable.yml and not inside the test suite in tests/.
