### PR TITLE
BUG: Number of cores used not matching arguments given

### DIFF
--- a/fissa/core.py
+++ b/fissa/core.py
@@ -401,7 +401,7 @@ class Experiment():
 
             if has_multiprocessing:
                 # define pool
-                pool = Pool()
+                pool = Pool(self.ncores_separation)
 
                 # run separation
                 results = pool.map(separate_func, inputs)

--- a/fissa/core.py
+++ b/fissa/core.py
@@ -296,7 +296,7 @@ class Experiment():
             # Do the extraction
             if has_multiprocessing:
                 # define pool
-                pool = Pool(self.ncores_separation)
+                pool = Pool(self.ncores_preparation)
 
                 # run extraction
                 results = pool.map(extract_func, inputs)


### PR DESCRIPTION
Fixed:
-   Use `ncores_preparation` for perparation step, not `ncores_separation`.
-   Only use `ncores_separation` for separation step, not all cores.