### PR TITLE
DOC: fix docstrings

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -191,7 +191,7 @@ This document was based on the contribution guidelines for
   [Git documentation]: http://git-scm.com/documentation
   [numpy workflow]: https://docs.scipy.org/doc/numpy-1.10.1/dev/gitwash/development_workflow.html
   [numpy workflow commits]: https://docs.scipy.org/doc/numpy-1.10.1/dev/gitwash/development_workflow.html#writing-the-commit-message
-  [numpy documenting]: https://github.com/numpy/numpy/blob/master/doc/HOWTO_DOCUMENT.rst.txt#sections
+  [numpy documenting]: https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard
   [numpy documenting example]: https://sphinxcontrib-napoleon.readthedocs.org/en/latest/example_numpy.html
   [sklearn contributing]: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md
   [sklearn guide]: http://scikit-learn.org/stable/developers/contributing.html#contributing-code

--- a/fissa/core.py
+++ b/fissa/core.py
@@ -130,7 +130,7 @@ class Experiment():
             - an explicit list of TIFF files (list of strings),
             - a list of array_like data already loaded into memory,
               each shaped `(frames, y-coords, x-coords)`.
-            Note that each tiff/array is considered a single trial.
+            Note that each TIFF/array is considered a single trial.
         rois : string or list
             The roi definitions.
             Should be one of:

--- a/fissa/core.py
+++ b/fissa/core.py
@@ -36,10 +36,10 @@ def extract_func(inputs):
 
     Returns
     -------
-    dictionary
-        dictionary containing data across cells
-    dictionary
-        dictionary containing polygons for each ROI
+    dict
+        Data across cells.
+    dict
+        Polygons for each ROI.
     """
     image = inputs[0]
     rois = inputs[1]
@@ -85,11 +85,19 @@ def separate_func(inputs):
         list of inputs
         [0] : Array with signals to separate
         [1] : Alpha input to npil.separate
-        [2] : current ROI number
+        [2] : method
+        [3] : current ROI number
 
     Returns
     -------
-    some output
+    numpy.ndarray
+        The raw separated traces.
+    numpy.ndarray
+        The separated traces matched to the primary signal.
+    numpy.ndarray
+        Mixing matrix.
+    dict
+        Metadata for the convergence result.
 
     """
     X = inputs[0]
@@ -116,50 +124,62 @@ class Experiment():
         Parameters
         ----------
         images : string or list
-            The raw images data.
-            Should be the path to a folder with tiffs,
-            an explicit list of tiff locations (strings),
-            or a list of already loaded in arrays.
-            Each tiff/array is seen as a single trial.
-            Non tiff data should be formatted as (frames,y-coords,x-coords)
+            The raw recording data.
+            Should be one of:
+            - the path to a directory containing TIFF files (string),
+            - an explicit list of TIFF files (list of strings),
+            - a list of array_like data already loaded into memory,
+              each shaped `(frames, y-coords, x-coords)`.
+            Note that each tiff/array is considered a single trial.
         rois : string or list
             The roi definitions.
-            Should be the path of a folder with imagej zips, the explicit path
-            of a single imagej zip, an explicit list of imagej zip locations,
-            a list of arrays encoding roi polygons, or a list of lists of
-            binary arrays representing roi masks.
-            Should be either a single roiset for all trials, or a different
+            Should be one of:
+            - the path to a directory containing ImageJ ZIP files (string),
+            - the path of a single ImageJ ZIP file (string),
+            - a list of ImageJ ZIP files (list of strings),
+            - a list of arrays, each encoding a ROI polygons,
+            - a list of lists of binary arrays, each representing a ROI mask.
+            This can either be a single roiset for all trials, or a different
             roiset for each trial.
         folder : string
-            Where to store the extracted data.
-        nRegions : int, optional (default: 4)
-            Number of neuropil regions to draw. Use higher number for densely
-            labelled tissue.
-        expansion : float, optional (default: 1)
-            How much larger to make each neuropil subregion than ROI area.
-            Full neuropil area will be nRegions*expansion*ROI area
-        alpha : float, optional (default: 0.1)
-            Sparsity constraint for NMF
+            Output path to a directory in which the extracted data will
+            be stored.
+        nRegions : int, optional
+            Number of neuropil regions to draw. Use a higher number for
+            densely labelled tissue. Default is 4.
+        expansion : float, optional
+            Expansion factor for the neuropil region, relative to the
+            ROI area. Default is 1. The total neuropil area will be
+            `nRegions * expansion * area(ROI)`.
+        alpha : float, optional
+            Sparsity regularizaton weight for NMF algorithm. Set to zero to
+            remove regularization. Default is 0.1. (Not used for ICA method.)
         ncores_preparation : int, optional (default: None)
