### PR TITLE
DOC: Change build status badge Shippable->Travis

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Join the FISSA chat](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/rochefort-lab/fissa)
-[![Shippable](https://img.shields.io/shippable/56391d7a1895ca4474227917.svg)](https://app.shippable.com/projects/56391d7a1895ca4474227917)
+[![Travis Build Status](https://travis-ci.org/rochefort-lab/fissa.svg?branch=master)](https://travis-ci.org/rochefort-lab/fissa)
 
 
 FISSA


### PR DESCRIPTION
Making this change because Shippable doesn't support Python 3.7,
whereas Travis does, so I would rather test on Travis over
Shippable. Since I will soon be adding Python 3.7 to the CI build
list, Shippable will start failing and so I want the badge to
swap to Travis before that happens.