### PR TITLE
BUG: Fix f0 detection with low sampling rates

### DIFF
--- a/fissa/deltaf.py
+++ b/fissa/deltaf.py
@@ -39,7 +39,7 @@ def findBaselineF0(rawF, fs, axis=0, keepdims=False):
     """
     # Parameters --------------------------------------------------------------
     nfilt = 30  # Number of taps to use in FIR filter
-    fw_base = 1  # Cut-off frequency for lowpass filter
+    fw_base = 1  # Cut-off frequency for lowpass filter, in Hz
     base_pctle = 5  # Percentile to take as baseline value
 
     # Main --------------------------------------------------------------------
@@ -49,16 +49,29 @@ def findBaselineF0(rawF, fs, axis=0, keepdims=False):
     # Remove the first datapoint, because it can be an erroneous sample
     rawF = np.split(rawF, [1], axis)[1]
 
-    # The Nyquist rate of the signal is half the sampling frequency
-    nyq_rate = fs / 2.0
+    if fs <= fw_base:
+        # If our sampling frequency is less than our goal with the smoothing
+        # (sampling at less than 1Hz) we don't need to apply the filter.
+        filtered_f = rawF
 
-    # Make a set of weights to use with our taps.
-    # We use an FIR filter with a Hamming window.
-    b = scipy.signal.firwin(nfilt, cutoff=fw_base / nyq_rate, window='hamming')
+    else:
+        # The Nyquist rate of the signal is half the sampling frequency
+        nyq_rate = fs / 2.0
 
-    # Use lfilter to filter with the FIR filter.
-    # We filter along the second dimension because that represents time
-    filtered_f = scipy.signal.filtfilt(b, [1.0], rawF, axis=axis)
+        # Cut-off needs to be relative to the nyquist rate. For sampling
+        # frequencies in the range from our target lowpass filter, to
+        # twice our target (i.e. the 1Hz to 2Hz range) we instead filter
+        # at the Nyquist rate, which is the highest possible frequency to
+        # filter at.
+        cutoff = min(1.0, fw_base / nyq_rate)
+
+        # Make a set of weights to use with our taps.
+        # We use an FIR filter with a Hamming window.
+        b = scipy.signal.firwin(nfilt, cutoff=cutoff, window='hamming')
+
+        # Use lfilter to filter with the FIR filter.
+        # We filter along the second dimension because that represents time
+        filtered_f = scipy.signal.filtfilt(b, [1.0], rawF, axis=axis)
 
     # Take a percentile of the filtered signal
     baselineF0 = np.percentile(filtered_f, base_pctle, axis=axis,


### PR DESCRIPTION
Can't filter at 1Hz for signals with fs < 2Hz!

Instead, we now
- low-pass filter at 1Hz for fs > 2Hz
- low-pass filter at Nyquist rate for frequencies  1Hz < fs < 2Hz
- don't filter for fs < 1 Hz

Closes #25.