### PR TITLE
MAINT: Fix accidental version change

### DIFF
--- a/fissa/__meta__.py
+++ b/fissa/__meta__.py
@@ -1,6 +1,6 @@
 __name__ = 'fissa'
 __path__ = __name__
-__version__ = '0.5.2.dev'
+__version__ = '0.6.0.alpha'
 __author__ = "Sander Keemink & Scott Lowe"
 __author_email__ = "swkeemink@scimail.eu"
 __description__ = "A Python Library estimating somatic signals in 2-photon data"


### PR DESCRIPTION
In previous commit 83dd012, PR #37, the version number was accidentally decremented when changing the location in which version numbers are housed.