-            Sets the number of processes to be used for data preparation
-            (ROI and subregions definitions, data extraction from tifs,
-            etc.)
-            By default FISSA uses all the available processing threads.
-            This can, especially for the data preparation step,
-            quickly fill up your memory.
+            Sets the number of subprocesses to be used during the data
+            preparation steps (ROI and subregions definitions, data
+            extraction from tifs, etc.).
+            If set to `None` (default), there will be as many subprocesses
+            as there are threads or cores on the machine. Note that this
+            behaviour can, especially for the data preparation step,
+            be very memory-intensive.
         ncores_separation : int, optional (default: None)
-            Same as ncores_preparation, but for the separation step.
-            As a rule, this can be set higher than ncores_preparation, as
-            the separation step takes much less memory.
-        method : string, optional
-            Either 'nmf' for non-negative matrix factorization, or 'ica' for
-            independent component analysis. 'nmf' option recommended.
+            Same as `ncores_preparation`, but for the separation step.
+            Note that this step requires less memory per subprocess, and
+            hence can often be set higher than `ncores_preparation`.
+        method : {'nmf', 'ica'}, optional
+            Which blind source-separation method to use. Either `'nmf'`
+            for non-negative matrix factorization, or `'ica'` for
+            independent component analysis. Default (recommended) is
+            `'nmf'`.
         lowmemory_mode : bool, optional
-            If True, FISSA will load tiff file frame by frame instead of
-            whole files at once. This will reduce the memory load.
+            If `True`, FISSA will load TIFF files into memory frame-by-frame
+            instead of holding the entire TIFF in memory at once. This
+            option reduces the memory load, and may be necessary for very
+            large inputs. Default is `False`.
         datahandler_custom : object, optional
             A custom datahandler for handling ROIs and calcium data can
-            optionally be given. See datahandler.py for an example.
+            be given here. See datahandler.py (the default handler) for
+            an example.
 
         """
         if isinstance(images, str):
@@ -212,14 +232,14 @@ class Experiment():
     def separation_prep(self, redo=False):
         """Prepare and extract the data to be separated.
 
-        Per trial:
-        * Load in data as arrays
-        * load in ROIs as masks
-        * grow and seaparate ROIs to get neuropil regions
-        * using neuropil and original regions, extract traces from data
+        For each trial, performs the following steps:
+        - Load in data as arrays
+        - Load in ROIs as masks
+        - Grow and seaparate ROIs to define neuropil regions
+        - Using neuropil and original ROI regions, extract traces from data
 
         After running this you can access the raw data (i.e. pre separation)
-        as self.raw and self.rois. self.raw is a list of arrays.
+        as `self.raw` and `self.rois`. self.raw is a list of arrays.
         self.raw[cell][trial] gives you the traces of a specific cell and
         trial, across cell and neuropil regions. self.roi_polys is a list of
         lists of arrays. self.roi_polys[cell][trial][region][0] gives you the
@@ -231,8 +251,10 @@ class Experiment():
 
         Parameters
         ----------
-        redo : bool
-            Redo the preparation even if done before
+        redo : bool, optional
+            If `False`, we load previously prepared data when possible.
+            If `True`, we re-run the preparation, even if it has previously
+            been run. Default is `False`.
 
         """
         # define filename where data will be present
@@ -292,31 +314,32 @@ class Experiment():
     def separate(self, redo_prep=False, redo_sep=False):
         """Separate all the trials with FISSA algorithm.
 
-        After running separate, data can be found as follows:
-
+        After running `separate`, data can be found as follows:
         self.sep
             Raw separation output, without being matched. Signal 'i' for
             a specific cell and trial can be found as
             self.sep[cell][trial][i,:]
         self.result
             Final output, in order of presence in cell ROI.
-            Signal 'i' for a specific cell and trial can be found as
-            self.result[cell][trial][i,:]
-            i = 0 is most strongly present signal
-            i = 1 less so, etc.
+            Signal `i` for a specific cell and trial can be found at
+            `self.result[cell][trial][i, :]`.
+            Note that the ordering is such that `i = 0` is the signal
+            most strongly present in the ROI, and subsequent entries
+            are in diminishing order.
         self.mixmat
