### PR TITLE
Windows example script

### DIFF
--- a/examples/Basic usage.html
+++ b/examples/Basic usage.html
@@ -11783,7 +11783,7 @@ div#notebook {
 </div>
 <div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
-<p>This notebook explains step-by-step how to use the FISSA toolbox. See basic_usage.py for a shorter example script if one does not use a notebook interface.</p>
+<p>This notebook explains step-by-step how to use the FISSA toolbox. See basic_usage.py (or basic_usage_windows.py for Windows users) for a shorter example script if one does not use a notebook interface.</p>
 
 </div>
 </div>

--- a/examples/Basic usage.ipynb
+++ b/examples/Basic usage.ipynb
@@ -11,7 +11,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This notebook explains step-by-step how to use the FISSA toolbox. See basic_usage.py for a shorter example script if one does not use a notebook interface."
+    "This notebook explains step-by-step how to use the FISSA toolbox. See basic_usage.py (or basic_usage_windows.py for Windows users) for a shorter example script if one does not use a notebook interface."
    ]
   },
   {
@@ -416,7 +416,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython2",
-   "version": "2.7.14"
+   "version": "2.7.15"
   }
  },
  "nbformat": 4,

--- a/examples/basic_usage_windows.py
+++ b/examples/basic_usage_windows.py
@@ -1,0 +1,27 @@
+"""Basic FISSA usage.
+
+This file explains step-by-step how to use the FISSA toolbox.
+
+See Basic usage.ipynb and Basic usage.html for a move verbose version.
+"""
+# FISSA toolbox import
+import fissa
+
+# The following if statement is necessary for multiprocessing in Windows
+if __name__ == '__main__':
+    # data location
+    rois = 'exampleData/20150429.zip'
+    images = 'exampleData/20150529'
+
+    # extraction location
+    folder = 'fissa_example'
+    # make sure you use a different folder for each experiment!
+
+    # experiment definition
+    experiment = fissa.Experiment(images, rois, folder)
+
+    # do separation
+    experiment.separate(redo_prep=True)
+
+    # (optional) export to matlab
+    experiment.save_to_matlab()


### PR DESCRIPTION
This adds an extra basic example Python script for Windows users, as multiprocessing expects an explicit ```if __name__ == '__main__':``` statement around the main code being run, but only for Windows. This fixes issue #24.