### PR TITLE
DOC: Add CHANGELOG, from 0.5.0 to 0.5.2dev (current)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,47 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+Categories for changes are: Added, Changed, Deprecated, Removed, Fixed, Security.
+
+
+## [Unreleased](https://github.com/rochefort-lab/fissa/tree/HEAD)
+
+[Full Changelog](https://github.com/rochefort-lab/fissa/compare/0.5.2...HEAD)
+
+### Fixed
+
+- Fix f0 detection with low sampling rates [\#27](https://github.com/rochefort-lab/fissa/pull/27) ([scottclowe](https://github.com/scottclowe))
+
+
+## [0.5.2](https://github.com/rochefort-lab/fissa/tree/0.5.2) (2018-03-07)
+[Full Changelog](https://github.com/rochefort-lab/fissa/compare/0.5.1...0.5.2)
+
+### Changed
+
+- The default alpha value was changed from 0.2 to 0.1 [\#20](https://github.com/rochefort-lab/fissa/pull/20) ([swkeemink](https://github.com/swkeemink))
+
+
+## [0.5.1](https://github.com/rochefort-lab/fissa/tree/0.5.1) (2018-01-10)
+[Full Changelog](https://github.com/rochefort-lab/fissa/compare/0.5.0...0.5.1)
+
+### Added
+
+- Possibility to define custom datahandler script for other formats
+- Added low memory mode option to load larger tiffs frame-by-frame [\#14](https://github.com/rochefort-lab/fissa/pull/14) ([swkeemink](https://github.com/swkeemink))
+- Added option to use ICA instead of NMF (not recommended, but is a lot faster)
+- Added the option for users to define a custom data and ROI loading script [\#13](https://github.com/rochefort-lab/fissa/pull/13) ([swkeemink](https://github.com/swkeemink))
+
+### Fixed
+
+- Fixed custom datahandler usage [\#14](https://github.com/rochefort-lab/fissa/pull/14) ([swkeemink](https://github.com/swkeemink))
+- Documentation fixes [\#12](https://github.com/rochefort-lab/fissa/pull/12) ([swkeemink](https://github.com/swkeemink))
+
+
+## [0.5.0](https://github.com/rochefort-lab/fissa/tree/0.5.0) (2017-10-05)
+
+Initial release
+


### PR DESCRIPTION
I initialised the CHANGELOG using this tool:
https://github.com/github-changelog-generator/github-changelog-generator

Command
```
github_changelog_generator -u rochefort-lab -p fissa
```

And then I refactored it to so the PRs it listed were organised following the style guide of [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).