### PR TITLE
REL: Update master version number to 0.6.dev0

### DIFF
--- a/fissa/__meta__.py
+++ b/fissa/__meta__.py
@@ -1,6 +1,6 @@
 name = 'fissa'
 path = name
-version = '0.6.0'
+version = '0.6.dev0'
 author = "Sander Keemink & Scott Lowe"
 author_email = "swkeemink@scimail.eu"
 description = "A Python Library estimating somatic signals in 2-photon data"


### PR DESCRIPTION
This conforms with our new standard for the master branch version number, conforming to [PEP440](https://www.python.org/dev/peps/pep-0440).