### PR TITLE
DOC: Add our URLs to setup.py metadata

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -61,10 +61,25 @@ setup(
     packages = [meta['name']],
     license = "GNU",
     long_description = read('README.rst'),
+    # https://pypi.org/pypi?%3Aaction=list_classifiers
     classifiers = [
+        "Development Status :: 5 - Production/Stable",
+        "Intended Audience :: Science/Research",
+        "License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)",
         "Natural Language :: English",
+        "Operating System :: OS Independent",
         "Programming Language :: Python",
-        "Topic :: Scientific/Engineering"
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.3',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        "Topic :: Scientific/Engineering",
+        "Topic :: Scientific/Engineering :: Bio-Informatics",
+        "Topic :: Scientific/Engineering :: Information Analysis",
     ],
     project_urls={
         "Documentation": "https://fissa.readthedocs.io",

--- a/setup.py
+++ b/setup.py
@@ -70,6 +70,7 @@ setup(
         "Documentation": "https://fissa.readthedocs.io",
         "Source Code": "https://github.com/rochefort-lab/fissa",
         "Bug Tracker": "https://github.com/rochefort-lab/fissa/issues",
+        "Citation": "https://www.doi.org/10.1038/s41598-018-21640-2",
     },
     cmdclass = {'test': PyTest},
 )

--- a/setup.py
+++ b/setup.py
@@ -66,5 +66,9 @@ setup(
         "Programming Language :: Python",
         "Topic :: Scientific/Engineering"
     ],
+    project_urls={
+        "Documentation": "https://fissa.readthedocs.io",
+        "Source Code": "https://github.com/rochefort-lab/fissa",
+    },
     cmdclass = {'test': PyTest},
 )

--- a/setup.py
+++ b/setup.py
@@ -69,6 +69,7 @@ setup(
     project_urls={
         "Documentation": "https://fissa.readthedocs.io",
         "Source Code": "https://github.com/rochefort-lab/fissa",
+        "Bug Tracker": "https://github.com/rochefort-lab/fissa/issues",
     },
     cmdclass = {'test': PyTest},
 )


### PR DESCRIPTION
Add a link to both documentation and source code in the metadata which setup.py will write for PyPI. I think this will add links to them on PyPI next time we push a new version.