### PR TITLE
BUG: Workaround for setup.py install accessing __meta__.py

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -25,13 +25,13 @@ from ..fissa import __meta__ as meta
 import datetime
 now = datetime.datetime.now()
 
-project = meta.__name__.upper()
-author = meta.__author__
+project = meta.name.upper()
+author = meta.author
 copyright = '{}, {}'.format(now.year, author)
 
 
 # The full version, including alpha/beta/rc tags
-release = meta.__version__
+release = meta.version
 # The short X.Y version
 version = '.'.join(release.split('.')[0:2])
 
@@ -195,7 +195,7 @@ latex_elements = {
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
     (master_doc, project + '.tex', project + ' Documentation',
-     meta.__author__, 'manual'),
+     meta.author, 'manual'),
 ]
 
 
@@ -216,7 +216,7 @@ man_pages = [
 #  dir menu entry, description, category)
 texinfo_documents = [
     (master_doc, project, project + ' Documentation',
-     author, project, meta.__description__,
+     author, project, meta.description,
      'Miscellaneous'),
 ]
 

--- a/fissa/__meta__.py
+++ b/fissa/__meta__.py
@@ -1,7 +1,7 @@
-__name__ = 'fissa'
-__path__ = __name__
-__version__ = '0.6.0.alpha'
-__author__ = "Sander Keemink & Scott Lowe"
-__author_email__ = "swkeemink@scimail.eu"
-__description__ = "A Python Library estimating somatic signals in 2-photon data"
-__url__ = "https://github.com/rochefort-lab/fissa"
+name = 'fissa'
+path = name
+version = '0.6.0.alpha'
+author = "Sander Keemink & Scott Lowe"
+author_email = "swkeemink@scimail.eu"
+description = "A Python Library estimating somatic signals in 2-photon data"
+url = "https://github.com/rochefort-lab/fissa"

--- a/setup.py
+++ b/setup.py
@@ -43,16 +43,16 @@ class PyTest(TestCommand):
 
 
 setup(
-    name = meta['__name__'],
+    name = meta['name'],
     install_requires = install_requires,
     extras_require = extras_require,
-    version = meta['__version__'],
-    author = meta['__author__'],
-    author_email = meta['__author_email__'],
-    description = meta['__description__'],
-    url = meta['__url__'],
-    package_dir = {meta['__name__']: os.path.join(".", meta['__path__'])},
-    packages = [meta['__name__']],
+    version = meta['version'],
+    author = meta['author'],
+    author_email = meta['author_email'],
+    description = meta['description'],
+    url = meta['url'],
+    package_dir = {meta['name']: os.path.join(".", meta['path'])},
+    packages = [meta['name']],
     license = "GNU",
     long_description = read('README.rst'),
     classifiers = [

--- a/setup.py
+++ b/setup.py
@@ -6,12 +6,14 @@ import os
 from distutils.core import setup
 from setuptools.command.test import test as TestCommand
 
-from fissa import __meta__ as meta
-
 
 def read(fname):
     return open(os.path.join(os.path.dirname(__file__), fname)).read()
 
+# Can't import __meta__.py if the requirements aren't installed
+# due to imports in __init__.py. This is a workaround.
+meta = {}
+exec(read('fissa/__meta__.py'), meta)
 
 install_requires = read('requirements.txt')
 
@@ -41,16 +43,16 @@ class PyTest(TestCommand):
 
 
 setup(
-    name = meta.__name__,
+    name = meta['__name__'],
     install_requires = install_requires,
     extras_require = extras_require,
-    version = meta.__version__,
-    author = meta.__author__,
-    author_email = meta.__author_email__,
-    description = meta.__description__,
-    url = meta.__url__,
-    package_dir = {meta.__name__: os.path.join(".", meta.__path__)},
-    packages = [meta.__name__],
+    version = meta['__version__'],
+    author = meta['__author__'],
+    author_email = meta['__author_email__'],
+    description = meta['__description__'],
+    url = meta['__url__'],
+    package_dir = {meta['__name__']: os.path.join(".", meta['__path__'])},
+    packages = [meta['__name__']],
     license = "GNU",
     long_description = read('README.rst'),
     classifiers = [


### PR DESCRIPTION
During install step, we can't import `__meta__.py` directly because
it loads `__init__.py` first, and that means importing other things
which aren't installed.

To escape this cycle, we use solution 3 shown here:
https://packaging.python.org/guides/single-sourcing-package-version/
which is to `exec()` the file contents of `__meta__.py` instead of
import them.