### PR TITLE
DOC: Reformat Changelog

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,16 +12,19 @@ Categories for changes are: Added, Changed, Deprecated, Removed, Fixed,
 Security.
 
 
-`Unreleased <https://github.com/rochefort-lab/fissa>`__
--------------------------------------------------------
+Unreleased
+----------
 
-`Full Changelog <https://github.com/rochefort-lab/fissa/compare/0.6.0...master>`__
+Full commit changelog
+`on github <https://github.com/rochefort-lab/fissa/compare/0.6.0...master>`__.
 
 
-`0.6.0 <https://github.com/rochefort-lab/fissa/tree/0.6.0>`__ (2019-02-26)
---------------------------------------------------------------------------
+Version `0.6.0 <https://github.com/rochefort-lab/fissa/tree/0.6.0>`__
+---------------------------------------------------------------------
 
-`Full Changelog <https://github.com/rochefort-lab/fissa/compare/0.5.3...0.6.0>`__
+Release date: 2019-02-26
+Full commit changelog
+`on github <https://github.com/rochefort-lab/fissa/compare/0.5.3...0.6.0>`__.
 
 Added
 ~~~~~
@@ -32,10 +35,12 @@ Added
    `#38 <https://github.com/rochefort-lab/fissa/pull/38>`__
 
 
-`0.5.3 <https://github.com/rochefort-lab/fissa/tree/0.5.3>`__ (2019-02-18)
---------------------------------------------------------------------------
+Version `0.5.3 <https://github.com/rochefort-lab/fissa/tree/0.5.3>`__
+---------------------------------------------------------------------
 
-`Full Changelog <https://github.com/rochefort-lab/fissa/compare/0.5.2...0.5.3>`__
+Release date: 2019-02-18.
+Full commit changelog
+`on github <https://github.com/rochefort-lab/fissa/compare/0.5.2...0.5.3>`__.
 
 Fixed
 ~~~~~
@@ -45,10 +50,12 @@ Fixed
    (`scottclowe <https://github.com/scottclowe>`__)
 
 
-`0.5.2 <https://github.com/rochefort-lab/fissa/tree/0.5.2>`__ (2018-03-07)
---------------------------------------------------------------------------
+Version `0.5.2 <https://github.com/rochefort-lab/fissa/tree/0.5.2>`__
+---------------------------------------------------------------------
 
-`Full Changelog <https://github.com/rochefort-lab/fissa/compare/0.5.1...0.5.2>`__
+Release date: 2018-03-07.
+Full commit changelog
+`on github <https://github.com/rochefort-lab/fissa/compare/0.5.1...0.5.2>`__.
 
 Changed
 ~~~~~~~
@@ -58,10 +65,12 @@ Changed
    (`swkeemink <https://github.com/swkeemink>`__)
 
 
-`0.5.1 <https://github.com/rochefort-lab/fissa/tree/0.5.1>`__ (2018-01-10)
---------------------------------------------------------------------------
+Version `0.5.1 <https://github.com/rochefort-lab/fissa/tree/0.5.1>`__
+---------------------------------------------------------------------
 
-`Full Changelog <https://github.com/rochefort-lab/fissa/compare/0.5.0...0.5.1>`__
+Release date: 2018-01-10.
+Full commit changelog
+`on github <https://github.com/rochefort-lab/fissa/compare/0.5.0...0.5.1>`__.
 
 Added
 ~~~~~
@@ -87,7 +96,9 @@ Fixed
    (`swkeemink <https://github.com/swkeemink>`__)
 
 
-`0.5.0 <https://github.com/rochefort-lab/fissa/tree/0.5.0>`__ (2017-10-05)
---------------------------------------------------------------------------
+Version `0.5.0 <https://github.com/rochefort-lab/fissa/tree/0.5.0>`__
+---------------------------------------------------------------------
+
+Release date: 2017-10-05
 
 Initial release

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -30,9 +30,9 @@ Added
 ~~~~~
 
 -  Python 3 compatibility.
-   `#33 <https://github.com/rochefort-lab/fissa/pull/33>`__
+   (`#33 <https://github.com/rochefort-lab/fissa/pull/33>`__)
 -  Documentation generation, with Sphinx, Sphinx-autodoc, and Napoleon.
-   `#38 <https://github.com/rochefort-lab/fissa/pull/38>`__
+   (`#38 <https://github.com/rochefort-lab/fissa/pull/38>`__)
 
 
 Version `0.5.3 <https://github.com/rochefort-lab/fissa/tree/0.5.3>`__
@@ -45,9 +45,8 @@ Full commit changelog
 Fixed
 ~~~~~
 
--  Fix f0 detection with low sampling rates
-   `#27 <https://github.com/rochefort-lab/fissa/pull/27>`__
-   (`scottclowe <https://github.com/scottclowe>`__)
+-  Fix f0 detection with low sampling rates.
+   (`#27 <https://github.com/rochefort-lab/fissa/pull/27>`__)
 
 
 Version `0.5.2 <https://github.com/rochefort-lab/fissa/tree/0.5.2>`__
@@ -60,9 +59,8 @@ Full commit changelog
 Changed
 ~~~~~~~
 
--  The default alpha value was changed from 0.2 to 0.1
-   `#20 <https://github.com/rochefort-lab/fissa/pull/20>`__
-   (`swkeemink <https://github.com/swkeemink>`__)
+-  The default alpha value was changed from 0.2 to 0.1.
+   (`#20 <https://github.com/rochefort-lab/fissa/pull/20>`__)
 
 
 Version `0.5.1 <https://github.com/rochefort-lab/fissa/tree/0.5.1>`__
@@ -77,24 +75,20 @@ Added
 
 -  Possibility to define custom datahandler script for other formats
 -  Added low memory mode option to load larger tiffs frame-by-frame
-   `#14 <https://github.com/rochefort-lab/fissa/pull/14>`__
-   (`swkeemink <https://github.com/swkeemink>`__)
+   (`#14 <https://github.com/rochefort-lab/fissa/pull/14>`__)
 -  Added option to use ICA instead of NMF (not recommended, but is a lot
-   faster)
+   faster).
 -  Added the option for users to define a custom data and ROI loading
-   script `#13 <https://github.com/rochefort-lab/fissa/pull/13>`__
-   (`swkeemink <https://github.com/swkeemink>`__)
+   script.
+   (`#13 <https://github.com/rochefort-lab/fissa/pull/13>`__)
 
 Fixed
 ~~~~~
 
--  Fixed custom datahandler usage
-   `#14 <https://github.com/rochefort-lab/fissa/pull/14>`__
-   (`swkeemink <https://github.com/swkeemink>`__)
--  Documentation fixes
-   `#12 <https://github.com/rochefort-lab/fissa/pull/12>`__
-   (`swkeemink <https://github.com/swkeemink>`__)
-
+-  Fixed custom datahandler usage.
+   (`#14 <https://github.com/rochefort-lab/fissa/pull/14>`__)
+-  Documentation fixes.
+   (`#12 <https://github.com/rochefort-lab/fissa/pull/12>`__)
 
 Version `0.5.0 <https://github.com/rochefort-lab/fissa/tree/0.5.0>`__
 ---------------------------------------------------------------------


### PR DESCRIPTION
Changes the formatting of the changelog, aiming to make it easier to read.

- Add "Version" to title of entries
- Date no longer in title, instead on separate line
- Full changelog link text clearer
- Don't include author of PR (its not necessary information for the reader to know this)