### PR TITLE
DOC: Change DOI to doi and add a space after the colon

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -223,7 +223,7 @@ S. W. Keemink, S. C. Lowe, J. M. P. Pakan, E. Dylda, M. C. W. van
 Rossum, and N. L. Rochefort. FISSA: A neuropil decontamination toolbox
 for calcium imaging signals, *Scientific Reports*, **8**\ (1):3493,
 2018.
-`DOI:10.1038/s41598-018-21640-2 <https://www.doi.org/10.1038/s41598-018-21640-2>`__.
+`doi: 10.1038/s41598-018-21640-2 <https://www.doi.org/10.1038/s41598-018-21640-2>`__.
 
 For your convenience, the FISSA package ships with a copy of this
 citation in bibtex format, available at


### PR DESCRIPTION
I think this is the correct standard, instead of DOI in capitals and no space. Not 100% sure though, as I see it done a mixture of ways.