-            The mixing matrix (how to go between self.separated and
-            self.raw from the separation_prep function)
+            The mixing matrix (how to go between `self.separated` and
+            `self.raw` from the `separation_prep()` function).
         self.info
-            Info about separation algorithm, iterations needed, etc.
+            Information about separation routine, iterations needed, etc.
 
         Parameters
         ----------
         redo_prep : bool, optional
-            Whether to redo the preparation. This will always set
-            redo_sep = True as well.
+            Whether to redo the preparation. Default is `False.` Note that
+            if this is true, we set `redo_sep = True` as well.
         redo_sep : bool, optional
-            Whether to redo the separation
+            Whether to redo the separation. Default is `False`. Note that
+            this parameter is ignored if `redo_prep` is set to `True`.
 
         """
         # Do data preparation
@@ -403,13 +426,16 @@ class Experiment():
         Parameters
         ----------
         freq : float
-            Imaging frequency in Hz.
-        use_raw_f0 : bool
-            If True (default), use the f0 from the raw ROI trace for both
-            raw and result traces. If False, use the f0 of each trace.
-        across_trials : bool
-            Whether to do calculate the deltaf/f0 across all trials (default),
-            or per trial.
+            Imaging frequency, in Hz.
+        use_raw_f0 : bool, optional
+            If `True` (default), use an f0 estimate from the raw ROI trace
+            for both raw and result traces. If `False`, use individual f0
+            estimates for each of the traces.
+        across_trials : bool, optional
+            If `True`, we estimate a single baseline f0 value across all
+            trials. If `False`, each trial will have their own baseline f0,
+            and df/f0 value will be relative to the trial-specific f0.
+            Default is `True`.
 
         """
         deltaf_raw = [[None for t in range(self.nTrials)]

--- a/fissa/datahandler.py
+++ b/fissa/datahandler.py
@@ -16,18 +16,18 @@ import roitools
 
 
 def image2array(image):
-    """Take the object 'image' and returns an array.
+    """Loads a TIFF image from disk.
 
     Parameters
-    ---------
-    image : unknown
-        The data. Should be either a tif location, or a list
-        of already loaded in data.
+    ----------
+    image : string or array_like
+        Either a path to a tiff file, or array_like data.
 
     Returns
     -------
-    np.array
-        A 3D array containing the data as (frames, y coordinate, x coordinate)
+    numpy.ndarray
+        A 3D array containing the data, with dimenisons corresponding to
+        `(frames, y_coordinate, x_coordinate)`.
 
     """
     if isinstance(image, str):
@@ -38,16 +38,16 @@ def image2array(image):
 
 
 def getmean(data):
-    """Get the mean image for data.
+    """Determine the mean image across all frames.
 
     Parameters
     ----------
-    data : array
-        Data array as made by image2array. Should be of shape [frames,y,x]
+    data : array_like
+        Data array as made by image2array. Should be shaped `(frames, y, x)`.
 
     Returns
     -------
-    array
+    numpy.ndarray
         y by x array for the mean values
 
     """
@@ -59,11 +59,11 @@ def rois2masks(rois, data):
 
     Parameters
     ----------
-    rois : unkown
+    rois : string or list of array_like
         Either a string with imagej roi zip location, list of arrays encoding
-        polygons, or binary arrays representing masks
+        polygons, or list of binary arrays representing masks
     data : array
-        Data array as made by image2array. Should be of shape [frames,y,x]
+        Data array as made by image2array. Must be shaped `(frames, y, x)`.
 
     Returns
     -------
@@ -90,14 +90,20 @@ def rois2masks(rois, data):
 
 
 def extracttraces(data, masks):
-    """Get the traces for each mask in masks from data.
+    """Extracts a temporal trace for each spatial mask.
 
-    Inputs
-    --------------------
-    data : array
-        Data array as made by image2array. Should be of shape [frames,y,x]
-    masks : list
-        list of binary arrays (masks)
+    Parameters
+    ----------
+    data : array_like
+        Data array as made by image2array. Should be shaped
+        `(frames, y, x)`.
+    masks : list of array_like
+        List of binary arrays.
+
+    Returns
+    -------
+    np.ndarray
+        Trace for each mask. Shaped `(len(masks), n_frames)`.
 
     """
     # get the number rois and frames

--- a/fissa/datahandler.py
+++ b/fissa/datahandler.py
@@ -21,7 +21,7 @@ def image2array(image):
     Parameters
     ----------
     image : string or array_like
-        Either a path to a tiff file, or array_like data.
+        Either a path to a TIFF file, or array_like data.
 
     Returns
     -------

--- a/fissa/datahandler.py
+++ b/fissa/datahandler.py
@@ -26,7 +26,7 @@ def image2array(image):
     Returns
     -------
     numpy.ndarray
-        A 3D array containing the data, with dimenisons corresponding to
+        A 3D array containing the data, with dimensions corresponding to
         `(frames, y_coordinate, x_coordinate)`.
 
     """

--- a/fissa/datahandler_framebyframe.py
+++ b/fissa/datahandler_framebyframe.py
@@ -16,39 +16,38 @@ from PIL import Image, ImageSequence
 
 
 def image2array(image):
-    """Take the object 'image' and returns a pillow image object.
+    """Open a given image file as a PIL.Image instance.
 
     Parameters
-    ---------
-    image : unknown
-        The data. Should be either a tif location, or a list
-        of already loaded in data.
+    ----------
+    image : str
+        A path to a TIFF image file.
 
     Returns
     -------
-    np.array
-        A 3D array containing the data as (frames, y coordinate, x coordinate)
+    PIL.Image
+        Handle from which frames can be loaded.
 
     """
     if isinstance(image, str):
         return Image.open(image)
 
     else:
-        raise ValueError('Only tiff locations are accepted as inputs')
+        raise ValueError('Only file paths are supported as inputs.')
 
 
 def getmean(data):
-    """Get the mean image for data.
+    """Determine the mean image across all frames.
 
     Parameters
     ----------
-    data : array
-        Data array as made by image2array. Should be a pillow image object.
+    data : PIL.Image
+        An open PIL.Image handle to a multi-frame TIFF image.
 
     Returns
     -------
-    array
-        y by x array for the mean values
+    numpy.ndarray
+        y-by-x array for the mean values.
 
     """
     # We don't load the entire image into memory at once, because
@@ -75,23 +74,24 @@ def rois2masks(rois, data):
 
     Parameters
     ----------
-    rois : unkown
+    rois : str or list of array_like
         Either a string with imagej roi zip location, list of arrays encoding
-        polygons, or binary arrays representing masks
-    data : array
-        Data array as made by image2array. Should be a pillow image object.
+        polygons, or list of binary arrays representing masks
+    data : PIL.Image
+        An open PIL.Image handle to a multi-frame TIFF image.
 
     Returns
     -------
     list
-        List of binary arrays (i.e. masks)
+        List of binary arrays (i.e. masks).
 
     """
     shape = data.size[::-1]
 
-    # if it's a list of strings
+    # If rois is string, we first need to read the contents of the file
     if isinstance(rois, str):
         rois = roitools.readrois(rois)
+
     if isinstance(rois, list):
         # if it's a something by 2 array (or vice versa), assume polygons
         if np.shape(rois[0])[1] == 2 or np.shape(rois[0])[0] == 2:
@@ -107,12 +107,17 @@ def rois2masks(rois, data):
 def extracttraces(data, masks):
     """Get the traces for each mask in masks from data.
 
-    Inputs
-    --------------------
-    data : array
-        Data array as made by image2array. Should be a pillow image object.
-    masks : list
-        list of binary arrays (masks)
+    Parameters
+    ----------
+    data : PIL.Image
+        An open PIL.Image handle to a multi-frame TIFF image.
+    masks : list of array_like
+        List of binary arrays.
+
+    Returns
+    -------
+    np.ndarray
+        Trace for each mask. Shaped `(len(masks), n_frames)`.
 
     """
     # get the number rois

--- a/fissa/deltaf.py
+++ b/fissa/deltaf.py
@@ -25,7 +25,7 @@ def findBaselineF0(rawF, fs, axis=0, keepdims=False):
         Dimension which contains the time series. Default is 0.
     keepdims : bool, optional
         Whether to preserve the dimensionality of the input. Default is
-        False.
+        `False`.
 
     Returns
     -------

--- a/fissa/neuropil.py
+++ b/fissa/neuropil.py
@@ -21,13 +21,14 @@ def separate(
     S : array_like
         2d array with signals. S[i,j], j = each signal, i = signal content.
         j = 0 is considered the primary signal. (i.e. the somatic signal)
-    sep_method : {'ica','nmf','nmf_sklearn'}
+    sep_method : {'ica','nmf'}
         Which source separation method to use, ica or nmf.
-            * ica: independent component analysis
-            * nmf: Non-negative matrix factorization
+        - ica: Independent Component Analysis
+        - nmf: Non-negative Matrix Factorization
     n : int, optional
-        How many components to estimate. If None, use PCA to estimate
-        how many components would explain at least 99% of the variance.
+        How many components to estimate. If `None` (default), use PCA to
+        estimate how many components would explain at least 99%% of the
+        variance and adopt this value for `n`.
     maxiter : int, optional
         Number of maximally allowed iterations. Default is 500.
     tol : float, optional
@@ -37,25 +38,28 @@ def separate(
     maxtries : int, optional
         Maximum number of tries before algorithm should terminate.
         Default is 10.
-    W0, H0 : arrays, optional
-        Optional starting conditions for nmf
-    alpha : float
-        [expand explanation] Roughly the sparsity constraint
+    W0, H0 : array_like, optional
+        Optional starting conditions for NMF algorithm. (Not used for ICA
+        method.)
+    alpha : float, optional
+        Sparsity regularizaton weight for NMF algorithm. Set to zero to
+        remove regularization. Default is 0.1. (Not used for ICA method.)
 
     Returns
     -------
-    S_sep : numpy.ndarray
-        The raw separated traces
-    S_matched :
+    numpy.ndarray
+        The raw separated traces.
+    numpy.ndarray
         The separated traces matched to the primary signal, in order
         of matching quality (see Implementation below).
-    A_sep :
-    convergence : dict
+    numpy.ndarray
+        Mixing matrix.
+    dict
         Metadata for the convergence result, with keys:
-            * random_state: seed for ica initiation
-            * iterations: number of iterations needed for convergence
-            * max_iterations: maximun number of iterations allowed
-            * converged: whether the algorithm converged or not (bool)
+        - random_state: seed for ICA initiation
+        - iterations: number of iterations needed for convergence
+        - max_iterations: maximum number of iterations allowed
+        - converged: whether the algorithm converged or not (bool)
 
     Implementation
     --------------
@@ -223,18 +227,18 @@ def lowPassFilter(F, fs=40, nfilt=40, fw_base=10, axis=0):
     F : array_like
         Fluorescence signal.
     fs : float, optional
-        Sampling frequency of F, in Hz. Default 40.
+        Sampling frequency of F, in Hz. Default is 40.
     nfilt : int, optional
-        Number of taps to use in FIR filter, default 40
+        Number of taps to use in FIR filter. Default is 40.
     fw_base : float, optional
-        Cut-off frequency for lowpass filter, default 1
+        Cut-off frequency for lowpass filter, in Hz. Default is 1.
     axis : int, optional
-        Along which axis to apply low pass filtering, default 0
+        Along which axis to apply low pass filtering. Default is 0.
 
     Returns
     -------
-    array
-        Low pass filtered signal of len(F)
+    numpy.ndarray
+        Low pass filtered signal with the same shape as `F`.
     '''
     # The Nyquist rate of the signal is half the sampling frequency
     nyq_rate = fs / 2.0

--- a/fissa/roitools.py
+++ b/fissa/roitools.py
@@ -123,23 +123,25 @@ def shift_2d_array(a, shift=1, axis=None):
     Shifts an entire array in the direction of axis by the amount shift,
     without refilling the array.
 
-    Uses numpy.roll the shift, then empties the refilled parts of the array.
-
     Parameters
     ----------
     a : array_like
-        input array
-    shift : int
-        how much to shift array by
-    axis : int
-        From numpy.roll doc:
+        Input array.
+    shift : int, optional
+        How much to shift array by. Default is 1.
+    axis : int, optional
         The axis along which elements are shifted.
         By default, the array is flattened before shifting,
         after which the original shape is restored.
 
     Returns
     -------
-    Array of same shape as a, but shifted as per above
+    numpy.ndarray
+        Array with the same shape as a, but shifted appropriately.
+
+    Notes
+    -----
+    Uses numpy.roll the shift, then empties the refilled parts of the array.
     '''
     # Ensure array_like input is a numpy.ndarray
     a = np.asarray(a)
@@ -177,7 +179,7 @@ def get_npil_mask(mask, totalexpansion=4):
 
     Returns
     -------
-    array
+    numpy.ndarray
         A boolean numpy.ndarray mask, where the region surrounding
         the input is now True and the region of the input mask is
         False.


### PR DESCRIPTION
Tidy up all the docstrings. Fix some entries which were mistaken, add some missing returns, otherwise clarify text or change to match numpy documentation styleguide recommendations.