### PR TITLE
DOC: Retitle API section of docs to be API Reference, and tidy up conf.py

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -26,6 +26,7 @@ from fissa import __meta__ as meta
 now = datetime.datetime.now()
 
 project = meta.name.upper()
+project_path = meta.path
 author = meta.author
 copyright = '{}, {}'.format(now.year, author)
 
@@ -40,7 +41,7 @@ version = '.'.join(release.split('.')[0:2])
 
 def run_apidoc(_):
     ignore_paths = [
-        os.path.join('..', project.lower(), 'tests'),
+        os.path.join('..', project_path, 'tests'),
     ]
 
     argv = [
@@ -49,7 +50,7 @@ def run_apidoc(_):
         "--separate",  # Put each module file in its own page
         "--module-first",  # Put module documentation before submodule
         "-o", "source/packages",  # Output path
-        os.path.join("..", project.lower()),
+        os.path.join("..", project_path),
     ] + ignore_paths
 
     try:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -12,6 +12,7 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
+import datetime
 import os
 import sys
 sys.path.insert(0, os.path.abspath('.'))
@@ -22,7 +23,6 @@ from fissa import __meta__ as meta
 
 # -- Project information -----------------------------------------------------
 
-import datetime
 now = datetime.datetime.now()
 
 project = meta.name.upper()

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -18,7 +18,8 @@ import sys
 sys.path.insert(0, os.path.abspath('.'))
 sys.path.insert(0, os.path.abspath('../'))
 
-from fissa import __meta__ as meta
+
+from fissa import __meta__ as meta  # noqa: E402
 
 
 # -- Project information -----------------------------------------------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -64,12 +64,15 @@ def run_apidoc(_):
         argv.insert(0, apidoc.__file__)
         apidoc.main(argv)
 
+
 def retitle_modules(_):
     pth = 'source/packages/modules.rst'
     lines = open(pth).read().splitlines()
-    lines[0] = 'API'
-    lines[1] = '==='
+    # Overwrite the junk in the first two lines with a better title
+    lines[0] = 'API Reference'
+    lines[1] = '============='
     open(pth, 'w').write('\n'.join(lines))
+
 
 def setup(app):
     app.connect('builder-inited', run_apidoc)


### PR DESCRIPTION
- Change the title of the [API](https://fissa.readthedocs.io/en/stable/source/packages/modules.html) section of the documentation to be API Reference.
- Make conf.py PEP8 compliant, except for one line which can't be altered and now has a noqa flag.
- Make use of the path value in `__meta__.py`, instead of inferring it here.