### PR TITLE
MAINT: __init__ import __meta__ directly

### DIFF
--- a/fissa/__init__.py
+++ b/fissa/__init__.py
@@ -1,3 +1,3 @@
-from .__meta__ import *
+from . import __meta__
 
 from .core import Experiment

--- a/fissa/__init__.py
+++ b/fissa/__init__.py
@@ -1,3 +1,5 @@
 from . import __meta__
 
 from .core import Experiment
+
+__version__ = __meta__.version


### PR DESCRIPTION
We now import __meta__ into fissa's __init__.py, instead of importing the contents of __meta__ with `import *`.

Also, make the version number available as `fissa.__version__` again, by aliasing `fissa.__meta__.version`.