### PR TITLE
Better handling for deltaf applied to very small datasets

### DIFF
--- a/fissa/deltaf.py
+++ b/fissa/deltaf.py
@@ -83,4 +83,8 @@ def findBaselineF0(rawF, fs, axis=0, keepdims=False):
     baselineF0 = np.percentile(filtered_f, base_pctle, axis=axis,
                                keepdims=keepdims)
 
+    # Ensure filtering doesn't take us below the minimum value which actually
+    # occurs in the data. This can occur when the amount of data is very low.
+    baselineF0 = np.maximum(baselineF0, rawF.min(axis=axis, keepdims=keepdims))
+
     return baselineF0

--- a/fissa/deltaf.py
+++ b/fissa/deltaf.py
@@ -52,6 +52,9 @@ def findBaselineF0(rawF, fs, axis=0, keepdims=False):
     # Remove the first datapoint, because it can be an erroneous sample
     rawF = np.split(rawF, [1], axis)[1]
 
+    # For short measurements, we reduce the number of taps
+    nfilt = min(nfilt, max(3, int(rawF.shape[axis] / 3)))
+
     if fs <= fw_base:
         # If our sampling frequency is less than our goal with the smoothing
         # (sampling at less than 1Hz) we don't need to apply the filter.


### PR DESCRIPTION
Improve edge-case handling by dynamically reducing number of taps in the filter as necessary, and preventing the baseline from going below the actual minimum value in the data (which in practice won't occur with normal inputs, but can occur when the sequence length is very low).