### PR TITLE
BUG: Check whether string by using isinstance of basestring

### DIFF
--- a/examples/datahandler_custom.py
+++ b/examples/datahandler_custom.py
@@ -10,6 +10,8 @@ Authors:
 
 """
 
+from past.builtins import basestring
+
 import numpy as np
 import tifffile
 from fissa import roitools
@@ -30,7 +32,7 @@ def image2array(image):
         A 3D array containing the data as (frames, y coordinate, x coordinate)
 
     """
-    if isinstance(image, str):
+    if isinstance(image, basestring):
         return tifffile.imread(image)
 
     if isinstance(image, np.ndarray):
@@ -75,7 +77,7 @@ def rois2masks(rois, data):
     shape = data.shape[1:]
 
     # if it's a list of strings
-    if isinstance(rois, str):
+    if isinstance(rois, basestring):
         rois = roitools.readrois(rois)
     if isinstance(rois, list):
         # if it's a something by 2 array (or vice versa), assume polygons

--- a/fissa/core.py
+++ b/fissa/core.py
@@ -6,6 +6,7 @@ Authors:
 """
 
 from __future__ import print_function
+from past.builtins import basestring
 
 import collections
 import glob
@@ -198,14 +199,14 @@ class Experiment():
             an example.
 
         """
-        if isinstance(images, str):
+        if isinstance(images, basestring):
             self.images = sorted(glob.glob(images + '/*.tif*'))
         elif isinstance(images, list):
             self.images = images
         else:
             raise ValueError('images should either be string or list')
 
-        if isinstance(rois, str):
+        if isinstance(rois, basestring):
             if rois[-3:] == 'zip':
                 self.rois = [rois] * len(self.images)
             else:

--- a/fissa/datahandler.py
+++ b/fissa/datahandler.py
@@ -10,6 +10,8 @@ Authors:
 
 """
 
+from past.builtins import basestring
+
 import numpy as np
 import tifffile
 
@@ -31,7 +33,7 @@ def image2array(image):
         `(frames, y_coordinate, x_coordinate)`.
 
     """
-    if isinstance(image, str):
+    if isinstance(image, basestring):
         return tifffile.imread(image)
 
     return np.array(image)
@@ -75,7 +77,7 @@ def rois2masks(rois, data):
     shape = data.shape[1:]
 
     # if it's a list of strings
-    if isinstance(rois, str):
+    if isinstance(rois, basestring):
         rois = roitools.readrois(rois)
 
     if not isinstance(rois, list):

--- a/fissa/datahandler_framebyframe.py
+++ b/fissa/datahandler_framebyframe.py
@@ -10,6 +10,8 @@ Authors:
 
 """
 
+from past.builtins import basestring
+
 import numpy as np
 from PIL import Image, ImageSequence
 
@@ -88,7 +90,7 @@ def rois2masks(rois, data):
     shape = data.size[::-1]
 
     # If rois is string, we first need to read the contents of the file
-    if isinstance(rois, str):
+    if isinstance(rois, basestring):
         rois = roitools.readrois(rois)
 
     if not isinstance(rois, list):


### PR DESCRIPTION
Causing problems in Python 2, where unicode strings aren't instances of `str`.
This can be fixed in Python 2 by checking `isintance(x, basestring)` instead.
However, in Python 3 basestring was removed, so we import it from `past` (which is provided by the `six` package).

There may be a better way of doing this, more in line with Python 3 style guide, but I think this is the way that will be more user-friendly - using basestring, this will work whether the user gives an implicit byte string or unicode string on Python 2/3.