### PR TITLE
Allow non-list sequences to be used as inputs

### DIFF
--- a/fissa/core.py
+++ b/fissa/core.py
@@ -200,7 +200,7 @@ class Experiment():
         """
         if isinstance(images, basestring):
             self.images = sorted(glob.glob(os.path.join(images, '*.tif*')))
-        elif isinstance(images, list):
+        elif isinstance(images, collections.Sequence):
             self.images = images
         else:
             raise ValueError('images should either be string or list')
@@ -210,7 +210,7 @@ class Experiment():
                 self.rois = [rois] * len(self.images)
             else:
                 self.rois = sorted(glob.glob(os.path.join(rois, '*.zip')))
-        elif isinstance(rois, list):
+        elif isinstance(rois, collections.Sequence):
             self.rois = rois
             if len(rois) == 1:  # if only one roiset is specified
                 self.rois *= len(self.images)

--- a/fissa/datahandler.py
+++ b/fissa/datahandler.py
@@ -12,6 +12,8 @@ Authors:
 
 from past.builtins import basestring
 
+import collections
+
 import numpy as np
 import tifffile
 
@@ -80,8 +82,11 @@ def rois2masks(rois, data):
     if isinstance(rois, basestring):
         rois = roitools.readrois(rois)
 
-    if not isinstance(rois, list):
-        raise ValueError('Wrong ROIs input format: expected a list.')
+    if not isinstance(rois, collections.Sequence):
+        raise ValueError(
+            'Wrong ROIs input format: expected a list or sequence, but got'
+            ' a {}'.format(rois.__class__)
+        )
 
     # if it's a something by 2 array (or vice versa), assume polygons
     if np.shape(rois[0])[1] == 2 or np.shape(rois[0])[0] == 2:

--- a/fissa/datahandler_framebyframe.py
+++ b/fissa/datahandler_framebyframe.py
@@ -12,6 +12,8 @@ Authors:
 
 from past.builtins import basestring
 
+import collections
+
 import numpy as np
 from PIL import Image, ImageSequence
 
@@ -93,8 +95,11 @@ def rois2masks(rois, data):
     if isinstance(rois, basestring):
         rois = roitools.readrois(rois)
 
-    if not isinstance(rois, list):
-        raise ValueError('Wrong ROIs input format: expected a list.')
+    if not isinstance(rois, collections.Sequence):
+        raise ValueError(
+            'Wrong ROIs input format: expected a list or sequence, but got'
+            ' a {}'.format(rois.__class__)
+        )
 
     # if it's a something by 2 array (or vice versa), assume polygons
     if np.shape(rois[0])[1] == 2 or np.shape(rois[0])[0] == 2:


### PR DESCRIPTION
These inputs could legitimately be tuples instead of lists. So I'm broadening the checks to just check for instances of collections.Sequence, which catches all types of sequences.