### PR TITLE
Add option to not save generated data

### DIFF
--- a/examples/Basic usage.html
+++ b/examples/Basic usage.html
@@ -1,8 +1,13 @@
 <!DOCTYPE html>
 <html>
 <head><meta charset="utf-8" />
-<title>Basic usage</title><script src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.1.10/require.min.js"></script>
+
+<title>Basic usage</title>
+
+<script src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.1.10/require.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.0.3/jquery.min.js"></script>
+
+
 
 <style type="text/css">
     /*!
@@ -199,7 +204,6 @@ th {
   *:before,
   *:after {
     background: transparent !important;
-    color: #000 !important;
     box-shadow: none !important;
     text-shadow: none !important;
   }
@@ -6744,15 +6748,15 @@ button.close {
 *
 */
 /*!
- *  Font Awesome 4.2.0 by @davegandy - http://fontawesome.io - @fontawesome
+ *  Font Awesome 4.7.0 by @davegandy - http://fontawesome.io - @fontawesome
  *  License - http://fontawesome.io/license (Font: SIL OFL 1.1, CSS: MIT License)
  */
 /* FONT PATH
  * -------------------------- */
 @font-face {
   font-family: 'FontAwesome';
-  src: url('../components/font-awesome/fonts/fontawesome-webfont.eot?v=4.2.0');
-  src: url('../components/font-awesome/fonts/fontawesome-webfont.eot?#iefix&v=4.2.0') format('embedded-opentype'), url('../components/font-awesome/fonts/fontawesome-webfont.woff?v=4.2.0') format('woff'), url('../components/font-awesome/fonts/fontawesome-webfont.ttf?v=4.2.0') format('truetype'), url('../components/font-awesome/fonts/fontawesome-webfont.svg?v=4.2.0#fontawesomeregular') format('svg');
+  src: url('../components/font-awesome/fonts/fontawesome-webfont.eot?v=4.7.0');
+  src: url('../components/font-awesome/fonts/fontawesome-webfont.eot?#iefix&v=4.7.0') format('embedded-opentype'), url('../components/font-awesome/fonts/fontawesome-webfont.woff2?v=4.7.0') format('woff2'), url('../components/font-awesome/fonts/fontawesome-webfont.woff?v=4.7.0') format('woff'), url('../components/font-awesome/fonts/fontawesome-webfont.ttf?v=4.7.0') format('truetype'), url('../components/font-awesome/fonts/fontawesome-webfont.svg?v=4.7.0#fontawesomeregular') format('svg');
   font-weight: normal;
   font-style: normal;
 }
@@ -6809,6 +6813,19 @@ button.close {
   border: solid 0.08em #eee;
   border-radius: .1em;
 }
+.fa-pull-left {
+  float: left;
+}
+.fa-pull-right {
+  float: right;
+}
+.fa.fa-pull-left {
+  margin-right: .3em;
+}
+.fa.fa-pull-right {
+  margin-left: .3em;
+}
+/* Deprecated as of 4.4.0 */
 .pull-right {
   float: right;
 }
@@ -6824,6 +6841,10 @@ button.close {
 .fa-spin {
   -webkit-animation: fa-spin 2s infinite linear;
   animation: fa-spin 2s infinite linear;
+}
+.fa-pulse {
+  -webkit-animation: fa-spin 1s infinite steps(8);
+  animation: fa-spin 1s infinite steps(8);
 }
 @-webkit-keyframes fa-spin {
   0% {
@@ -6846,31 +6867,31 @@ button.close {
   }
 }
 .fa-rotate-90 {
-  filter: progid:DXImageTransform.Microsoft.BasicImage(rotation=1);
+  -ms-filter: "progid:DXImageTransform.Microsoft.BasicImage(rotation=1)";
   -webkit-transform: rotate(90deg);
   -ms-transform: rotate(90deg);
   transform: rotate(90deg);
 }
 .fa-rotate-180 {
-  filter: progid:DXImageTransform.Microsoft.BasicImage(rotation=2);
+  -ms-filter: "progid:DXImageTransform.Microsoft.BasicImage(rotation=2)";
   -webkit-transform: rotate(180deg);
   -ms-transform: rotate(180deg);
   transform: rotate(180deg);
 }
 .fa-rotate-270 {
-  filter: progid:DXImageTransform.Microsoft.BasicImage(rotation=3);
+  -ms-filter: "progid:DXImageTransform.Microsoft.BasicImage(rotation=3)";
   -webkit-transform: rotate(270deg);
   -ms-transform: rotate(270deg);
   transform: rotate(270deg);
 }
 .fa-flip-horizontal {
-  filter: progid:DXImageTransform.Microsoft.BasicImage(rotation=0, mirror=1);
+  -ms-filter: "progid:DXImageTransform.Microsoft.BasicImage(rotation=0, mirror=1)";
   -webkit-transform: scale(-1, 1);
   -ms-transform: scale(-1, 1);
   transform: scale(-1, 1);
 }
 .fa-flip-vertical {
-  filter: progid:DXImageTransform.Microsoft.BasicImage(rotation=2, mirror=1);
+  -ms-filter: "progid:DXImageTransform.Microsoft.BasicImage(rotation=2, mirror=1)";
   -webkit-transform: scale(1, -1);
   -ms-transform: scale(1, -1);
   transform: scale(1, -1);
@@ -7355,6 +7376,7 @@ button.close {
 .fa-twitter:before {
   content: "\f099";
 }
+.fa-facebook-f:before,
 .fa-facebook:before {
   content: "\f09a";
 }
@@ -7367,6 +7389,7 @@ button.close {
 .fa-credit-card:before {
   content: "\f09d";
 }
+.fa-feed:before,
 .fa-rss:before {
   content: "\f09e";
 }
@@ -8004,7 +8027,8 @@ button.close {
 .fa-male:before {
   content: "\f183";
 }
-.fa-gittip:before {
+.fa-gittip:before,
+.fa-gratipay:before {
   content: "\f184";
 }
 .fa-sun-o:before {
@@ -8108,7 +8132,7 @@ button.close {
 .fa-digg:before {
   content: "\f1a6";
 }
-.fa-pied-piper:before {
+.fa-pied-piper-pp:before {
   content: "\f1a7";
 }
 .fa-pied-piper-alt:before {
@@ -8234,6 +8258,7 @@ button.close {
   content: "\f1ce";
 }
 .fa-ra:before,
+.fa-resistance:before,
 .fa-rebel:before {
   content: "\f1d0";
 }
@@ -8247,6 +8272,8 @@ button.close {
 .fa-git:before {
   content: "\f1d3";
 }
+.fa-y-combinator-square:before,
+.fa-yc-square:before,
 .fa-hacker-news:before {
   content: "\f1d4";
 }
@@ -8415,6 +8442,657 @@ button.close {
 .fa-meanpath:before {
   content: "\f20c";
 }
+.fa-buysellads:before {
+  content: "\f20d";
+}
+.fa-connectdevelop:before {
+  content: "\f20e";
+}
+.fa-dashcube:before {
+  content: "\f210";
+}
+.fa-forumbee:before {
+  content: "\f211";
+}
+.fa-leanpub:before {
+  content: "\f212";
+}
+.fa-sellsy:before {
+  content: "\f213";
+}
+.fa-shirtsinbulk:before {
+  content: "\f214";
+}
+.fa-simplybuilt:before {
+  content: "\f215";
+}
+.fa-skyatlas:before {
+  content: "\f216";
+}
+.fa-cart-plus:before {
+  content: "\f217";
+}
+.fa-cart-arrow-down:before {
+  content: "\f218";
+}
+.fa-diamond:before {
+  content: "\f219";
+}
+.fa-ship:before {
+  content: "\f21a";
+}
+.fa-user-secret:before {
+  content: "\f21b";
+}
+.fa-motorcycle:before {
+  content: "\f21c";
+}
+.fa-street-view:before {
+  content: "\f21d";
+}
+.fa-heartbeat:before {
+  content: "\f21e";
+}
+.fa-venus:before {
+  content: "\f221";
+}
+.fa-mars:before {
+  content: "\f222";
+}
+.fa-mercury:before {
+  content: "\f223";
+}
+.fa-intersex:before,
+.fa-transgender:before {
+  content: "\f224";
+}
+.fa-transgender-alt:before {
+  content: "\f225";
+}
+.fa-venus-double:before {
+  content: "\f226";
+}
+.fa-mars-double:before {
+  content: "\f227";
+}
+.fa-venus-mars:before {
+  content: "\f228";
+}
+.fa-mars-stroke:before {
+  content: "\f229";
+}
+.fa-mars-stroke-v:before {
+  content: "\f22a";
+}
+.fa-mars-stroke-h:before {
+  content: "\f22b";
+}
+.fa-neuter:before {
+  content: "\f22c";
+}
+.fa-genderless:before {
+  content: "\f22d";
+}
+.fa-facebook-official:before {
+  content: "\f230";
+}
+.fa-pinterest-p:before {
+  content: "\f231";
+}
+.fa-whatsapp:before {
+  content: "\f232";
+}
+.fa-server:before {
+  content: "\f233";
+}
+.fa-user-plus:before {
+  content: "\f234";
+}
+.fa-user-times:before {
+  content: "\f235";
+}
+.fa-hotel:before,
+.fa-bed:before {
+  content: "\f236";
+}
+.fa-viacoin:before {
+  content: "\f237";
+}
+.fa-train:before {
+  content: "\f238";
+}
+.fa-subway:before {
+  content: "\f239";
+}
+.fa-medium:before {
+  content: "\f23a";
+}
+.fa-yc:before,
+.fa-y-combinator:before {
+  content: "\f23b";
+}
+.fa-optin-monster:before {
+  content: "\f23c";
+}
+.fa-opencart:before {
+  content: "\f23d";
+}
+.fa-expeditedssl:before {
+  content: "\f23e";
+}
+.fa-battery-4:before,
+.fa-battery:before,
+.fa-battery-full:before {
+  content: "\f240";
+}
+.fa-battery-3:before,
+.fa-battery-three-quarters:before {
+  content: "\f241";
+}
+.fa-battery-2:before,
+.fa-battery-half:before {
+  content: "\f242";
+}
+.fa-battery-1:before,
+.fa-battery-quarter:before {
+  content: "\f243";
+}
+.fa-battery-0:before,
+.fa-battery-empty:before {
+  content: "\f244";
+}
+.fa-mouse-pointer:before {
+  content: "\f245";
+}
+.fa-i-cursor:before {
+  content: "\f246";
+}
+.fa-object-group:before {
+  content: "\f247";
+}
+.fa-object-ungroup:before {
+  content: "\f248";
+}
+.fa-sticky-note:before {
+  content: "\f249";
+}
+.fa-sticky-note-o:before {
+  content: "\f24a";
+}
+.fa-cc-jcb:before {
+  content: "\f24b";
+}
+.fa-cc-diners-club:before {
+  content: "\f24c";
+}
+.fa-clone:before {
+  content: "\f24d";
+}
+.fa-balance-scale:before {
+  content: "\f24e";
+}
+.fa-hourglass-o:before {
+  content: "\f250";
+}
+.fa-hourglass-1:before,
+.fa-hourglass-start:before {
+  content: "\f251";
+}
+.fa-hourglass-2:before,
+.fa-hourglass-half:before {
+  content: "\f252";
+}
+.fa-hourglass-3:before,
+.fa-hourglass-end:before {
+  content: "\f253";
+}
+.fa-hourglass:before {
+  content: "\f254";
+}
+.fa-hand-grab-o:before,
+.fa-hand-rock-o:before {
+  content: "\f255";
+}
+.fa-hand-stop-o:before,
+.fa-hand-paper-o:before {
+  content: "\f256";
+}
+.fa-hand-scissors-o:before {
+  content: "\f257";
+}
+.fa-hand-lizard-o:before {
+  content: "\f258";
+}
+.fa-hand-spock-o:before {
+  content: "\f259";
+}
+.fa-hand-pointer-o:before {
+  content: "\f25a";
+}
+.fa-hand-peace-o:before {
+  content: "\f25b";
+}
+.fa-trademark:before {
+  content: "\f25c";
+}
+.fa-registered:before {
+  content: "\f25d";
+}
+.fa-creative-commons:before {
+  content: "\f25e";
+}
+.fa-gg:before {
+  content: "\f260";
+}
+.fa-gg-circle:before {
+  content: "\f261";
+}
+.fa-tripadvisor:before {
+  content: "\f262";
+}
+.fa-odnoklassniki:before {
+  content: "\f263";
+}
+.fa-odnoklassniki-square:before {
+  content: "\f264";
+}
+.fa-get-pocket:before {
+  content: "\f265";
+}
+.fa-wikipedia-w:before {
+  content: "\f266";
+}
+.fa-safari:before {
+  content: "\f267";
+}
+.fa-chrome:before {
+  content: "\f268";
+}
+.fa-firefox:before {
+  content: "\f269";
+}
+.fa-opera:before {
+  content: "\f26a";
+}
+.fa-internet-explorer:before {
+  content: "\f26b";
+}
+.fa-tv:before,
+.fa-television:before {
+  content: "\f26c";
+}
+.fa-contao:before {
+  content: "\f26d";
+}
+.fa-500px:before {
+  content: "\f26e";
+}
+.fa-amazon:before {
+  content: "\f270";
+}
+.fa-calendar-plus-o:before {
+  content: "\f271";
+}
+.fa-calendar-minus-o:before {
+  content: "\f272";
+}
+.fa-calendar-times-o:before {
+  content: "\f273";
+}
+.fa-calendar-check-o:before {
+  content: "\f274";
+}
+.fa-industry:before {
+  content: "\f275";
+}
+.fa-map-pin:before {
+  content: "\f276";
+}
+.fa-map-signs:before {
+  content: "\f277";
+}
+.fa-map-o:before {
+  content: "\f278";
+}
+.fa-map:before {
+  content: "\f279";
+}
+.fa-commenting:before {
+  content: "\f27a";
+}
+.fa-commenting-o:before {
+  content: "\f27b";
+}
+.fa-houzz:before {
+  content: "\f27c";
+}
+.fa-vimeo:before {
+  content: "\f27d";
+}
+.fa-black-tie:before {
+  content: "\f27e";
+}
+.fa-fonticons:before {
+  content: "\f280";
+}
+.fa-reddit-alien:before {
+  content: "\f281";
+}
+.fa-edge:before {
+  content: "\f282";
+}
+.fa-credit-card-alt:before {
+  content: "\f283";
+}
+.fa-codiepie:before {
+  content: "\f284";
+}
+.fa-modx:before {
+  content: "\f285";
+}
+.fa-fort-awesome:before {
+  content: "\f286";
+}
+.fa-usb:before {
+  content: "\f287";
+}
+.fa-product-hunt:before {
+  content: "\f288";
+}
+.fa-mixcloud:before {
+  content: "\f289";
+}
+.fa-scribd:before {
+  content: "\f28a";
+}
+.fa-pause-circle:before {
+  content: "\f28b";
+}
+.fa-pause-circle-o:before {
+  content: "\f28c";
+}
+.fa-stop-circle:before {
+  content: "\f28d";
+}
+.fa-stop-circle-o:before {
+  content: "\f28e";
+}
+.fa-shopping-bag:before {
+  content: "\f290";
+}
+.fa-shopping-basket:before {
+  content: "\f291";
+}
+.fa-hashtag:before {
+  content: "\f292";
+}
+.fa-bluetooth:before {
+  content: "\f293";
+}
+.fa-bluetooth-b:before {
+  content: "\f294";
+}
+.fa-percent:before {
+  content: "\f295";
+}
+.fa-gitlab:before {
+  content: "\f296";
+}
+.fa-wpbeginner:before {
+  content: "\f297";
+}
+.fa-wpforms:before {
+  content: "\f298";
+}
+.fa-envira:before {
+  content: "\f299";
+}
+.fa-universal-access:before {
+  content: "\f29a";
+}
+.fa-wheelchair-alt:before {
+  content: "\f29b";
+}
+.fa-question-circle-o:before {
+  content: "\f29c";
+}
+.fa-blind:before {
+  content: "\f29d";
+}
+.fa-audio-description:before {
+  content: "\f29e";
+}
+.fa-volume-control-phone:before {
+  content: "\f2a0";
+}
+.fa-braille:before {
+  content: "\f2a1";
+}
+.fa-assistive-listening-systems:before {
+  content: "\f2a2";
+}
+.fa-asl-interpreting:before,
+.fa-american-sign-language-interpreting:before {
+  content: "\f2a3";
+}
+.fa-deafness:before,
+.fa-hard-of-hearing:before,
+.fa-deaf:before {
+  content: "\f2a4";
+}
+.fa-glide:before {
+  content: "\f2a5";
+}
+.fa-glide-g:before {
+  content: "\f2a6";
+}
+.fa-signing:before,
+.fa-sign-language:before {
+  content: "\f2a7";
+}
+.fa-low-vision:before {
+  content: "\f2a8";
+}
+.fa-viadeo:before {
+  content: "\f2a9";
+}
+.fa-viadeo-square:before {
+  content: "\f2aa";
+}
+.fa-snapchat:before {
+  content: "\f2ab";
+}
+.fa-snapchat-ghost:before {
+  content: "\f2ac";
+}
+.fa-snapchat-square:before {
+  content: "\f2ad";
+}
+.fa-pied-piper:before {
+  content: "\f2ae";
+}
+.fa-first-order:before {
+  content: "\f2b0";
+}
+.fa-yoast:before {
+  content: "\f2b1";
+}
+.fa-themeisle:before {
+  content: "\f2b2";
+}
+.fa-google-plus-circle:before,
+.fa-google-plus-official:before {
+  content: "\f2b3";
+}
+.fa-fa:before,
+.fa-font-awesome:before {
+  content: "\f2b4";
+}
+.fa-handshake-o:before {
+  content: "\f2b5";
+}
+.fa-envelope-open:before {
+  content: "\f2b6";
+}
+.fa-envelope-open-o:before {
+  content: "\f2b7";
+}
+.fa-linode:before {
+  content: "\f2b8";
+}
+.fa-address-book:before {
+  content: "\f2b9";
+}
+.fa-address-book-o:before {
+  content: "\f2ba";
+}
+.fa-vcard:before,
+.fa-address-card:before {
+  content: "\f2bb";
+}
+.fa-vcard-o:before,
+.fa-address-card-o:before {
+  content: "\f2bc";
+}
+.fa-user-circle:before {
+  content: "\f2bd";
+}
+.fa-user-circle-o:before {
+  content: "\f2be";
+}
+.fa-user-o:before {
+  content: "\f2c0";
+}
+.fa-id-badge:before {
+  content: "\f2c1";
+}
+.fa-drivers-license:before,
+.fa-id-card:before {
+  content: "\f2c2";
+}
+.fa-drivers-license-o:before,
+.fa-id-card-o:before {
+  content: "\f2c3";
+}
+.fa-quora:before {
+  content: "\f2c4";
+}
+.fa-free-code-camp:before {
+  content: "\f2c5";
+}
+.fa-telegram:before {
+  content: "\f2c6";
+}
+.fa-thermometer-4:before,
+.fa-thermometer:before,
+.fa-thermometer-full:before {
+  content: "\f2c7";
+}
+.fa-thermometer-3:before,
+.fa-thermometer-three-quarters:before {
+  content: "\f2c8";
+}
+.fa-thermometer-2:before,
+.fa-thermometer-half:before {
+  content: "\f2c9";
+}
+.fa-thermometer-1:before,
+.fa-thermometer-quarter:before {
+  content: "\f2ca";
+}
+.fa-thermometer-0:before,
+.fa-thermometer-empty:before {
+  content: "\f2cb";
+}
+.fa-shower:before {
+  content: "\f2cc";
+}
+.fa-bathtub:before,
+.fa-s15:before,
+.fa-bath:before {
+  content: "\f2cd";
+}
+.fa-podcast:before {
+  content: "\f2ce";
+}
+.fa-window-maximize:before {
+  content: "\f2d0";
+}
+.fa-window-minimize:before {
+  content: "\f2d1";
+}
+.fa-window-restore:before {
+  content: "\f2d2";
+}
+.fa-times-rectangle:before,
+.fa-window-close:before {
+  content: "\f2d3";
+}
+.fa-times-rectangle-o:before,
+.fa-window-close-o:before {
+  content: "\f2d4";
+}
+.fa-bandcamp:before {
+  content: "\f2d5";
+}
+.fa-grav:before {
+  content: "\f2d6";
+}
+.fa-etsy:before {
+  content: "\f2d7";
+}
+.fa-imdb:before {
+  content: "\f2d8";
+}
+.fa-ravelry:before {
+  content: "\f2d9";
+}
+.fa-eercast:before {
+  content: "\f2da";
+}
+.fa-microchip:before {
+  content: "\f2db";
+}
+.fa-snowflake-o:before {
+  content: "\f2dc";
+}
+.fa-superpowers:before {
+  content: "\f2dd";
+}
+.fa-wpexplorer:before {
+  content: "\f2de";
+}
+.fa-meetup:before {
+  content: "\f2e0";
+}
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+}
+.sr-only-focusable:active,
+.sr-only-focusable:focus {
+  position: static;
+  width: auto;
+  height: auto;
+  margin: 0;
+  overflow: visible;
+  clip: auto;
+}
+.sr-only-focusable:active,
+.sr-only-focusable:focus {
+  position: static;
+  width: auto;
+  height: auto;
+  margin: 0;
+  overflow: visible;
+  clip: auto;
+}
 /*!
 *
 * IPython base
@@ -8451,15 +9129,15 @@ label {
 }
 /* Flexible box model classes */
 /* Taken from Alex Russell http://infrequently.org/2009/08/css-3-progress/ */
-/* This file is a compatability layer.  It allows the usage of flexible box
+/* This file is a compatability layer.  It allows the usage of flexible box 
 model layouts accross multiple browsers, including older browsers.  The newest,
 universal implementation of the flexible box model is used when available (see
-`Modern browsers` comments below).  Browsers that are known to implement this
+`Modern browsers` comments below).  Browsers that are known to implement this 
 new spec completely include:
 
     Firefox 28.0+
     Chrome 29.0+
-    Internet Explorer 11+
+    Internet Explorer 11+ 
     Opera 17.0+
 
 Browsers not listed, including Safari, are supported via the styling under the
@@ -8694,6 +9372,10 @@ div.traceback-wrapper {
   max-width: 800px;
   margin: auto;
 }
+div.traceback-wrapper pre.traceback {
+  max-height: 600px;
+  overflow: auto;
+}
 /**
  * Primary styles
  *
@@ -8719,6 +9401,10 @@ body > #header {
   z-index: 100;
 }
 body > #header #header-container {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  padding: 5px;
   padding-bottom: 5px;
   padding-top: 5px;
   box-sizing: border-box;
@@ -8750,13 +9436,16 @@ body > #header .header-bar {
   padding-top: 1px;
   padding-bottom: 1px;
 }
-@media (max-width: 991px) {
-  #ipython_notebook {
-    margin-left: 10px;
-  }
-}
 [dir="rtl"] #ipython_notebook {
+  margin-right: 10px;
+  margin-left: 0;
+}
+[dir="rtl"] #ipython_notebook.pull-left {
   float: right !important;
+  float: right;
+}
+.flex-spacer {
+  flex: 1;
 }
 #noscript {
   width: auto;
@@ -8791,8 +9480,14 @@ body > #header .header-bar {
 input.ui-button {
   padding: 0.3em 0.9em;
 }
+span#kernel_logo_widget {
+  margin: 0 10px;
+}
 span#login_widget {
   float: right;
+}
+[dir="rtl"] span#login_widget {
+  float: left;
 }
 span#login_widget > .button,
 #logout {
@@ -8908,6 +9603,9 @@ span#login_widget > .button .badge,
   overflow: auto;
   flex: 1;
 }
+.modal-header {
+  cursor: move;
+}
 @media (min-width: 768px) {
   .modal .modal-dialog {
     width: 700px;
@@ -8928,6 +9626,19 @@ span#login_widget > .button .badge,
   display: inline-block;
   margin-bottom: -4px;
 }
+[dir="rtl"] .center-nav form.pull-left {
+  float: right !important;
+  float: right;
+}
+[dir="rtl"] .center-nav .navbar-text {
+  float: right;
+}
+[dir="rtl"] .navbar-inner {
+  text-align: right;
+}
+[dir="rtl"] div.text-left {
+  text-align: right;
+}
 /*!
 *
 * IPython tree view
@@ -8944,34 +9655,42 @@ span#login_widget > .button .badge,
   margin: 0;
 }
 .alternate_upload input.fileinput {
-  text-align: center;
-  vertical-align: middle;
-  display: inline;
+  position: absolute;
+  display: block;
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+  cursor: pointer;
   opacity: 0;
   z-index: 2;
-  width: 12ex;
-  margin-right: -12ex;
+}
+.alternate_upload .btn-xs > input.fileinput {
+  margin: -1px -5px;
 }
 .alternate_upload .btn-upload {
+  position: relative;
   height: 22px;
+}
+::-webkit-file-upload-button {
+  cursor: pointer;
 }
 /**
  * Primary styles
  *
  * Author: Jupyter Development Team
  */
-[dir="rtl"] #tabs li {
-  float: right;
-}
 ul#tabs {
   margin-bottom: 4px;
-}
-[dir="rtl"] ul#tabs {
-  margin-right: 0px;
 }
 ul#tabs a {
   padding-top: 6px;
   padding-bottom: 4px;
+}
+[dir="rtl"] ul#tabs.nav-tabs > li {
+  float: right;
+}
+[dir="rtl"] ul#tabs.nav.nav-tabs {
+  padding-right: 0;
 }
 ul.breadcrumb a:focus,
 ul.breadcrumb a:hover {
@@ -8991,15 +9710,13 @@ ul.breadcrumb span {
 .list_toolbar .tree-buttons {
   padding-top: 1px;
 }
-[dir="rtl"] .list_toolbar .tree-buttons {
+[dir="rtl"] .list_toolbar .tree-buttons .pull-right {
   float: left !important;
+  float: left;
 }
-[dir="rtl"] .list_toolbar .pull-right {
-  padding-top: 1px;
-  float: left !important;
-}
-[dir="rtl"] .list_toolbar .pull-left {
-  float: right !important;
+[dir="rtl"] .list_toolbar .col-sm-4,
+[dir="rtl"] .list_toolbar .col-sm-8 {
+  float: right;
 }
 .dynamic-buttons {
   padding-top: 3px;
@@ -9055,7 +9772,7 @@ ul.breadcrumb span {
 .list_item > div input {
   margin-right: 7px;
   margin-left: 14px;
-  vertical-align: baseline;
+  vertical-align: text-bottom;
   line-height: 22px;
   position: relative;
   top: -1px;
@@ -9065,6 +9782,9 @@ ul.breadcrumb span {
   margin-left: -1px;
   vertical-align: baseline;
   line-height: 22px;
+}
+[dir="rtl"] .list_item > div input {
+  margin-right: 0;
 }
 .new-file input[type=checkbox] {
   visibility: hidden;
@@ -9080,6 +9800,14 @@ ul.breadcrumb span {
   margin-left: 7px;
   line-height: 22px;
   vertical-align: baseline;
+}
+.item_modified {
+  margin-right: 7px;
+  margin-left: 7px;
+}
+[dir="rtl"] .item_modified.pull-right {
+  float: left !important;
+  float: left;
 }
 .item_buttons {
   line-height: 1em;
@@ -9108,6 +9836,14 @@ ul.breadcrumb span {
   margin-right: 7px;
   float: left;
 }
+[dir="rtl"] .item_buttons.pull-right {
+  float: left !important;
+  float: left;
+}
+[dir="rtl"] .item_buttons .kernel-name {
+  margin-left: 7px;
+  float: right;
+}
 .toolbar_info {
   height: 24px;
   line-height: 24px;
@@ -9133,18 +9869,32 @@ ul.breadcrumb span {
   background-color: transparent;
   font-weight: bold;
 }
+.sort_button {
+  display: inline-block;
+  padding-left: 7px;
+}
+[dir="rtl"] .sort_button.pull-right {
+  float: left !important;
+  float: left;
+}
 #tree-selector {
   padding-right: 0px;
-}
-[dir="rtl"] #tree-selector a {
-  float: right;
 }
 #button-select-all {
   min-width: 50px;
 }
+[dir="rtl"] #button-select-all.btn {
+  float: right ;
+}
 #select-all {
   margin-left: 7px;
   margin-right: 2px;
+  margin-top: 2px;
+  height: 16px;
+}
+[dir="rtl"] #select-all.pull-left {
+  float: right !important;
+  float: right;
 }
 .menu_icon {
   margin-right: 2px;
@@ -9162,6 +9912,12 @@ ul.breadcrumb span {
   -moz-osx-font-smoothing: grayscale;
   content: "\f114";
 }
+.folder_icon:before.fa-pull-left {
+  margin-right: .3em;
+}
+.folder_icon:before.fa-pull-right {
+  margin-left: .3em;
+}
 .folder_icon:before.pull-left {
   margin-right: .3em;
 }
@@ -9178,6 +9934,12 @@ ul.breadcrumb span {
   content: "\f02d";
   position: relative;
   top: -1px;
+}
+.notebook_icon:before.fa-pull-left {
+  margin-right: .3em;
+}
+.notebook_icon:before.fa-pull-right {
+  margin-left: .3em;
 }
 .notebook_icon:before.pull-left {
   margin-right: .3em;
@@ -9197,6 +9959,12 @@ ul.breadcrumb span {
   top: -1px;
   color: #5cb85c;
 }
+.running_notebook_icon:before.fa-pull-left {
+  margin-right: .3em;
+}
+.running_notebook_icon:before.fa-pull-right {
+  margin-left: .3em;
+}
 .running_notebook_icon:before.pull-left {
   margin-right: .3em;
 }
@@ -9214,6 +9982,12 @@ ul.breadcrumb span {
   position: relative;
   top: -2px;
 }
+.file_icon:before.fa-pull-left {
+  margin-right: .3em;
+}
+.file_icon:before.fa-pull-right {
+  margin-left: .3em;
+}
 .file_icon:before.pull-left {
   margin-right: .3em;
 }
@@ -9228,8 +10002,11 @@ ul#new-menu {
   left: auto;
   right: 0;
 }
-[dir="rtl"] #new-menu {
-  text-align: right;
+#new-menu .dropdown-header {
+  font-size: 10px;
+  border-bottom: 1px solid #e5e5e5;
+  padding: 0 0 3px;
+  margin: -3px 20px 0;
 }
 .kernel-menu-icon {
   padding-right: 12px;
@@ -9276,9 +10053,6 @@ ul#new-menu {
 #running .panel-group .panel .panel-body .list_container .list_item:last-child {
   border-bottom: 0px;
 }
-[dir="rtl"] #running .col-sm-8 {
-  float: right !important;
-}
 .delete-button {
   display: none;
 }
@@ -9286,6 +10060,12 @@ ul#new-menu {
   display: none;
 }
 .rename-button {
+  display: none;
+}
+.move-button {
+  display: none;
+}
+.download-button {
   display: none;
 }
 .shutdown-button {
@@ -9328,6 +10108,12 @@ ul#new-menu {
   -moz-osx-font-smoothing: grayscale;
   width: 20px;
 }
+.dirty-indicator.fa-pull-left {
+  margin-right: .3em;
+}
+.dirty-indicator.fa-pull-right {
+  margin-left: .3em;
+}
 .dirty-indicator.pull-left {
   margin-right: .3em;
 }
@@ -9342,6 +10128,12 @@ ul#new-menu {
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   width: 20px;
+}
+.dirty-indicator-dirty.fa-pull-left {
+  margin-right: .3em;
+}
+.dirty-indicator-dirty.fa-pull-right {
+  margin-left: .3em;
 }
 .dirty-indicator-dirty.pull-left {
   margin-right: .3em;
@@ -9358,6 +10150,12 @@ ul#new-menu {
   -moz-osx-font-smoothing: grayscale;
   width: 20px;
 }
+.dirty-indicator-clean.fa-pull-left {
+  margin-right: .3em;
+}
+.dirty-indicator-clean.fa-pull-right {
+  margin-left: .3em;
+}
 .dirty-indicator-clean.pull-left {
   margin-right: .3em;
 }
@@ -9372,6 +10170,12 @@ ul#new-menu {
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   content: "\f00c";
+}
+.dirty-indicator-clean:before.fa-pull-left {
+  margin-right: .3em;
+}
+.dirty-indicator-clean:before.fa-pull-right {
+  margin-left: .3em;
 }
 .dirty-indicator-clean:before.pull-left {
   margin-right: .3em;
@@ -9417,14 +10221,132 @@ ul#new-menu {
     box-shadow: 0px 0px 12px 1px rgba(87, 87, 87, 0.2);
   }
 }
+.CodeMirror-dialog {
+  background-color: #fff;
+}
 /*!
 *
 * IPython notebook
 *
 */
-/* CSS font colors for translated ANSI colors. */
+/* CSS font colors for translated ANSI escape sequences */
+/* The color values are a mix of
+   http://www.xcolors.net/dl/baskerville-ivorylight and
+   http://www.xcolors.net/dl/euphrasia */
+.ansi-black-fg {
+  color: #3E424D;
+}
+.ansi-black-bg {
+  background-color: #3E424D;
+}
+.ansi-black-intense-fg {
+  color: #282C36;
+}
+.ansi-black-intense-bg {
+  background-color: #282C36;
+}
+.ansi-red-fg {
+  color: #E75C58;
+}
+.ansi-red-bg {
+  background-color: #E75C58;
+}
+.ansi-red-intense-fg {
+  color: #B22B31;
+}
+.ansi-red-intense-bg {
+  background-color: #B22B31;
+}
+.ansi-green-fg {
+  color: #00A250;
+}
+.ansi-green-bg {
+  background-color: #00A250;
+}
+.ansi-green-intense-fg {
+  color: #007427;
+}
+.ansi-green-intense-bg {
+  background-color: #007427;
+}
+.ansi-yellow-fg {
+  color: #DDB62B;
+}
+.ansi-yellow-bg {
+  background-color: #DDB62B;
+}
+.ansi-yellow-intense-fg {
+  color: #B27D12;
+}
+.ansi-yellow-intense-bg {
+  background-color: #B27D12;
+}
+.ansi-blue-fg {
+  color: #208FFB;
+}
+.ansi-blue-bg {
+  background-color: #208FFB;
+}
+.ansi-blue-intense-fg {
+  color: #0065CA;
+}
+.ansi-blue-intense-bg {
+  background-color: #0065CA;
+}
+.ansi-magenta-fg {
+  color: #D160C4;
+}
+.ansi-magenta-bg {
+  background-color: #D160C4;
+}
+.ansi-magenta-intense-fg {
+  color: #A03196;
+}
+.ansi-magenta-intense-bg {
+  background-color: #A03196;
+}
+.ansi-cyan-fg {
+  color: #60C6C8;
+}
+.ansi-cyan-bg {
+  background-color: #60C6C8;
+}
+.ansi-cyan-intense-fg {
+  color: #258F8F;
+}
+.ansi-cyan-intense-bg {
+  background-color: #258F8F;
+}
+.ansi-white-fg {
+  color: #C5C1B4;
+}
+.ansi-white-bg {
+  background-color: #C5C1B4;
+}
+.ansi-white-intense-fg {
+  color: #A1A6B2;
+}
+.ansi-white-intense-bg {
+  background-color: #A1A6B2;
+}
+.ansi-default-inverse-fg {
+  color: #FFFFFF;
+}
+.ansi-default-inverse-bg {
+  background-color: #000000;
+}
+.ansi-bold {
+  font-weight: bold;
+}
+.ansi-underline {
+  text-decoration: underline;
+}
+/* The following styles are deprecated an will be removed in a future version */
 .ansibold {
   font-weight: bold;
+}
+.ansi-inverse {
+  outline: 0.5px dotted;
 }
 /* use dark versions for foreground, to improve visibility */
 .ansiblack {
@@ -9503,12 +10425,20 @@ div.cell {
   /* This acts as a spacer between cells, that is outside the border */
   margin: 0px;
   outline: none;
-  border-left-width: 1px;
-  padding-left: 5px;
-  background: linear-gradient(to right, transparent -40px, transparent 1px, transparent 1px, transparent 100%);
+  position: relative;
+  overflow: visible;
+}
+div.cell:before {
+  position: absolute;
+  display: block;
+  top: -1px;
+  left: -1px;
+  width: 5px;
+  height: calc(100% +  2px);
+  content: '';
+  background: transparent;
 }
 div.cell.jupyter-soft-selected {
-  border-left-color: #90CAF9;
   border-left-color: #E3F2FD;
   border-left-width: 1px;
   padding-left: 5px;
@@ -9521,27 +10451,39 @@ div.cell.jupyter-soft-selected {
     border-color: transparent;
   }
 }
-div.cell.selected {
+div.cell.selected,
+div.cell.selected.jupyter-soft-selected {
   border-color: #ababab;
-  border-left-width: 0px;
-  padding-left: 6px;
-  background: linear-gradient(to right, #42A5F5 -40px, #42A5F5 5px, transparent 5px, transparent 100%);
+}
+div.cell.selected:before,
+div.cell.selected.jupyter-soft-selected:before {
+  position: absolute;
+  display: block;
+  top: -1px;
+  left: -1px;
+  width: 5px;
+  height: calc(100% +  2px);
+  content: '';
+  background: #42A5F5;
 }
 @media print {
-  div.cell.selected {
+  div.cell.selected,
+  div.cell.selected.jupyter-soft-selected {
     border-color: transparent;
   }
 }
-div.cell.selected.jupyter-soft-selected {
-  border-left-width: 0;
-  padding-left: 6px;
-  background: linear-gradient(to right, #42A5F5 -40px, #42A5F5 7px, #E3F2FD 7px, #E3F2FD 100%);
-}
 .edit_mode div.cell.selected {
   border-color: #66BB6A;
-  border-left-width: 0px;
-  padding-left: 6px;
-  background: linear-gradient(to right, #66BB6A -40px, #66BB6A 5px, transparent 5px, transparent 100%);
+}
+.edit_mode div.cell.selected:before {
+  position: absolute;
+  display: block;
+  top: -1px;
+  left: -1px;
+  width: 5px;
+  height: calc(100% +  2px);
+  content: '';
+  background: #66BB6A;
 }
 @media print {
   .edit_mode div.cell.selected {
@@ -9737,7 +10679,9 @@ div.input_area > div.highlight > pre {
 .CodeMirror-lines {
   /* In CM2, this used to be 0.4em, but in CM3 it went to 4px. We need the em value because */
   /* we have set a different line-height and want this to scale with that. */
-  padding: 0.4em;
+  /* Note that this should set vertical padding only, since CodeMirror assumes
+       that horizontal padding will be set on CodeMirror pre */
+  padding: 0.4em 0;
 }
 .CodeMirror-linenumber {
   padding: 0 8px 0 4px;
@@ -9747,11 +10691,24 @@ div.input_area > div.highlight > pre {
   border-top-left-radius: 2px;
 }
 .CodeMirror pre {
-  /* In CM3 this went to 4px from 0 in CM2. We need the 0 value because of how we size */
-  /* .CodeMirror-lines */
-  padding: 0;
+  /* In CM3 this went to 4px from 0 in CM2. This sets horizontal padding only,
+    use .CodeMirror-lines for vertical */
+  padding: 0 0.4em;
   border: 0;
   border-radius: 0;
+}
+.CodeMirror-cursor {
+  border-left: 1.4px solid black;
+}
+@media screen and (min-width: 2138px) and (max-width: 4319px) {
+  .CodeMirror-cursor {
+    border-left: 2px solid black;
+  }
+}
+@media screen and (min-width: 4320px) {
+  .CodeMirror-cursor {
+    border-left: 4px solid black;
+  }
 }
 /*
 
@@ -10005,6 +10962,9 @@ div.output_area img.unconfined,
 div.output_area svg.unconfined {
   max-width: none;
 }
+div.output_area .mglyph > img {
+  max-width: none;
+}
 /* This is needed to protect the pre formating from global settings such
    as that of bootstrap */
 .output {
@@ -10043,7 +11003,7 @@ div.output_area svg.unconfined {
 }
 div.output_area pre {
   margin: 0;
-  padding: 0;
+  padding: 1px 0 1px 0;
   border: 0;
   vertical-align: baseline;
   color: black;
@@ -10203,39 +11163,35 @@ div.output_unrecognized a:hover {
 .rendered_html h6:first-child {
   margin-top: 1em;
 }
+.rendered_html ul:not(.list-inline),
+.rendered_html ol:not(.list-inline) {
+  padding-left: 2em;
+}
 .rendered_html ul {
   list-style: disc;
-  margin: 0em 2em;
-  padding-left: 0px;
 }
 .rendered_html ul ul {
   list-style: square;
-  margin: 0em 2em;
+  margin-top: 0;
 }
 .rendered_html ul ul ul {
   list-style: circle;
-  margin: 0em 2em;
 }
 .rendered_html ol {
   list-style: decimal;
-  margin: 0em 2em;
-  padding-left: 0px;
 }
 .rendered_html ol ol {
   list-style: upper-alpha;
-  margin: 0em 2em;
+  margin-top: 0;
 }
 .rendered_html ol ol ol {
   list-style: lower-alpha;
-  margin: 0em 2em;
 }
 .rendered_html ol ol ol ol {
   list-style: lower-roman;
-  margin: 0em 2em;
 }
 .rendered_html ol ol ol ol ol {
   list-style: decimal;
-  margin: 0em 2em;
 }
 .rendered_html * + ul {
   margin-top: 1em;
@@ -10249,14 +11205,23 @@ div.output_unrecognized a:hover {
 }
 .rendered_html pre {
   margin: 1em 2em;
+  padding: 0px;
+  background-color: #fff;
+}
+.rendered_html code {
+  background-color: #eff0f1;
+}
+.rendered_html p code {
+  padding: 1px 5px;
+}
+.rendered_html pre code {
+  background-color: #fff;
 }
 .rendered_html pre,
 .rendered_html code {
   border: 0;
-  background-color: #fff;
   color: #000;
   font-size: 100%;
-  padding: 0px;
 }
 .rendered_html blockquote {
   margin: 1em 2em;
@@ -10264,24 +11229,36 @@ div.output_unrecognized a:hover {
 .rendered_html table {
   margin-left: auto;
   margin-right: auto;
-  border: 1px solid black;
+  border: none;
   border-collapse: collapse;
+  border-spacing: 0;
+  color: black;
+  font-size: 12px;
+  table-layout: fixed;
+}
+.rendered_html thead {
+  border-bottom: 1px solid black;
+  vertical-align: bottom;
 }
 .rendered_html tr,
 .rendered_html th,
 .rendered_html td {
-  border: 1px solid black;
-  border-collapse: collapse;
-  margin: 1em 2em;
-}
-.rendered_html td,
-.rendered_html th {
-  text-align: left;
+  text-align: right;
   vertical-align: middle;
-  padding: 4px;
+  padding: 0.5em 0.5em;
+  line-height: normal;
+  white-space: normal;
+  max-width: none;
+  border: none;
 }
 .rendered_html th {
   font-weight: bold;
+}
+.rendered_html tbody tr:nth-child(odd) {
+  background: #f5f5f5;
+}
+.rendered_html tbody tr:hover {
+  background: rgba(66, 165, 245, 0.2);
 }
 .rendered_html * + table {
   margin-top: 1em;
@@ -10308,6 +11285,15 @@ div.output_unrecognized a:hover {
 .rendered_html img.unconfined,
 .rendered_html svg.unconfined {
   max-width: none;
+}
+.rendered_html .alert {
+  margin-bottom: initial;
+}
+.rendered_html * + .alert {
+  margin-top: 1em;
+}
+[dir="rtl"] .rendered_html p {
+  text-align: right;
 }
 div.text_cell {
   /* Old browsers */
@@ -10362,8 +11348,17 @@ h6:hover .anchor-link {
   overflow-x: auto;
   overflow-y: hidden;
 }
+.text_cell.rendered .rendered_html tr,
+.text_cell.rendered .rendered_html th,
+.text_cell.rendered .rendered_html td {
+  max-width: none;
+}
 .text_cell.unrendered .text_cell_render {
   display: none;
+}
+.text_cell .dropzone .input_area {
+  border: 2px dashed #bababa;
+  margin: -1px;
 }
 .cm-header-1,
 .cm-header-2,
@@ -10500,6 +11495,28 @@ kbd {
   padding-top: 1px;
   padding-bottom: 1px;
 }
+.jupyter-keybindings {
+  padding: 1px;
+  line-height: 24px;
+  border-bottom: 1px solid gray;
+}
+.jupyter-keybindings input {
+  margin: 0;
+  padding: 0;
+  border: none;
+}
+.jupyter-keybindings i {
+  padding: 6px;
+}
+.well code {
+  background-color: #ffffff;
+  border-color: #ababab;
+  border-width: 1px;
+  border-style: solid;
+  padding: 2px;
+  padding-top: 1px;
+  padding-bottom: 1px;
+}
 /* CSS for the cell toolbar */
 .celltoolbar {
   border: thin solid #CFCFCF;
@@ -10632,6 +11649,152 @@ select[multiple].celltoolbar select {
   margin-left: 5px;
   margin-right: 5px;
 }
+.tags_button_container {
+  width: 100%;
+  display: flex;
+}
+.tag-container {
+  display: flex;
+  flex-direction: row;
+  flex-grow: 1;
+  overflow: hidden;
+  position: relative;
+}
+.tag-container > * {
+  margin: 0 4px;
+}
+.remove-tag-btn {
+  margin-left: 4px;
+}
+.tags-input {
+  display: flex;
+}
+.cell-tag:last-child:after {
+  content: "";
+  position: absolute;
+  right: 0;
+  width: 40px;
+  height: 100%;
+  /* Fade to background color of cell toolbar */
+  background: linear-gradient(to right, rgba(0, 0, 0, 0), #EEE);
+}
+.tags-input > * {
+  margin-left: 4px;
+}
+.cell-tag,
+.tags-input input,
+.tags-input button {
+  display: block;
+  width: 100%;
+  height: 32px;
+  padding: 6px 12px;
+  font-size: 13px;
+  line-height: 1.42857143;
+  color: #555555;
+  background-color: #fff;
+  background-image: none;
+  border: 1px solid #ccc;
+  border-radius: 2px;
+  -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
+  box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
+  -webkit-transition: border-color ease-in-out .15s, box-shadow ease-in-out .15s;
+  -o-transition: border-color ease-in-out .15s, box-shadow ease-in-out .15s;
+  transition: border-color ease-in-out .15s, box-shadow ease-in-out .15s;
+  height: 30px;
+  padding: 5px 10px;
+  font-size: 12px;
+  line-height: 1.5;
+  border-radius: 1px;
+  box-shadow: none;
+  width: inherit;
+  font-size: inherit;
+  height: 22px;
+  line-height: 22px;
+  padding: 0px 4px;
+  display: inline-block;
+}
+.cell-tag:focus,
+.tags-input input:focus,
+.tags-input button:focus {
+  border-color: #66afe9;
+  outline: 0;
+  -webkit-box-shadow: inset 0 1px 1px rgba(0,0,0,.075), 0 0 8px rgba(102, 175, 233, 0.6);
+  box-shadow: inset 0 1px 1px rgba(0,0,0,.075), 0 0 8px rgba(102, 175, 233, 0.6);
+}
+.cell-tag::-moz-placeholder,
+.tags-input input::-moz-placeholder,
+.tags-input button::-moz-placeholder {
+  color: #999;
+  opacity: 1;
+}
+.cell-tag:-ms-input-placeholder,
+.tags-input input:-ms-input-placeholder,
+.tags-input button:-ms-input-placeholder {
+  color: #999;
+}
+.cell-tag::-webkit-input-placeholder,
+.tags-input input::-webkit-input-placeholder,
+.tags-input button::-webkit-input-placeholder {
+  color: #999;
+}
+.cell-tag::-ms-expand,
+.tags-input input::-ms-expand,
+.tags-input button::-ms-expand {
+  border: 0;
+  background-color: transparent;
+}
+.cell-tag[disabled],
+.tags-input input[disabled],
+.tags-input button[disabled],
+.cell-tag[readonly],
+.tags-input input[readonly],
+.tags-input button[readonly],
+fieldset[disabled] .cell-tag,
+fieldset[disabled] .tags-input input,
+fieldset[disabled] .tags-input button {
+  background-color: #eeeeee;
+  opacity: 1;
+}
+.cell-tag[disabled],
+.tags-input input[disabled],
+.tags-input button[disabled],
+fieldset[disabled] .cell-tag,
+fieldset[disabled] .tags-input input,
+fieldset[disabled] .tags-input button {
+  cursor: not-allowed;
+}
+textarea.cell-tag,
+textarea.tags-input input,
+textarea.tags-input button {
+  height: auto;
+}
+select.cell-tag,
+select.tags-input input,
+select.tags-input button {
+  height: 30px;
+  line-height: 30px;
+}
+textarea.cell-tag,
+textarea.tags-input input,
+textarea.tags-input button,
+select[multiple].cell-tag,
+select[multiple].tags-input input,
+select[multiple].tags-input button {
+  height: auto;
+}
+.cell-tag,
+.tags-input button {
+  padding: 0px 4px;
+}
+.cell-tag {
+  background-color: #fff;
+  white-space: nowrap;
+}
+.tags-input input[type=text]:focus {
+  outline: none;
+  box-shadow: none;
+  border-color: #ccc;
+}
 .completions {
   position: absolute;
   z-index: 110;
@@ -10657,16 +11820,28 @@ select[multiple].celltoolbar select {
 .completions select option.context {
   color: #286090;
 }
-#kernel_logo_widget {
-  float: right !important;
-  float: right;
-}
 #kernel_logo_widget .current_kernel_logo {
   display: none;
   margin-top: -1px;
   margin-bottom: -1px;
   width: 32px;
   height: 32px;
+}
+[dir="rtl"] #kernel_logo_widget {
+  float: left !important;
+  float: left;
+}
+.modal .modal-body .move-path {
+  display: flex;
+  flex-direction: row;
+  justify-content: space;
+  align-items: center;
+}
+.modal .modal-body .move-path .server-root {
+  padding-right: 20px;
+}
+.modal .modal-body .move-path .path-input {
+  flex: 1;
 }
 #menubar {
   box-sizing: border-box;
@@ -10688,11 +11863,41 @@ select[multiple].celltoolbar select {
 #menubar .navbar-collapse {
   clear: left;
 }
+[dir="rtl"] #menubar .navbar-toggle {
+  float: right;
+}
+[dir="rtl"] #menubar .navbar-collapse {
+  clear: right;
+}
+[dir="rtl"] #menubar .navbar-nav {
+  float: right;
+}
+[dir="rtl"] #menubar .nav {
+  padding-right: 0px;
+}
+[dir="rtl"] #menubar .navbar-nav > li {
+  float: right;
+}
+[dir="rtl"] #menubar .navbar-right {
+  float: left !important;
+}
+[dir="rtl"] ul.dropdown-menu {
+  text-align: right;
+  left: auto;
+}
+[dir="rtl"] ul#new-menu.dropdown-menu {
+  right: auto;
+  left: 0;
+}
 .nav-wrapper {
   border-bottom: 1px solid #e7e7e7;
 }
 i.menu-icon {
   padding-top: 4px;
+}
+[dir="rtl"] i.menu-icon.pull-right {
+  float: left !important;
+  float: left;
 }
 ul#help_menu li a {
   overflow: hidden;
@@ -10700,6 +11905,17 @@ ul#help_menu li a {
 }
 ul#help_menu li a i {
   margin-right: -1.2em;
+}
+[dir="rtl"] ul#help_menu li a {
+  padding-left: 2.2em;
+}
+[dir="rtl"] ul#help_menu li a i {
+  margin-right: 0;
+  margin-left: -1.2em;
+}
+[dir="rtl"] ul#help_menu li a i.pull-right {
+  float: left !important;
+  float: left;
 }
 .dropdown-submenu {
   position: relative;
@@ -10709,6 +11925,10 @@ ul#help_menu li a i {
   left: 100%;
   margin-top: -6px;
   margin-left: -1px;
+}
+[dir="rtl"] .dropdown-submenu > .dropdown-menu {
+  right: 100%;
+  margin-right: -1px;
 }
 .dropdown-submenu:hover > .dropdown-menu {
   display: block;
@@ -10727,11 +11947,23 @@ ul#help_menu li a i {
   margin-top: 2px;
   margin-right: -10px;
 }
+.dropdown-submenu > a:after.fa-pull-left {
+  margin-right: .3em;
+}
+.dropdown-submenu > a:after.fa-pull-right {
+  margin-left: .3em;
+}
 .dropdown-submenu > a:after.pull-left {
   margin-right: .3em;
 }
 .dropdown-submenu > a:after.pull-right {
   margin-left: .3em;
+}
+[dir="rtl"] .dropdown-submenu > a:after {
+  float: left;
+  content: "\f0d9";
+  margin-right: 0;
+  margin-left: -10px;
 }
 .dropdown-submenu:hover > a:after {
   color: #262626;
@@ -10748,6 +11980,10 @@ ul#help_menu li a i {
   float: right;
   z-index: 10;
 }
+[dir="rtl"] #notification_area {
+  float: left !important;
+  float: left;
+}
 .indicator_area {
   float: right !important;
   float: right;
@@ -10758,6 +11994,10 @@ ul#help_menu li a i {
   z-index: 10;
   text-align: center;
   width: auto;
+}
+[dir="rtl"] .indicator_area {
+  float: left !important;
+  float: left;
 }
 #kernel_indicator {
   float: right !important;
@@ -10775,6 +12015,12 @@ ul#help_menu li a i {
   padding-left: 5px;
   padding-right: 5px;
 }
+[dir="rtl"] #kernel_indicator {
+  float: left !important;
+  float: left;
+  border-left: 0;
+  border-right: 1px solid;
+}
 #modal_indicator {
   float: right !important;
   float: right;
@@ -10785,6 +12031,10 @@ ul#help_menu li a i {
   z-index: 10;
   text-align: center;
   width: auto;
+}
+[dir="rtl"] #modal_indicator {
+  float: left !important;
+  float: left;
 }
 #readonly-indicator {
   float: right !important;
@@ -10815,6 +12065,12 @@ ul#help_menu li a i {
   -moz-osx-font-smoothing: grayscale;
   content: "\f040";
 }
+.edit_mode .modal_indicator:before.fa-pull-left {
+  margin-right: .3em;
+}
+.edit_mode .modal_indicator:before.fa-pull-right {
+  margin-left: .3em;
+}
 .edit_mode .modal_indicator:before.pull-left {
   margin-right: .3em;
 }
@@ -10829,6 +12085,12 @@ ul#help_menu li a i {
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   content: ' ';
+}
+.command_mode .modal_indicator:before.fa-pull-left {
+  margin-right: .3em;
+}
+.command_mode .modal_indicator:before.fa-pull-right {
+  margin-left: .3em;
 }
 .command_mode .modal_indicator:before.pull-left {
   margin-right: .3em;
@@ -10845,6 +12107,12 @@ ul#help_menu li a i {
   -moz-osx-font-smoothing: grayscale;
   content: "\f10c";
 }
+.kernel_idle_icon:before.fa-pull-left {
+  margin-right: .3em;
+}
+.kernel_idle_icon:before.fa-pull-right {
+  margin-left: .3em;
+}
 .kernel_idle_icon:before.pull-left {
   margin-right: .3em;
 }
@@ -10859,6 +12127,12 @@ ul#help_menu li a i {
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   content: "\f111";
+}
+.kernel_busy_icon:before.fa-pull-left {
+  margin-right: .3em;
+}
+.kernel_busy_icon:before.fa-pull-right {
+  margin-left: .3em;
 }
 .kernel_busy_icon:before.pull-left {
   margin-right: .3em;
@@ -10875,6 +12149,12 @@ ul#help_menu li a i {
   -moz-osx-font-smoothing: grayscale;
   content: "\f1e2";
 }
+.kernel_dead_icon:before.fa-pull-left {
+  margin-right: .3em;
+}
+.kernel_dead_icon:before.fa-pull-right {
+  margin-left: .3em;
+}
 .kernel_dead_icon:before.pull-left {
   margin-right: .3em;
 }
@@ -10889,6 +12169,12 @@ ul#help_menu li a i {
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   content: "\f127";
+}
+.kernel_disconnected_icon:before.fa-pull-left {
+  margin-right: .3em;
+}
+.kernel_disconnected_icon:before.fa-pull-right {
+  margin-left: .3em;
 }
 .kernel_disconnected_icon:before.pull-left {
   margin-right: .3em;
@@ -11233,7 +12519,7 @@ div#pager .ui-resizable-handle {
   background: #f7f7f7;
   border-top: 1px solid #cfcfcf;
   border-bottom: 1px solid #cfcfcf;
-  /* This injects handle bars (a short, wide = symbol) for
+  /* This injects handle bars (a short, wide = symbol) for 
         the resize handle. */
 }
 div#pager .ui-resizable-handle::after {
@@ -11279,27 +12565,46 @@ div#pager .ui-resizable-handle::after {
   flex: 1;
 }
 span.save_widget {
-  margin-top: 6px;
+  height: 30px;
+  margin-top: 4px;
+  display: flex;
+  justify-content: flex-start;
+  align-items: baseline;
+  width: 50%;
+  flex: 1;
 }
 span.save_widget span.filename {
-  height: 1em;
+  height: 100%;
   line-height: 1em;
-  padding: 3px;
   margin-left: 16px;
   border: none;
   font-size: 146.5%;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
   border-radius: 2px;
 }
 span.save_widget span.filename:hover {
   background-color: #e6e6e6;
 }
+[dir="rtl"] span.save_widget.pull-left {
+  float: right !important;
+  float: right;
+}
+[dir="rtl"] span.save_widget span.filename {
+  margin-left: 0;
+  margin-right: 16px;
+}
 span.checkpoint_status,
 span.autosave_status {
   font-size: small;
+  white-space: nowrap;
+  padding: 0 5px;
 }
 @media (max-width: 767px) {
   span.save_widget {
     font-size: small;
+    padding: 0 0 0 5px;
   }
   span.checkpoint_status,
   span.autosave_status {
@@ -11343,6 +12648,9 @@ span.autosave_status {
   margin-top: 0px;
   margin-left: 5px;
 }
+.toolbar-btn-label {
+  margin-left: 6px;
+}
 #maintoolbar {
   margin-bottom: -3px;
   margin-top: -8px;
@@ -11362,6 +12670,10 @@ span.autosave_status {
 }
 .select-xs {
   height: 24px;
+}
+[dir="rtl"] .btn-group > .btn,
+.btn-group-vertical > .btn {
+  float: right;
 }
 .pulse,
 .dropdown-menu > li > a.pulse,
@@ -11512,6 +12824,10 @@ ul.typeahead-list i {
   margin-left: -10px;
   width: 18px;
 }
+[dir="rtl"] ul.typeahead-list i {
+  margin-left: 0;
+  margin-right: -10px;
+}
 ul.typeahead-list {
   max-height: 80vh;
   overflow: auto;
@@ -11520,6 +12836,13 @@ ul.typeahead-list > li > a {
   /** Firefox bug **/
   /* see https://github.com/jupyter/notebook/issues/559 */
   white-space: normal;
+}
+ul.typeahead-list  > li > a.pull-right {
+  float: left !important;
+  float: left;
+}
+[dir="rtl"] .typeahead-list {
+  text-align: right;
 }
 .cmd-palette .modal-body {
   padding: 7px;
@@ -11531,10 +12854,19 @@ ul.typeahead-list > li > a {
   outline: none;
 }
 .no-shortcut {
-  display: none;
+  min-width: 20px;
+  color: transparent;
+}
+[dir="rtl"] .no-shortcut.pull-right {
+  float: left !important;
+  float: left;
+}
+[dir="rtl"] .command-shortcut.pull-right {
+  float: left !important;
+  float: left;
 }
 .command-shortcut:before {
-  content: "(command)";
+  content: "(command mode)";
   padding-right: 3px;
   color: #777777;
 }
@@ -11543,6 +12875,10 @@ ul.typeahead-list > li > a {
   padding-right: 3px;
   color: #777777;
 }
+[dir="rtl"] .edit-shortcut.pull-right {
+  float: left !important;
+  float: left;
+}
 #find-and-replace #replace-preview .match,
 #find-and-replace #replace-preview .insert {
   background-color: #BBDEFB;
@@ -11550,6 +12886,12 @@ ul.typeahead-list > li > a {
   border-style: solid;
   border-width: 1px;
   border-radius: 0px;
+}
+[dir="ltr"] #find-and-replace .input-group-btn + .form-control {
+  border-left: none;
+}
+[dir="rtl"] #find-and-replace .input-group-btn + .form-control {
+  border-right: none;
 }
 #find-and-replace #replace-preview .replace .match {
   background-color: #FFCDD2;
@@ -11676,7 +13018,7 @@ ul.typeahead-list > li > a {
 .highlight .il { color: #666666 } /* Literal.Number.Integer.Long */
     </style>
 <style type="text/css">
-
+    
 /* Temporary definitions which will become obsolete with Notebook release 5.0 */
 .ansi-black-fg { color: #3E424D; }
 .ansi-black-bg { background-color: #3E424D; }
@@ -11730,14 +13072,14 @@ div#notebook {
   div.cell {
     display: block;
     page-break-inside: avoid;
-  }
-  div.output_wrapper {
+  } 
+  div.output_wrapper { 
     display: block;
-    page-break-inside: avoid;
+    page-break-inside: avoid; 
   }
-  div.output {
+  div.output { 
     display: block;
-    page-break-inside: avoid;
+    page-break-inside: avoid; 
   }
 }
 </style>
@@ -11747,7 +13089,7 @@ div#notebook {
 
 <!-- Loading mathjax macro -->
 <!-- Load mathjax -->
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS_HTML"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/latest.js?config=TeX-AMS_HTML"></script>
     <!-- MathJax configuration -->
     <script type="text/x-mathjax-config">
     MathJax.Hub.Config({
@@ -11772,16 +13114,14 @@ div#notebook {
     <div class="container" id="notebook-container">
 
 <div class="cell border-box-sizing text_cell rendered"><div class="prompt input_prompt">
-</div>
-<div class="inner_cell">
+</div><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
 <h1 id="Basic-FISSA-usage">Basic FISSA usage<a class="anchor-link" href="#Basic-FISSA-usage">&#182;</a></h1>
 </div>
 </div>
 </div>
 <div class="cell border-box-sizing text_cell rendered"><div class="prompt input_prompt">
-</div>
-<div class="inner_cell">
+</div><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
 <p>This notebook explains step-by-step how to use the FISSA toolbox. See basic_usage.py (or basic_usage_windows.py for Windows users) for a shorter example script if one does not use a notebook interface.</p>
 
@@ -11793,20 +13133,19 @@ div#notebook {
 <div class="prompt input_prompt">In&nbsp;[1]:</div>
 <div class="inner_cell">
     <div class="input_area">
-<div class=" highlight hl-ipython2"><pre><span></span><span class="c1"># FISSA toolbox imports</span>
+<div class=" highlight hl-ipython3"><pre><span></span><span class="c1"># FISSA toolbox imports</span>
 <span class="kn">import</span> <span class="nn">fissa</span>
 </pre></div>
 
-</div>
+    </div>
 </div>
 </div>
 
 </div>
 <div class="cell border-box-sizing text_cell rendered"><div class="prompt input_prompt">
-</div>
-<div class="inner_cell">
+</div><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
-<p>Plotting toolbox import.
+<p>Plotting toolbox import. 
 Plotting in this notebook is done with Holoviews, for details see <a href="http://holoviews.org/">http://holoviews.org/</a>.</p>
 
 </div>
@@ -11817,13 +13156,13 @@ Plotting in this notebook is done with Holoviews, for details see <a href="http:
 <div class="prompt input_prompt">In&nbsp;[2]:</div>
 <div class="inner_cell">
     <div class="input_area">
-<div class=" highlight hl-ipython2"><pre><span></span><span class="c1"># Plotting toolbox</span>
-<span class="kn">import</span> <span class="nn">holoviews</span> <span class="kn">as</span> <span class="nn">hv</span>
+<div class=" highlight hl-ipython3"><pre><span></span><span class="c1"># Plotting toolbox</span>
+<span class="kn">import</span> <span class="nn">holoviews</span> <span class="k">as</span> <span class="nn">hv</span>
 <span class="o">%</span><span class="k">load_ext</span> holoviews.ipython
 <span class="o">%</span><span class="k">output</span> widgets=&#39;embed&#39;
 </pre></div>
 
-</div>
+    </div>
 </div>
 </div>
 
@@ -11833,481 +13172,105 @@ Plotting in this notebook is done with Holoviews, for details see <a href="http:
 
 <div class="output_area">
 
-<div class="prompt"></div>
+    <div class="prompt"></div>
 
 
 
 <div class="output_html rendered_html output_subarea ">
 
-<script src="https://code.jquery.com/ui/1.10.4/jquery-ui.min.js" type="text/javascript"></script>
-<script type="text/javascript">function HoloViewsWidget(){
-}
-
-HoloViewsWidget.comms = {};
-HoloViewsWidget.comm_state = {};
-
-HoloViewsWidget.prototype.init_slider = function(init_val){
-  if(this.load_json) {
-    this.from_json()
-  } else {
-    this.update_cache();
-  }
-}
-
-HoloViewsWidget.prototype.populate_cache = function(idx){
-  this.cache[idx].html(this.frames[idx]);
-  if (this.embed) {
-    delete this.frames[idx];
-  }
-}
-
-HoloViewsWidget.prototype.process_error = function(msg){
-
-}
-
-HoloViewsWidget.prototype.from_json = function() {
-  var data_url = this.json_path + this.id + '.json';
-  $.getJSON(data_url, $.proxy(function(json_data) {
-    this.frames = json_data;
-    this.update_cache();
-    this.update(0);
-  }, this));
-}
-
-HoloViewsWidget.prototype.dynamic_update = function(current){
-  if (current === undefined) {
-    return
-  }
-  if(this.dynamic) {
-    current = JSON.stringify(current);
-  }
-  function callback(initialized, msg){
-    /* This callback receives data from Python as a string
-       in order to parse it correctly quotes are sliced off*/
-    if (msg.content.ename != undefined) {
-      this.process_error(msg);
-    }
-    if (msg.msg_type != "execute_result") {
-      console.log("Warning: HoloViews callback returned unexpected data for key: (", current, ") with the following content:", msg.content)
-    } else {
-      if (msg.content.data['text/plain'].includes('Complete')) {
-        if (this.queue.length > 0) {
-          this.time = Date.now();
-          this.dynamic_update(this.queue[this.queue.length-1]);
-          this.queue = [];
-        } else {
-          this.wait = false;
-        }
-        return
-      }
-    }
-  }
-  this.current = current;
-  if ((window.Jupyter !== undefined) && (Jupyter.notebook.kernel != null)) {
-    var kernel = Jupyter.notebook.kernel;
-    callbacks = {iopub: {output: $.proxy(callback, this, this.initialized)}};
-    var cmd = "holoviews.plotting.widgets.NdWidget.widgets['" + this.id + "'].update(" + current + ")";
-    kernel.execute("import holoviews;" + cmd, callbacks, {silent : false});
-  }
-}
-
-HoloViewsWidget.prototype.update_cache = function(force){
-  var frame_len = Object.keys(this.frames).length;
-  for (var i=0; i<frame_len; i++) {
-    if(!this.load_json || this.dynamic)  {
-      frame = Object.keys(this.frames)[i];
-    } else {
-      frame = i;
-    }
-    if(!(frame in this.cache) || force) {
-      if ((frame in this.cache) && force) { this.cache[frame].remove() }
-      this.cache[frame] = $('<div />').appendTo("#"+"_anim_img"+this.id).hide();
-      var cache_id = "_anim_img"+this.id+"_"+frame;
-      this.cache[frame].attr("id", cache_id);
-      this.populate_cache(frame);
-    }
-  }
-}
-
-HoloViewsWidget.prototype.update = function(current){
-  if(current in this.cache) {
-    $.each(this.cache, function(index, value) {
-      value.hide();
-    });
-    this.cache[current].show();
-    this.wait = false;
-  }
-}
-
-HoloViewsWidget.prototype.init_comms = function() {
-  if ((window.Jupyter !== undefined) && (Jupyter.notebook.kernel !== undefined)) {
-    var widget = this;
-    comm_manager = Jupyter.notebook.kernel.comm_manager;
-    comm_manager.register_target(this.id, function (comm) {
-      comm.on_msg(function (msg) { widget.process_msg(msg) });
-    });
-  }
-}
-
-HoloViewsWidget.prototype.process_msg = function(msg) {
-}
-
-function SelectionWidget(frames, id, slider_ids, keyMap, dim_vals, notFound, load_json, mode, cached, json_path, dynamic){
-  this.frames = frames;
-  this.id = id;
-  this.slider_ids = slider_ids;
-  this.keyMap = keyMap
-  this.current_frame = 0;
-  this.current_vals = dim_vals;
-  this.load_json = load_json;
-  this.mode = mode;
-  this.notFound = notFound;
-  this.cached = cached;
-  this.dynamic = dynamic;
-  this.cache = {};
-  this.json_path = json_path;
-  this.init_slider(this.current_vals[0]);
-  this.queue = [];
-  this.wait = false;
-  if (!this.cached || this.dynamic) {
-    this.init_comms()
-  }
-}
-
-SelectionWidget.prototype = new HoloViewsWidget;
-
-
-SelectionWidget.prototype.get_key = function(current_vals) {
-  var key = "(";
-  for (var i=0; i<this.slider_ids.length; i++)
-  {
-    val = this.current_vals[i];
-    if (!(typeof val === 'string')) {
-      if (val % 1 === 0) { val = val.toFixed(1); }
-      else { val = val.toFixed(10); val = val.slice(0, val.length-1);}
-    }
-    key += "'" + val + "'";
-    if(i != this.slider_ids.length-1) { key += ', ';}
-    else if(this.slider_ids.length == 1) { key += ',';}
-  }
-  key += ")";
-  return this.keyMap[key];
-}
-
-SelectionWidget.prototype.set_frame = function(dim_val, dim_idx){
-  this.current_vals[dim_idx] = dim_val;
-  var key = this.current_vals;
-  if (!this.dynamic) {
-    key = this.get_key(key)
-  }
-  if (this.dynamic || !this.cached) {
-    if ((this.time !== undefined) && ((this.wait) && ((this.time + 10000) > Date.now()))) {
-      this.queue.push(key);
-      return
-    }
-    this.queue = [];
-    this.time = Date.now();
-    this.current_frame = key;
-    this.wait = true;
-    this.dynamic_update(key)
-  } else if (key !== undefined) {
-    this.update(key)
-  }
-}
-
-
-/* Define the ScrubberWidget class */
-function ScrubberWidget(frames, num_frames, id, interval, load_json, mode, cached, json_path, dynamic){
-  this.slider_id = "_anim_slider" + id;
-  this.loop_select_id = "_anim_loop_select" + id;
-  this.id = id;
-  this.interval = interval;
-  this.current_frame = 0;
-  this.direction = 0;
-  this.dynamic = dynamic;
-  this.timer = null;
-  this.load_json = load_json;
-  this.mode = mode;
-  this.cached = cached;
-  this.frames = frames;
-  this.cache = {};
-  this.length = num_frames;
-  this.json_path = json_path;
-  document.getElementById(this.slider_id).max = this.length - 1;
-  this.init_slider(0);
-  this.wait = false;
-  this.queue = [];
-  if (!this.cached || this.dynamic) {
-    this.init_comms()
-  }
-}
-
-ScrubberWidget.prototype = new HoloViewsWidget;
-
-ScrubberWidget.prototype.set_frame = function(frame){
-  this.current_frame = frame;
-  widget = document.getElementById(this.slider_id);
-  if (widget === null) {
-    this.pause_animation();
-    return
-  }
-  widget.value = this.current_frame;
-  if(this.cached) {
-    this.update(frame)
-  } else {
-    this.dynamic_update(frame)
-  }
-}
-
-
-ScrubberWidget.prototype.get_loop_state = function(){
-  var button_group = document[this.loop_select_id].state;
-  for (var i = 0; i < button_group.length; i++) {
-    var button = button_group[i];
-    if (button.checked) {
-      return button.value;
-    }
-  }
-  return undefined;
-}
-
-
-ScrubberWidget.prototype.next_frame = function() {
-  this.set_frame(Math.min(this.length - 1, this.current_frame + 1));
-}
-
-ScrubberWidget.prototype.previous_frame = function() {
-  this.set_frame(Math.max(0, this.current_frame - 1));
-}
-
-ScrubberWidget.prototype.first_frame = function() {
-  this.set_frame(0);
-}
-
-ScrubberWidget.prototype.last_frame = function() {
-  this.set_frame(this.length - 1);
-}
-
-ScrubberWidget.prototype.slower = function() {
-  this.interval /= 0.7;
-  if(this.direction > 0){this.play_animation();}
-  else if(this.direction < 0){this.reverse_animation();}
-}
-
-ScrubberWidget.prototype.faster = function() {
-  this.interval *= 0.7;
-  if(this.direction > 0){this.play_animation();}
-  else if(this.direction < 0){this.reverse_animation();}
-}
-
-ScrubberWidget.prototype.anim_step_forward = function() {
-  if(this.current_frame < this.length - 1){
-    this.next_frame();
-  }else{
-    var loop_state = this.get_loop_state();
-    if(loop_state == "loop"){
-      this.first_frame();
-    }else if(loop_state == "reflect"){
-      this.last_frame();
-      this.reverse_animation();
-    }else{
-      this.pause_animation();
-      this.last_frame();
-    }
-  }
-}
-
-ScrubberWidget.prototype.anim_step_reverse = function() {
-  if(this.current_frame > 0){
-    this.previous_frame();
-  } else {
-    var loop_state = this.get_loop_state();
-    if(loop_state == "loop"){
-      this.last_frame();
-    }else if(loop_state == "reflect"){
-      this.first_frame();
-      this.play_animation();
-    }else{
-      this.pause_animation();
-      this.first_frame();
-    }
-  }
-}
-
-ScrubberWidget.prototype.pause_animation = function() {
-  this.direction = 0;
-  if (this.timer){
-    clearInterval(this.timer);
-    this.timer = null;
-  }
-}
-
-ScrubberWidget.prototype.play_animation = function() {
-  this.pause_animation();
-  this.direction = 1;
-  var t = this;
-  if (!this.timer) this.timer = setInterval(function(){t.anim_step_forward();}, this.interval);
-}
-
-ScrubberWidget.prototype.reverse_animation = function() {
-  this.pause_animation();
-  this.direction = -1;
-  var t = this;
-  if (!this.timer) this.timer = setInterval(function(){t.anim_step_reverse();}, this.interval);
-}
-
-function extend(destination, source) {
-  for (var k in source) {
-    if (source.hasOwnProperty(k)) {
-      destination[k] = source[k];
-    }
-  }
-  return destination;
-}
-
-function update_widget(widget, values) {
-  if (widget.hasClass("ui-slider")) {
-    widget.slider('option', {
-      min: 0,
-      max: values.length-1,
-      dim_vals: values,
-      value: 0,
-      dim_labels: values
-	})
-    widget.slider('option', 'slide').call(widget, event, {value: 0})
-  } else {
-    widget.empty();
-    for (var i=0; i<values.length; i++){
-      widget.append($("<option>", {
-        value: i,
-        text: values[i]
-      }))
-    };
-    widget.data('values', values);
-    widget.data('value', 0);
-    widget.trigger("change");
-  };
-}
-
-// Define MPL specific subclasses
-function MPLSelectionWidget() {
-    SelectionWidget.apply(this, arguments);
-}
-
-function MPLScrubberWidget() {
-    ScrubberWidget.apply(this, arguments);
-}
-
-// Let them inherit from the baseclasses
-MPLSelectionWidget.prototype = Object.create(SelectionWidget.prototype);
-MPLScrubberWidget.prototype = Object.create(ScrubberWidget.prototype);
-
-// Define methods to override on widgets
-var MPLMethods = {
-    init_slider : function(init_val){
-        if(this.load_json) {
-            this.from_json()
-        } else {
-            this.update_cache();
-        }
-        this.update(0);
-        if(this.mode == 'nbagg') {
-            this.set_frame(init_val, 0);
-        }
-    },
-    populate_cache : function(idx){
-        var cache_id = "_anim_img"+this.id+"_"+idx;
-        this.cache[idx].html(this.frames[idx]);
-        if (this.embed) {
-            delete this.frames[idx];
-        }
-    },
-    process_msg : function(msg) {
-        if (!(this.mode == 'nbagg')) {
-            var data = msg.content.data;
-            this.frames[this.current] = data;
-            this.update_cache(true);
-            this.update(this.current);
-        }
-    }
-}
-// Extend MPL widgets with backend specific methods
-extend(MPLSelectionWidget.prototype, MPLMethods);
-extend(MPLScrubberWidget.prototype, MPLMethods);
-</script>
-
-
 <link rel="stylesheet" href="https://code.jquery.com/ui/1.10.4/themes/smoothness/jquery-ui.css">
 <style>div.hololayout {
-    display: flex;
-    align-items: center;
-    margin: 0;
+  display: flex;
+  align-items: center;
+  margin: 0;
 }
 
 div.holoframe {
-	width: 75%;
+  width: 75%;
 }
 
 div.holowell {
-    display: flex;
-    align-items: center;
-    margin: 0;
+  display: flex;
+  align-items: center;
 }
 
 form.holoform {
-    background-color: #fafafa;
-    border-radius: 5px;
-    overflow: hidden;
-	padding-left: 0.8em;
-    padding-right: 0.8em;
-    padding-top: 0.4em;
-    padding-bottom: 0.4em;
+  background-color: #fafafa;
+  border-radius: 5px;
+  overflow: hidden;
+  padding-left: 0.8em;
+  padding-right: 0.8em;
+  padding-top: 0.4em;
+  padding-bottom: 0.4em;
+  box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.05);
+  margin-bottom: 20px;
+  border: 1px solid #e3e3e3;
 }
 
 div.holowidgets {
-    padding-right: 0;
-	width: 25%;
+  padding-right: 0;
+  width: 25%;
 }
 
 div.holoslider {
-    min-height: 0 !important;
-    height: 0.8em;
-    width: 60%;
+  min-height: 0 !important;
+  height: 0.8em;
+  width: 100%;
 }
 
 div.holoformgroup {
-    padding-top: 0.5em;
-    margin-bottom: 0.5em;
+  padding-top: 0.5em;
+  margin-bottom: 0.5em;
 }
 
 div.hologroup {
-    padding-left: 0;
-    padding-right: 0.8em;
-    width: 50%;
+  padding-left: 0;
+  padding-right: 0.8em;
+  width: 100%;
 }
 
 .holoselect {
-    width: 92%;
-    margin-left: 0;
-    margin-right: 0;
+  width: 92%;
+  margin-left: 0;
+  margin-right: 0;
 }
 
 .holotext {
-    width: 100%;
-    padding-left:  0.5em;
-    padding-right: 0;
+  padding-left:  0.5em;
+  padding-right: 0;
+  width: 100%;
 }
 
 .holowidgets .ui-resizable-se {
-	visibility: hidden
+  visibility: hidden
 }
 
 .holoframe > .ui-resizable-se {
-	visibility: hidden
+  visibility: hidden
 }
 
 .holowidgets .ui-resizable-s {
-	visibility: hidden
+  visibility: hidden
+}
+
+
+/* CSS rules for noUISlider based slider used by JupyterLab extension  */
+
+.noUi-handle {
+  width: 20px !important;
+  height: 20px !important;
+  left: -5px !important;
+  top: -5px !important;
+}
+
+.noUi-handle:before, .noUi-handle:after {
+  visibility: hidden;
+  height: 0px;
+}
+
+.noUi-target {
+  margin-left: 0.5em;
+  margin-right: 0.5em;
 }
 </style>
 
@@ -12439,11 +13402,829 @@ mhrfO3fufECS5GHXnf8pAAAAHMfdURTdimGYPjExsTo0NHTyj2ynEplMxurs7HyHIAiKJMlSHMct
 U9k9N2vl5+cH0en0TRiGWX18fC65vnh+LxqNBq2oqFhgMpmi7XY7arVaj+zdu/fxn/l/4bSZl5fH
 5nK5CQAQMtXznCRJePpEbwOAZhzHX4ix/wHzzC/tu64gcwAAAABJRU5ErkJggg=='
        style='height:15px; border-radius:12px; display: inline-block; float: left'></img>
-
+  
 
 
 </div>
 
+</div>
+
+</div>
+
+<div class="output_area">
+
+    <div class="prompt"></div>
+
+
+
+
+
+<div id="c61551d5-15c8-47f5-b427-bfe366c2dcb1"></div>
+<div class="output_subarea output_javascript ">
+<script type="text/javascript">
+var element = $('#c61551d5-15c8-47f5-b427-bfe366c2dcb1');
+function HoloViewsWidget() {
+}
+
+HoloViewsWidget.prototype.init_slider = function(init_val){
+  if(this.load_json) {
+    this.from_json()
+  } else {
+    this.update_cache();
+  }
+}
+
+HoloViewsWidget.prototype.populate_cache = function(idx){
+  this.cache[idx].innerHTML = this.frames[idx];
+  if (this.embed) {
+    delete this.frames[idx];
+  }
+}
+
+HoloViewsWidget.prototype.process_error = function(msg){
+}
+
+HoloViewsWidget.prototype.from_json = function() {
+  var data_url = this.json_path + this.id + '.json';
+  $.getJSON(data_url, $.proxy(function(json_data) {
+    this.frames = json_data;
+    this.update_cache();
+    this.update(0);
+  }, this));
+}
+
+HoloViewsWidget.prototype.dynamic_update = function(current){
+  if (current === undefined) {
+    return
+  }
+  this.current = current;
+  if (this.comm) {
+    var msg = {comm_id: this.id+'_client', content: current}
+    this.comm.send(msg);
+  }
+}
+
+HoloViewsWidget.prototype.update_cache = function(force){
+  var frame_len = Object.keys(this.frames).length;
+  for (var i=0; i<frame_len; i++) {
+    if(!this.load_json || this.dynamic)  {
+      var frame = Object.keys(this.frames)[i];
+    } else {
+      var frame = i;
+    }
+    if(!(frame in this.cache) || force) {
+      if ((frame in this.cache) && force) { this.cache[frame].remove() }
+      var div = document.createElement("div");
+      var parent = document.getElementById("_anim_img"+this.id);
+      div.style.display = "none";
+      parent.appendChild(div)
+      this.cache[frame] = div;
+      var cache_id = "_anim_img"+this.id+"_"+frame;
+      this.populate_cache(frame);
+    }
+  }
+}
+
+HoloViewsWidget.prototype.update = function(current){
+  if(current in this.cache) {
+    for (var index in this.cache) {
+      this.cache[index].style.display = "none";
+    }
+    this.cache[current].style.display = "";
+    this.wait = false;
+  }
+}
+
+HoloViewsWidget.prototype.init_comms = function() {
+  var that = this
+  HoloViews.comm_manager.register_target(this.plot_id, this.id, function (msg) { that.msg_handler(msg) })
+  if (!this.cached || this.dynamic) {
+    function ack_callback(msg) {
+      var msg = msg.metadata;
+      var comm_id = msg.comm_id;
+      var comm_status = HoloViews.comm_status[comm_id];
+      if (that.queue.length > 0) {
+        that.time = Date.now();
+        that.dynamic_update(that.queue[that.queue.length-1]);
+        that.queue = [];
+      } else {
+        that.wait = false;
+      }
+      if ((msg.msg_type == "Ready") && msg.content) {
+        console.log("Python callback returned following output:", msg.content);
+      } else if (msg.msg_type == "Error") {
+        console.log("Python failed with the following traceback:", msg.traceback)
+      }
+    }
+    var comm = HoloViews.comm_manager.get_client_comm(this.plot_id, this.id+'_client', ack_callback);
+    return comm
+  }
+}
+
+HoloViewsWidget.prototype.msg_handler = function(msg) {
+  var metadata = msg.metadata;
+  if ((metadata.msg_type == "Ready")) {
+    if (metadata.content) {
+      console.log("Python callback returned following output:", metadata.content);
+    }
+	return;
+  } else if (metadata.msg_type == "Error") {
+    console.log("Python failed with the following traceback:", metadata.traceback)
+    return
+  }
+  this.process_msg(msg)
+}
+
+HoloViewsWidget.prototype.process_msg = function(msg) {
+}
+
+function SelectionWidget(frames, id, slider_ids, keyMap, dim_vals, notFound, load_json, mode, cached, json_path, dynamic, plot_id){
+  this.frames = frames;
+  this.id = id;
+  this.plot_id = plot_id;
+  this.slider_ids = slider_ids;
+  this.keyMap = keyMap
+  this.current_frame = 0;
+  this.current_vals = dim_vals;
+  this.load_json = load_json;
+  this.mode = mode;
+  this.notFound = notFound;
+  this.cached = cached;
+  this.dynamic = dynamic;
+  this.cache = {};
+  this.json_path = json_path;
+  this.init_slider(this.current_vals[0]);
+  this.queue = [];
+  this.wait = false;
+  if (!this.cached || this.dynamic) {
+    this.comm = this.init_comms();
+  }
+}
+
+SelectionWidget.prototype = new HoloViewsWidget;
+
+
+SelectionWidget.prototype.get_key = function(current_vals) {
+  var key = "(";
+  for (var i=0; i<this.slider_ids.length; i++)
+  {
+    var val = this.current_vals[i];
+    if (!(typeof val === 'string')) {
+      if (val % 1 === 0) { val = val.toFixed(1); }
+      else { val = val.toFixed(10); val = val.slice(0, val.length-1);}
+    }
+    key += "'" + val + "'";
+    if(i != this.slider_ids.length-1) { key += ', ';}
+    else if(this.slider_ids.length == 1) { key += ',';}
+  }
+  key += ")";
+  return this.keyMap[key];
+}
+
+SelectionWidget.prototype.set_frame = function(dim_val, dim_idx){
+  this.current_vals[dim_idx] = dim_val;
+  var key = this.current_vals;
+  if (!this.dynamic) {
+    key = this.get_key(key)
+  }
+  if (this.dynamic || !this.cached) {
+    if ((this.time !== undefined) && ((this.wait) && ((this.time + 10000) > Date.now()))) {
+      this.queue.push(key);
+      return
+    }
+    this.queue = [];
+    this.time = Date.now();
+    this.current_frame = key;
+    this.wait = true;
+    this.dynamic_update(key)
+  } else if (key !== undefined) {
+    this.update(key)
+  }
+}
+
+
+/* Define the ScrubberWidget class */
+function ScrubberWidget(frames, num_frames, id, interval, load_json, mode, cached, json_path, dynamic, plot_id){
+  this.slider_id = "_anim_slider" + id;
+  this.loop_select_id = "_anim_loop_select" + id;
+  this.id = id;
+  this.plot_id = plot_id;
+  this.interval = interval;
+  this.current_frame = 0;
+  this.direction = 0;
+  this.dynamic = dynamic;
+  this.timer = null;
+  this.load_json = load_json;
+  this.mode = mode;
+  this.cached = cached;
+  this.frames = frames;
+  this.cache = {};
+  this.length = num_frames;
+  this.json_path = json_path;
+  document.getElementById(this.slider_id).max = this.length - 1;
+  this.init_slider(0);
+  this.wait = false;
+  this.queue = [];
+  if (!this.cached || this.dynamic) {
+    this.comm = this.init_comms()
+  }
+}
+
+ScrubberWidget.prototype = new HoloViewsWidget;
+
+ScrubberWidget.prototype.set_frame = function(frame){
+  this.current_frame = frame;
+  var widget = document.getElementById(this.slider_id);
+  if (widget === null) {
+    this.pause_animation();
+    return
+  }
+  widget.value = this.current_frame;
+  if (this.dynamic || !this.cached) {
+    if ((this.time !== undefined) && ((this.wait) && ((this.time + 10000) > Date.now()))) {
+      this.queue.push(frame);
+      return
+    }
+    this.queue = [];
+    this.time = Date.now();
+    this.wait = true;
+    this.dynamic_update(frame)
+  } else {
+    this.update(frame)
+  }
+}
+
+ScrubberWidget.prototype.get_loop_state = function(){
+  var button_group = document[this.loop_select_id].state;
+  for (var i = 0; i < button_group.length; i++) {
+    var button = button_group[i];
+    if (button.checked) {
+      return button.value;
+    }
+  }
+  return undefined;
+}
+
+
+ScrubberWidget.prototype.next_frame = function() {
+  this.set_frame(Math.min(this.length - 1, this.current_frame + 1));
+}
+
+ScrubberWidget.prototype.previous_frame = function() {
+  this.set_frame(Math.max(0, this.current_frame - 1));
+}
+
+ScrubberWidget.prototype.first_frame = function() {
+  this.set_frame(0);
+}
+
+ScrubberWidget.prototype.last_frame = function() {
+  this.set_frame(this.length - 1);
+}
+
+ScrubberWidget.prototype.slower = function() {
+  this.interval /= 0.7;
+  if(this.direction > 0){this.play_animation();}
+  else if(this.direction < 0){this.reverse_animation();}
+}
+
+ScrubberWidget.prototype.faster = function() {
+  this.interval *= 0.7;
+  if(this.direction > 0){this.play_animation();}
+  else if(this.direction < 0){this.reverse_animation();}
+}
+
+ScrubberWidget.prototype.anim_step_forward = function() {
+  if(this.current_frame < this.length - 1){
+    this.next_frame();
+  }else{
+    var loop_state = this.get_loop_state();
+    if(loop_state == "loop"){
+      this.first_frame();
+    }else if(loop_state == "reflect"){
+      this.last_frame();
+      this.reverse_animation();
+    }else{
+      this.pause_animation();
+      this.last_frame();
+    }
+  }
+}
+
+ScrubberWidget.prototype.anim_step_reverse = function() {
+  if(this.current_frame > 0){
+    this.previous_frame();
+  } else {
+    var loop_state = this.get_loop_state();
+    if(loop_state == "loop"){
+      this.last_frame();
+    }else if(loop_state == "reflect"){
+      this.first_frame();
+      this.play_animation();
+    }else{
+      this.pause_animation();
+      this.first_frame();
+    }
+  }
+}
+
+ScrubberWidget.prototype.pause_animation = function() {
+  this.direction = 0;
+  if (this.timer){
+    clearInterval(this.timer);
+    this.timer = null;
+  }
+}
+
+ScrubberWidget.prototype.play_animation = function() {
+  this.pause_animation();
+  this.direction = 1;
+  var t = this;
+  if (!this.timer) this.timer = setInterval(function(){t.anim_step_forward();}, this.interval);
+}
+
+ScrubberWidget.prototype.reverse_animation = function() {
+  this.pause_animation();
+  this.direction = -1;
+  var t = this;
+  if (!this.timer) this.timer = setInterval(function(){t.anim_step_reverse();}, this.interval);
+}
+
+function extend(destination, source) {
+  for (var k in source) {
+    if (source.hasOwnProperty(k)) {
+      destination[k] = source[k];
+    }
+  }
+  return destination;
+}
+
+function update_widget(widget, values) {
+  if (widget.hasClass("ui-slider")) {
+    widget.slider('option', {
+      min: 0,
+      max: values.length-1,
+      dim_vals: values,
+      value: 0,
+      dim_labels: values
+    })
+    widget.slider('option', 'slide').call(widget, event, {value: 0})
+  } else {
+    widget.empty();
+    for (var i=0; i<values.length; i++){
+      widget.append($("<option>", {
+        value: i,
+        text: values[i]
+      }))
+    };
+    widget.data('values', values);
+    widget.data('value', 0);
+    widget.trigger("change");
+  };
+}
+
+function init_slider(id, plot_id, dim, values, next_vals, labels, dynamic, step, value, next_dim,
+                     dim_idx, delay, jQueryUI_CDN, UNDERSCORE_CDN) {
+  // Slider JS Block START
+  function loadcssfile(filename){
+    var fileref=document.createElement("link")
+    fileref.setAttribute("rel", "stylesheet")
+    fileref.setAttribute("type", "text/css")
+    fileref.setAttribute("href", filename)
+    document.getElementsByTagName("head")[0].appendChild(fileref)
+  }
+  loadcssfile("https://code.jquery.com/ui/1.10.4/themes/smoothness/jquery-ui.css");
+  /* Check if jQuery and jQueryUI have been loaded
+     otherwise load with require.js */
+  var jQuery = window.jQuery,
+    // check for old versions of jQuery
+    oldjQuery = jQuery && !!jQuery.fn.jquery.match(/^1\.[0-4](\.|$)/),
+    jquery_path = '',
+    paths = {},
+    noConflict;
+  var jQueryUI = jQuery.ui;
+  // check for jQuery
+  if (!jQuery || oldjQuery) {
+    // load if it's not available or doesn't meet min standards
+    paths.jQuery = jQuery;
+    noConflict = !!oldjQuery;
+  } else {
+    // register the current jQuery
+    define('jquery', [], function() { return jQuery; });
+  }
+  if (!jQueryUI) {
+    paths.jQueryUI = jQueryUI_CDN.slice(null, -3);
+  } else {
+    define('jQueryUI', [], function() { return jQuery.ui; });
+  }
+  paths.underscore = UNDERSCORE_CDN.slice(null, -3);
+  var jquery_require = {
+    paths: paths,
+    shim: {
+      "jQueryUI": {
+        exports:"$",
+        deps: ['jquery']
+      },
+      "underscore": {
+        exports: '_'
+      }
+    }
+  }
+  require.config(jquery_require);
+  require(["jQueryUI", "underscore"], function(jUI, _){
+    if (noConflict) $.noConflict(true);
+    var vals = values;
+    if (dynamic && vals.constructor === Array) {
+      var default_value = parseFloat(value);
+      var min = parseFloat(vals[0]);
+      var max = parseFloat(vals[vals.length-1]);
+      var wstep = step;
+      var wlabels = [default_value];
+      var init_label = default_value;
+    } else {
+      var min = 0;
+      if (dynamic) {
+        var max = Object.keys(vals).length - 1;
+        var init_label = labels[value];
+        var default_value = values[value];
+      } else {
+        var max = vals.length - 1;
+        var init_label = labels[value];
+        var default_value = value;
+      }
+      var wstep = 1;
+      var wlabels = labels;
+    }
+    function adjustFontSize(text) {
+      var width_ratio = (text.parent().width()/8)/text.val().length;
+      var size = Math.min(0.9, Math.max(0.6, width_ratio))+'em';
+      text.css('font-size', size);
+    }
+    var slider = $('#_anim_widget'+id+'_'+dim);
+    slider.slider({
+      animate: "fast",
+      min: min,
+      max: max,
+      step: wstep,
+      value: default_value,
+      dim_vals: vals,
+      dim_labels: wlabels,
+      next_vals: next_vals,
+      slide: function(event, ui) {
+        var vals = slider.slider("option", "dim_vals");
+        var next_vals = slider.slider("option", "next_vals");
+        var dlabels = slider.slider("option", "dim_labels");
+        if (dynamic) {
+          var dim_val = ui.value;
+          if (vals.constructor === Array) {
+            var label = ui.value;
+          } else {
+            var label = dlabels[ui.value];
+          }
+        } else {
+          var dim_val = vals[ui.value];
+          var label = dlabels[ui.value];
+        }
+        var text = $('#textInput'+id+'_'+dim);
+        text.val(label);
+        adjustFontSize(text);
+        HoloViews.index[plot_id].set_frame(dim_val, dim_idx);
+        if (Object.keys(next_vals).length > 0) {
+          var new_vals = next_vals[dim_val];
+          var next_widget = $('#_anim_widget'+id+'_'+next_dim);
+          update_widget(next_widget, new_vals);
+        }
+      }
+    });
+    slider.keypress(function(event) {
+      if (event.which == 80 || event.which == 112) {
+        var start = slider.slider("option", "value");
+        var stop =  slider.slider("option", "max");
+        for (var i=start; i<=stop; i++) {
+          var delay = i*delay;
+          $.proxy(function doSetTimeout(i) { setTimeout($.proxy(function() {
+            var val = {value:i};
+            slider.slider('value',i);
+            slider.slider("option", "slide")(null, val);
+          }, slider), delay);}, slider)(i);
+        }
+      }
+      if (event.which == 82 || event.which == 114) {
+        var start = slider.slider("option", "value");
+        var stop =  slider.slider("option", "min");
+        var count = 0;
+        for (var i=start; i>=stop; i--) {
+          var delay = count*delay;
+          count = count + 1;
+          $.proxy(function doSetTimeout(i) { setTimeout($.proxy(function() {
+            var val = {value:i};
+            slider.slider('value',i);
+            slider.slider("option", "slide")(null, val);
+          }, slider), delay);}, slider)(i);
+        }
+      }
+    });
+    var textInput = $('#textInput'+id+'_'+dim)
+    textInput.val(init_label);
+    adjustFontSize(textInput);
+  });
+}
+
+function init_dropdown(id, plot_id, dim, vals, value, next_vals, labels, next_dim, dim_idx, dynamic) {
+  var widget = $("#_anim_widget"+id+'_'+dim);
+  widget.data('values', vals)
+  for (var i=0; i<vals.length; i++){
+    if (dynamic) {
+      var val = vals[i];
+    } else {
+      var val = i;
+    }
+    widget.append($("<option>", {
+      value: val,
+      text: labels[i]
+    }));
+  };
+  widget.data("next_vals", next_vals);
+  widget.val(value);
+  widget.on('change', function(event, ui) {
+    if (dynamic) {
+      var dim_val = parseInt(this.value);
+    } else {
+      var dim_val = $.data(this, 'values')[this.value];
+    }
+    var next_vals = $.data(this, "next_vals");
+    if (Object.keys(next_vals).length > 0) {
+      var new_vals = next_vals[dim_val];
+      var next_widget = $('#_anim_widget'+id+'_'+next_dim);
+      update_widget(next_widget, new_vals);
+    }
+    var widgets = HoloViews.index[plot_id]
+    if (widgets) {
+      widgets.set_frame(dim_val, dim_idx);
+    }
+  });
+}
+
+
+if (window.HoloViews === undefined) {
+  window.HoloViews = {}
+  window.PyViz = window.HoloViews
+} else if (window.PyViz === undefined) {
+  window.PyViz = window.HoloViews
+}
+
+
+var _namespace = {
+  init_slider: init_slider,
+  init_dropdown: init_dropdown,
+  comms: {},
+  comm_status: {},
+  index: {},
+  plot_index: {},
+  kernels: {},
+  receivers: {}
+}
+
+for (var k in _namespace) {
+  if (!(k in window.HoloViews)) {
+    window.HoloViews[k] = _namespace[k];
+  }
+}
+
+// Define MPL specific subclasses
+function MPLSelectionWidget() {
+  SelectionWidget.apply(this, arguments);
+}
+
+function MPLScrubberWidget() {
+  ScrubberWidget.apply(this, arguments);
+}
+
+// Let them inherit from the baseclasses
+MPLSelectionWidget.prototype = Object.create(SelectionWidget.prototype);
+MPLScrubberWidget.prototype = Object.create(ScrubberWidget.prototype);
+
+// Define methods to override on widgets
+var MPLMethods = {
+  init_slider : function(init_val){
+    if(this.load_json) {
+      this.from_json()
+    } else {
+      this.update_cache();
+    }
+    if (this.dynamic | !this.cached | (this.current_vals === undefined)) {
+      this.update(0)
+    } else {
+      this.set_frame(this.current_vals[0], 0)
+    }
+  },
+  process_msg : function(msg) {
+    var data = msg.content.data;
+    this.frames[this.current] = data;
+    this.update_cache(true);
+    this.update(this.current);
+  }
+}
+// Extend MPL widgets with backend specific methods
+extend(MPLSelectionWidget.prototype, MPLMethods);
+extend(MPLScrubberWidget.prototype, MPLMethods);
+
+window.HoloViews.MPLSelectionWidget = MPLSelectionWidget
+window.HoloViews.MPLScrubberWidget = MPLScrubberWidget
+
+    function JupyterCommManager() {
+    }
+
+    JupyterCommManager.prototype.register_target = function(plot_id, comm_id, msg_handler) {
+      if (window.comm_manager || ((window.Jupyter !== undefined) && (Jupyter.notebook.kernel != null))) {
+        var comm_manager = window.comm_manager || Jupyter.notebook.kernel.comm_manager;
+        comm_manager.register_target(comm_id, function(comm) {
+          comm.on_msg(msg_handler);
+        });
+      } else if ((plot_id in window.PyViz.kernels) && (window.PyViz.kernels[plot_id])) {
+        window.PyViz.kernels[plot_id].registerCommTarget(comm_id, function(comm) {
+          comm.onMsg = msg_handler;
+        });
+      }
+    }
+
+    JupyterCommManager.prototype.get_client_comm = function(plot_id, comm_id, msg_handler) {
+      if (comm_id in window.PyViz.comms) {
+        return window.PyViz.comms[comm_id];
+      } else if (window.comm_manager || ((window.Jupyter !== undefined) && (Jupyter.notebook.kernel != null))) {
+        var comm_manager = window.comm_manager || Jupyter.notebook.kernel.comm_manager;
+        var comm = comm_manager.new_comm(comm_id, {}, {}, {}, comm_id);
+        if (msg_handler) {
+          comm.on_msg(msg_handler);
+        }
+      } else if ((plot_id in window.PyViz.kernels) && (window.PyViz.kernels[plot_id])) {
+        var comm = window.PyViz.kernels[plot_id].connectToComm(comm_id);
+        comm.open();
+        if (msg_handler) {
+          comm.onMsg = msg_handler;
+        }
+      }
+
+      window.PyViz.comms[comm_id] = comm;
+      return comm;
+    }
+
+    window.PyViz.comm_manager = new JupyterCommManager();
+    
+
+var JS_MIME_TYPE = 'application/javascript';
+var HTML_MIME_TYPE = 'text/html';
+var EXEC_MIME_TYPE = 'application/vnd.holoviews_exec.v0+json';
+var CLASS_NAME = 'output';
+
+/**
+ * Render data to the DOM node
+ */
+function render(props, node) {
+  var div = document.createElement("div");
+  var script = document.createElement("script");
+  node.appendChild(div);
+  node.appendChild(script);
+}
+
+/**
+ * Handle when a new output is added
+ */
+function handle_add_output(event, handle) {
+  var output_area = handle.output_area;
+  var output = handle.output;
+  if ((output.data == undefined) || (!output.data.hasOwnProperty(EXEC_MIME_TYPE))) {
+    return
+  }
+  var id = output.metadata[EXEC_MIME_TYPE]["id"];
+  var toinsert = output_area.element.find("." + CLASS_NAME.split(' ')[0]);
+  if (id !== undefined) {
+    var nchildren = toinsert.length;
+    var html_node = toinsert[nchildren-1].children[0];
+    html_node.innerHTML = output.data[HTML_MIME_TYPE];
+    var scripts = [];
+    var nodelist = html_node.querySelectorAll("script");
+    for (var i in nodelist) {
+      if (nodelist.hasOwnProperty(i)) {
+        scripts.push(nodelist[i])
+      }
+    }
+
+    scripts.forEach( function (oldScript) {
+      var newScript = document.createElement("script");
+      var attrs = [];
+      var nodemap = oldScript.attributes;
+      for (var j in nodemap) {
+        if (nodemap.hasOwnProperty(j)) {
+          attrs.push(nodemap[j])
+        }
+      }
+      attrs.forEach(function(attr) { newScript.setAttribute(attr.name, attr.value) });
+      newScript.appendChild(document.createTextNode(oldScript.innerHTML));
+      oldScript.parentNode.replaceChild(newScript, oldScript);
+    });
+    if (JS_MIME_TYPE in output.data) {
+      toinsert[nchildren-1].children[1].textContent = output.data[JS_MIME_TYPE];
+    }
+    output_area._hv_plot_id = id;
+    if ((window.Bokeh !== undefined) && (id in Bokeh.index)) {
+      window.PyViz.plot_index[id] = Bokeh.index[id];
+    } else {
+      window.PyViz.plot_index[id] = null;
+    }
+  } else if (output.metadata[EXEC_MIME_TYPE]["server_id"] !== undefined) {
+    var bk_div = document.createElement("div");
+    bk_div.innerHTML = output.data[HTML_MIME_TYPE];
+    var script_attrs = bk_div.children[0].attributes;
+    for (var i = 0; i < script_attrs.length; i++) {
+      toinsert[toinsert.length - 1].childNodes[1].setAttribute(script_attrs[i].name, script_attrs[i].value);
+    }
+    // store reference to server id on output_area
+    output_area._bokeh_server_id = output.metadata[EXEC_MIME_TYPE]["server_id"];
+  }
+}
+
+/**
+ * Handle when an output is cleared or removed
+ */
+function handle_clear_output(event, handle) {
+  var id = handle.cell.output_area._hv_plot_id;
+  var server_id = handle.cell.output_area._bokeh_server_id;
+  if (((id === undefined) || !(id in PyViz.plot_index)) && (server_id !== undefined)) { return; }
+  var comm = window.PyViz.comm_manager.get_client_comm("hv-extension-comm", "hv-extension-comm", function () {});
+  if (server_id !== null) {
+    comm.send({event_type: 'server_delete', 'id': server_id});
+    return;
+  } else if (comm !== null) {
+    comm.send({event_type: 'delete', 'id': id});
+  }
+  delete PyViz.plot_index[id];
+  if ((window.Bokeh !== undefined) & (id in window.Bokeh.index)) {
+    var doc = window.Bokeh.index[id].model.document
+    doc.clear();
+    const i = window.Bokeh.documents.indexOf(doc);
+    if (i > -1) {
+      window.Bokeh.documents.splice(i, 1);
+    }
+  }
+}
+
+/**
+ * Handle kernel restart event
+ */
+function handle_kernel_cleanup(event, handle) {
+  delete PyViz.comms["hv-extension-comm"];
+  window.PyViz.plot_index = {}
+}
+
+/**
+ * Handle update_display_data messages
+ */
+function handle_update_output(event, handle) {
+  handle_clear_output(event, {cell: {output_area: handle.output_area}})
+  handle_add_output(event, handle)
+}
+
+function register_renderer(events, OutputArea) {
+  function append_mime(data, metadata, element) {
+    // create a DOM node to render to
+    var toinsert = this.create_output_subarea(
+    metadata,
+    CLASS_NAME,
+    EXEC_MIME_TYPE
+    );
+    this.keyboard_manager.register_events(toinsert);
+    // Render to node
+    var props = {data: data, metadata: metadata[EXEC_MIME_TYPE]};
+    render(props, toinsert[0]);
+    element.append(toinsert);
+    return toinsert
+  }
+
+  events.on('output_added.OutputArea', handle_add_output);
+  events.on('output_updated.OutputArea', handle_update_output);
+  events.on('clear_output.CodeCell', handle_clear_output);
+  events.on('delete.Cell', handle_clear_output);
+  events.on('kernel_ready.Kernel', handle_kernel_cleanup);
+
+  OutputArea.prototype.register_mime_type(EXEC_MIME_TYPE, append_mime, {
+    safe: true,
+    index: 0
+  });
+}
+
+if (window.Jupyter !== undefined) {
+  try {
+    var events = require('base/js/events');
+    var OutputArea = require('notebook/js/outputarea').OutputArea;
+    if (OutputArea.prototype.mime_types().indexOf(EXEC_MIME_TYPE) == -1) {
+      register_renderer(events, OutputArea);
+    }
+  } catch(err) {
+  }
+}
+
+</script>
 </div>
 
 </div>
@@ -12453,8 +14234,7 @@ U9k9N2vl5+cH0en0TRiGWX18fC65vnh+LxqNBq2oqFhgMpmi7XY7arVaj+zdu/fxn/l/4bSZl5fH
 
 </div>
 <div class="cell border-box-sizing text_cell rendered"><div class="prompt input_prompt">
-</div>
-<div class="inner_cell">
+</div><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
 <h3 id="Defining-an-experiment">Defining an experiment<a class="anchor-link" href="#Defining-an-experiment">&#182;</a></h3><p>Define your inputs. All that's necessary to define are the image data and ROIs.</p>
 <p>Images can be defined as a folder with tiff stacks:</p>
@@ -12480,24 +14260,23 @@ rois = ['rois1.zip', 'rois2.zip',...] # for a roiset for each image</code></pre>
 <div class="prompt input_prompt">In&nbsp;[3]:</div>
 <div class="inner_cell">
     <div class="input_area">
-<div class=" highlight hl-ipython2"><pre><span></span><span class="c1"># roi and data locations</span>
+<div class=" highlight hl-ipython3"><pre><span></span><span class="c1"># roi and data locations</span>
 <span class="n">rois_location</span> <span class="o">=</span> <span class="s1">&#39;exampleData/20150429.zip&#39;</span>
 <span class="n">images_location</span> <span class="o">=</span> <span class="s1">&#39;exampleData/20150529&#39;</span>
 
 <span class="c1"># Folder where data will be stored. Make sure to use a different folder for each experiment.</span>
-<span class="n">output_folder</span> <span class="o">=</span> <span class="s1">&#39;fissa_example&#39;</span>
+<span class="n">output_folder</span> <span class="o">=</span> <span class="s1">&#39;fissa_example&#39;</span> 
 
 <span class="n">experiment</span> <span class="o">=</span> <span class="n">fissa</span><span class="o">.</span><span class="n">Experiment</span><span class="p">(</span><span class="n">images_location</span><span class="p">,</span> <span class="n">rois_location</span><span class="p">,</span> <span class="n">output_folder</span><span class="p">)</span>
 </pre></div>
 
-</div>
+    </div>
 </div>
 </div>
 
 </div>
 <div class="cell border-box-sizing text_cell rendered"><div class="prompt input_prompt">
-</div>
-<div class="inner_cell">
+</div><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
 <p>Previously analyzed experiments in output_folder will be loaded, if they exist, and the next step could be skipped.</p>
 
@@ -12505,8 +14284,7 @@ rois = ['rois1.zip', 'rois2.zip',...] # for a roiset for each image</code></pre>
 </div>
 </div>
 <div class="cell border-box-sizing text_cell rendered"><div class="prompt input_prompt">
-</div>
-<div class="inner_cell">
+</div><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
 <h3 id="Extracting-traces-and-separating-them">Extracting traces and separating them<a class="anchor-link" href="#Extracting-traces-and-separating-them">&#182;</a></h3><p>Next, we need to extract the traces and separate them:</p>
 
@@ -12518,10 +14296,10 @@ rois = ['rois1.zip', 'rois2.zip',...] # for a roiset for each image</code></pre>
 <div class="prompt input_prompt">In&nbsp;[4]:</div>
 <div class="inner_cell">
     <div class="input_area">
-<div class=" highlight hl-ipython2"><pre><span></span><span class="n">experiment</span><span class="o">.</span><span class="n">separate</span><span class="p">()</span>
+<div class=" highlight hl-ipython3"><pre><span></span><span class="n">experiment</span><span class="o">.</span><span class="n">separate</span><span class="p">()</span>
 </pre></div>
 
-</div>
+    </div>
 </div>
 </div>
 
@@ -12531,20 +14309,20 @@ rois = ['rois1.zip', 'rois2.zip',...] # for a roiset for each image</code></pre>
 
 <div class="output_area">
 
-<div class="prompt"></div>
+    <div class="prompt"></div>
 
 
 <div class="output_subarea output_stream output_stdout output_text">
 <pre>Doing region growing and data extraction....
 Doing signal separation....
-NMF converged after 618 iterations.
-Finished ROI number 0
-NMF converged after 575 iterations.
+NMF converged after 1071 iterations.
 Finished ROI number 1
-NMF converged after 636 iterations.
-Finished ROI number 2
-NMF converged after 610 iterations.
+NMF converged after 1184 iterations.
 Finished ROI number 3
+NMF converged after 1201 iterations.
+Finished ROI number 0
+NMF converged after 1229 iterations.
+Finished ROI number 2
 </pre>
 </div>
 </div>
@@ -12554,8 +14332,7 @@ Finished ROI number 3
 
 </div>
 <div class="cell border-box-sizing text_cell rendered"><div class="prompt input_prompt">
-</div>
-<div class="inner_cell">
+</div><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
 <p>If you want to redo preparation and/or separation you can set:</p>
 
@@ -12566,8 +14343,7 @@ Finished ROI number 3
 </div>
 </div>
 <div class="cell border-box-sizing text_cell rendered"><div class="prompt input_prompt">
-</div>
-<div class="inner_cell">
+</div><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
 <h2 id="Accessing-results">Accessing results<a class="anchor-link" href="#Accessing-results">&#182;</a></h2><p>After running <code>experiment.separate()</code> the results are stored as follows.</p>
 <h4 id="ROI-outlines">ROI outlines<a class="anchor-link" href="#ROI-outlines">&#182;</a></h4><p>The ROI outlines, as well as the extra neuropil regions, can be found as in <code>experiment.roi_polys</code> as follows. For cell number <code>c</code> and tiff number <code>t</code>, the set of ROIs for that cell and tiff is at</p>
@@ -12587,14 +14363,14 @@ experiment.roi_polys[c][t][n][0] # n = 1, 2, 3.... the neuropil regions</code></
 <div class="prompt input_prompt">In&nbsp;[5]:</div>
 <div class="inner_cell">
     <div class="input_area">
-<div class=" highlight hl-ipython2"><pre><span></span><span class="n">c</span> <span class="o">=</span> <span class="mi">0</span>
+<div class=" highlight hl-ipython3"><pre><span></span><span class="n">c</span> <span class="o">=</span> <span class="mi">0</span>
 <span class="n">t</span> <span class="o">=</span> <span class="mi">0</span>
 <span class="n">cell</span> <span class="o">=</span> <span class="n">hv</span><span class="o">.</span><span class="n">Curve</span><span class="p">(</span><span class="n">experiment</span><span class="o">.</span><span class="n">roi_polys</span><span class="p">[</span><span class="n">c</span><span class="p">][</span><span class="n">t</span><span class="p">][</span><span class="mi">0</span><span class="p">][</span><span class="mi">0</span><span class="p">])</span>
 <span class="n">neuropil1</span> <span class="o">=</span> <span class="n">hv</span><span class="o">.</span><span class="n">Curve</span><span class="p">(</span><span class="n">experiment</span><span class="o">.</span><span class="n">roi_polys</span><span class="p">[</span><span class="n">c</span><span class="p">][</span><span class="n">t</span><span class="p">][</span><span class="mi">1</span><span class="p">][</span><span class="mi">0</span><span class="p">])</span>
 <span class="n">cell</span><span class="o">*</span><span class="n">neuropil1</span>
 </pre></div>
 
-</div>
+    </div>
 </div>
 </div>
 
@@ -12604,12 +14380,12 @@ experiment.roi_polys[c][t][n][0] # n = 1, 2, 3.... the neuropil regions</code></
 
 <div class="output_area">
 
-<div class="prompt output_prompt">Out[5]:</div>
+    <div class="prompt output_prompt">Out[5]:</div>
 
 
 
 <div class="output_html rendered_html output_subarea output_execute_result">
-<img src='data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAP0AAAD6CAYAAABqMEFEAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDIuMS4wLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvpW3flQAAIABJREFUeJzt3XtcVHX+x/HXmeHmBeR+EVRUTBFFFMRK11KXtszLdlmky/7wkmzWtqa2aummlqnldjFtTTe33DLNblrqUiZ205QwsdLKS95ARARRQG4z8/39McVv+4kJypkzw3ye/yTHOXM+jyPvzpnv+c7nqymlFEIIt2EyugAhhGNJ6IVwMxJ6IdyMhF4INyOhF8LNSOiFcDMSeiHcjIReCDcjoRfCzXgYXUBD3HjjjWRmZhpdhluzKcXr35Xy/O5iam2XP4mzZ7APc/uH0d7PqwmrE43hEqE/ffq00SW4tVPnLfxt20myT1YCcFsXP27p0gatEe9RWGHhyS+L+OZ0FWkbj/FQUgi3xPihaY15F9EUNFeYe5+UlEROTo7RZbilzUfLmLvjFOdqbPh7m5l1TSjXt2t9We91rtrKvOxTfHCkHIBB7Vrxt6vDCPAxN2XJ4hIk9G6g2mrjwJkabI34p1bA2/vP8v6PZQD0b9uS2deGEdziym4OlVL853AZ87OLKK+1EdzCzENJIUS0apqbTpOmEePvhY+HDFddjIS+mdt9qpKZn5/kRIXlsvb3NmtMTgzmD1e1adJb8RPltczcdpLdp6qa7D1/1raVB3MHhNM7tEWTv3dzIKFvpmptiuV7ivnX3jPYlD0IQY28Sgf5mHmgTzCd2ugz6Ga1KVZ9X8qWY+U01W9hSZWF/HILJg3GxAXwp15BeJpk3OC/SeiboaPnanjk85PsK65GA8b0CODe+CA8zc3/l7/Wqlj2dTH/+vYMCuge5M0T/cOJ1ul/XK5IQt+MKKV458A5/p5TRJVVEd7Kg7n9w0kMc7/b3K8KK5m57SQFFRZ8zBpTkkK4rYs8LQAJvcv56GgZn+RV1Hs7XFBh4atT9sdqN3f0ZVpyCL5e7jsyXlZj5cnsIjYetg9GDoxsxaxrQgm8wsFIVyehdxFlNVYWZBex6adf4Ivx9TLxSHIoN3b0dVBlzi/zcBnzsk9RVmMj0MfM7GvC+E1UK6PLMoyE3gXs+ulW9eRPt6r39AwkrJ5HXCagb3hLQlq695WsPicrapm1vbBugtHtV7VhcmIwLdzw0Z6E3onVWhVL9xTzyl77oFRckDdPDAing0xhvSw2pXjtu1KW/DSVONrPkycGhNM9yMfo0hxKQu+kDp+tYcbnJ/mupBqTBmN7BJIRHyiPn5rADyXVPPL5SX48W4OHBvf2CiK1a/3Tir3Npmb31ENC72SUUqzdf5Znd52m2qqIbG0fgU+QiSZNqspiY/HuYl7/vvRXX9fSQ+MvfYJJbeLJSUaS0DuR05UWZm8vZNuJ8wAM7+TL1L4htHbjEXi9bT9RwcIviyiqtF7wd0opzlvs8WiqacjOQPfQW61WkpKSiIyMZMOGDRw+fJi0tDSKi4tJTEzk1Vdfxcvr1z+jukPovyuu4r4tJyittuLnZWLm1aGkdJAReKP9/y8cPXpNKIMu8wtHzkL3octFixYRGxtb9/O0adOYNGkSBw8eJCAggBUrVuhdgkvIOlZOabWVnsE+rB3WXgLvJFI6+PLm8A70C29BabWVyR8X8PgXhZyvtRld2mXTNfR5eXls3LiRe+65B7DfLmVlZXH77bcDkJ6ezrp16/QswWX8fLs1MKoVYa08Da1F/FJoSw/+8dtIpiQG42nSeOfgOdI2HuPb003/ZSFH0DX0Dz74IE899RQmk/0wxcXF+Pv74+Fh/1wUFRVFfn6+niUI0SRMmsbd3QNYNbQdXfy9OF5Wy+jM4yz/uhjLFXQSMoJuod+wYQOhoaEkJiZe1v7Lly8nKSmJpKQkioqKmrg6IS5PlwBvXh3ajrti/bEqWLqnhHEf5pFXVmt0aQ2mW+i3bdvGe++9R3R0NGlpaWRlZTFx4kRKS0uxWOzf7c7LyyMyMrLe/TMyMsjJySEnJ4eQkBC9ynQKpystdTPFmsdDoebN22zioaQQlv42kpAWZr4uqmLUhqO8d+gcLvAwTL/Qz58/n7y8PI4cOcKaNWsYPHgwq1atYtCgQbz11lsArFy5kpEjR+pVgkvYerycP7x/jG9OV9HGy0T/yJZGlyQa6OqIlrw5vAO/bd+a8xbFrO2FTP30JKXVFz7+cyYOn3j85JNP8swzzxATE0NxcTHjxo1zdAlO4Xytjce/KGTyxwWUVlu5OqIla4d3oFuge00JdXVtvM08NTCcOdeG0dJD46Nj5aS+f5QdBeeNLu2iZHKOAb4pqmLGtpMcL6vFy6QxsU8Qad38MTWTGV/uKq/M3gJsT5F9VP+uWH8e6B2Et9m5vtTjXNW4gZV7zzDmg+McL6ulS4AXq4a2487YAAl8MxDl68lLN0RxX68gzBqs+q6UuzcdJ9/JBvkk9A5ksSkWfXUaq4I/dvfntZvaERPgbXRZogl5mDTGxwfyyo3taOfrycHSGt49eNbosn5BQu9AStkn4XiYYHJiCF5Odtsnmk6PYB9uifEDwOpkH6Dlt04INyOhF8LNSOgdaG+xa87VFs2L63852AVYbIqXvinhpW9KAOgdIg0xhHEk9Do7dq6GmdsK+eZ0FRqQ3j2A+xICjS5LuDEJvU6UUqw7eI6FOUVUWhRhLT14vH8YfcNlmq0wloReB2U1VmZvLyTreAUAN3RozYx+ofh5S9srYTwJvQ5Wf19K1vEKWnuaeDg5hJs6+jabporC9UnodVD1UzPF9LgAhnbyM7gaIX5JHtnpSK7twhlJ6IVwM7qFvqqqiuTkZHr16kVcXByzZs0CYPTo0XTs2JGEhAQSEhLIzc3VqwRDKKUoqrQYXYZwIkXnLU7VUUe3z/Te3t5kZWXRunVramtrGTBgADfddBMACxcurOuI25yUVFl47ItTfJJnH7Vv5ytdbd1Z1E///hsPl1FWa7Mvk+1j/DCabld6TdNo3dq+KEBtbS21tbXNegT78/wKUt8/xid59lH7eQPCuCFaete7s5QOvswbEE5rTxOf5tl/Pz7LrzC6LH0/01utVhISEggNDSUlJYV+/foBMGPGDOLj45k0aRLV1dX17usq3XArLTYWZJ/igawTFFdZSQxrwRvD2nNTRxm1F3BTR1/WDm9PUlgLiqus/CXrBPN3nqLSYtxiGQ5pl1VaWsott9zC4sWLCQoKIjw8nJqaGjIyMujcuTOPPvror+7vrO2yvi+p4pHPCzl8tgYPE9zXK4j/6R6AWVaWFf+P1fbTMtm5p7HYINrPk3kDwok1YJlsh4ze+/v7M2jQIDIzM4mIiEDTNLy9vRkzZgzZ2dmOKKHJWW2K8R/mc/hsDR3bePHqTe0Y0yNQAi/qZTZppMcF8NpN7enYxosj52rJ2JxvyEIZuoW+qKiI0lL7MsCVlZVs3ryZbt26UVBQAPw0N33dOnr06KFXCbqyKEV5rQ0PE6wa2k662IoG6RrozetD2+Fp0iivtVFrQOh1G0osKCggPT0dq9WKzWYjNTWVYcOGMXjwYIqKilBKkZCQwIsvvqhXCQ5hQqOFh0x3EA3n42HCrIFR7TJ1C318fDy7d+++YHtWVpZehxRCNIBcooRwMxJ6IdyMhF4INyOhF8LNSOiFcDMSeiHcjIReCDcjoRfCzUjohXAzEnoh3IyEXgg3I6EXws1I6IVwMxJ6IdyMw1tgHz58mH79+hETE8OoUaOoqanRqwQhRD10C/3PLbD37NlDbm4umZmZ7Nixg2nTpjFp0iQOHjxIQEAAK1as0KsEIUQ9HN4COysrq67nfXp6OuvWrdOrBCFEPRzaArtz5874+/vj4WFv2BMVFUV+fn69+7pKC2whXI2uoTebzeTm5pKXl0d2djbff/99g/fNyMggJyeHnJwcQkJCdKxSCPfi0BbYX3zxBaWlpVgs9rXe8vLyiIyMdEQJQoifOLQFdmxsLIMGDeKtt94CYOXKlYwcOVKvEoQQ9XB4C+zu3buTlpbGzJkz6d27N+PGjdOrBCFEPRzeArtTp04uu6qNEM2BzMgTws1I6IVwMxJ6IdyMhF4INyOhF8LNSOiFMNCGH8+hlGOXq5bQC2GAkTF+AMzbWcSkjwsoqbI47NgSeiEMMD05lHkDwmjtaeKTvApS3z/GZ/kVDjm2hF4Ig9zU0Y83hrWnT2gLiqus/CXrBAuyT1Fpsel6XAm9EAZq29qT5SmRTOwThIcJ3vjhLNeuPsTzX53W7ZgSeiEMZjZpjI4L5NWb2tVte3nvGd2OJ6EXwkl0C/Th3l6BAIzo7KvbcST0QjgRH7M9kv7eZt2OIaEXws3oFvrjx48zaNAgunfvTlxcHIsWLQJg9uzZREZGkpCQQEJCAps2bdKrBIewKMXe4iqjyxCiwXT7Pr2HhwdPP/00ffr0oaysjMTERFJSUgCYNGkSDz30kF6Hdggvk0aPIG++La5m9H+Oc2+vIEbHBWA2aUaXJsSv0u1KHxERQZ8+fQDw9fUlNjb2op1vXZGmabz0uyju7OaPRcGS3GLGb84jv6zW6NKE+FUO+Ux/5MgRdu/eTb9+/QBYsmQJ8fHxjB07ljNn6n804QotsL3NJv7aN4R/DGlLcAszu09VMWrjMUPmUwvRULqHvry8nNtuu43nnnsOPz8/JkyYwKFDh8jNzSUiIoIpU6bUu58rtcC+pm0r3hzegcHtW1FRa+Nv2wqZ/tlJztfqO7NKiMuha+hra2u57bbbuOuuu7j11lsBCAsLw2w2YzKZGD9+fLPpl+fvbebvAyOYfU0oLT00PjxazrqDZ40uS4gL6BZ6pRTjxo0jNjaWyZMn120vKCio+/O7775Ljx499CrB4TRNY2RMG1K7+gNQaZFbfHFlVNlZlKVpx4l0G73ftm0br776Kj179iQhIQGAefPmsXr1anJzc9E0jejoaJYtW6ZXCYaR8XtxpTSbFdubK1BrXoSwtpgmzUPrEtck761b6AcMGFDvYNbQoUP1OqQQzULbilPc9u85qON77RtOHMM2fTRa2p/Qbh2DZr6y2XoyI09Hp85bZBRfNEpg/n5e/+ivtD2+FwKCMc1YhDbiLrBaUKtewDbzHlThlT36ltDroL2fJwBr959l6qcnKa22GlyRcBXhP35Fa0slJ9rFYVr0JlrfgZjGPoRpzlIIDIHvcrE9OApb1nuXfUGR0OtgZGc/Hrs2jFaeJj46Vk7q+0fZUXDe6LKECymIikXz86/7Wet1Nabn1sI1Q6CyAvX8LNTCaaiyxj8hktDrQNM0hnf2442b29MrxIeiSisTPsrn7zlFVFvl2b24PJqfP6apC9EemAM+LVHbN2N7MBW1Z2ej3kdCr6NIX09euiGK+3oFYdZg1Xel3L3pOPvPVBtdmnBRmqZhGjIC03NvQLdeUHwK26x7sf751ga/h4ReZx4mjfHxgbxyYzva+3pysLSGuzcd57V9Z7DJIJ/4LwWHjuCfs8X+g/br0dTCozA98RLaHRPsG/ION/g4lwz94sWLLzo/XjRcj2AfVt/cnltj/Ki1KZ7edZoJH+Vz6rzjWh8L52Sz2di1Zi2tpt1Jp9OHON0ikNAbh19yP83sgWlUBlr/Gxp1vEuGvrCwkL59+5KamkpmZqY8groCLT1N/O2aMJ69PgJ/bzPZJyv5w/tH2Xy0zOjShEFKTxezZ9pEEtbMp5Wlkq+7DMBnyZtExzdipmojJ+1cMvRz587lwIEDjBs3jldeeYUuXbrwyCOPcOjQoUYdSPyf69u15s3h7RkQ2ZJzNTamfnqSWdtPUl4jj/bcyb4tH1P9QCrxBz7nvIcPuWkP0+vJRbQJCtT1uA36TK9pGuHh4YSHh+Ph4cGZM2e4/fbbmTp1qq7FNWfBLTx4flBbHk4Owdus8d6hMtI2HuPouRqjSxM6q66sJHv+43RdPIngyhIOhHWj4snVJKalYjLpP8x2ySMsWrSIxMREpk6dSv/+/fnmm29YunQpu3bt4u2339a9wOZM0zRSu/rz+s3t6dzGi/xyCx8dLTe6LKGjI1/v5cR9d5C48x0smoldg8cQs+TfhHeOdlgNl5x7X1JSwjvvvEOHDh1+sd1kMrFhwwbdCnMnndp4cX27Vhw6W4OMmDRPVquVr1asoEfmP/GyWTjhF0H1nx8nOTnR4bVcMvRz5sy56N/FxsY2aTFCNEen805QuOAR+uTtAeCrhKH0mPIILXxbGVKPbt+yE0JA7vr36bDqKbrVlFPq7Ud++sP0HXqjoTU5vAV2SUkJKSkpdOnShZSUFJkD8P98VVgpo/jNQHnpWXbN+Cs9X34Uv5py9kYnwXNvEG9w4EHH0P/cAnvfvn3s2LGDF154gX379rFgwQKGDBnCgQMHGDJkCAsWLNCrBJdydduW+Jg1vig4z6gNx9h9qtLoksRl2v9FNmf/PIqEvR9RbfZk98i/0OOZZQRFhBtdGmBAC+z169eTnp4OQHp6OuvWrdOrBJeSFNaS1Te3JzbQmxMVFu75MI8Xdp+m1iZDe66itqaG7GeeJvrJewkvL+RIUCdOz32VpDFjHPIorqEc3gK7sLCQiIgIAMLDwyksLKx3H1dogd3Uott4sfLGdtzTIwCAl749w+jM4xw5K8/unV3+Dwc5cv/dJH76Ghqw69pRtH9hNe1juxpd2gUc3gL7v2mahqbV31HOlVpgNyVPs8b9vYP5Z0oUEa082FdczR0bj/Hm/lKZAu2EbDYbOf9+jTaP3E2nogOcahXMoSmLSZ46HU8fL6PLq5chLbB/7ohbUFBAaGioniW4rD5hLXhjWHtu7uhLlVUxb2cRD24toKRSvqDjLM6cKuKbh+6j9ztP08JazZ5u19N6yZt0+01/o0v7Vbo9srtYC+wRI0awcuVKpk+fzsqVKxk5cqReJbg8Xy8zcweE85uoVjyx8xSf5lfwx3d/YEZwMQHeF94haSYTHRISDHv+606+/fAjwv71BD2qSin3bMmPoybT5/bbjC6rQRzeAnv69OmkpqayYsUKOnTowNq1a/Uqodn4XbQvvUJ8eH1NJndsfpbQqos/5jzVKpij9852+quNq6qsqODbZ56kz673AfihbQ+Cps2jd4d2BlfWcA5vgQ2wZcsWvQ7bLKmaakLXLGbi+6sAOBkQxdkWARe8rnV5MZHnThD89ANkf5FK779MdtrPla7ox6/2YH5+Jn1K86jVzHydMobE8X/C7Olac9xcq1o3pI4cwPbsDDh6AExmtLQ/0fa2MUSaL/ynq62pYdeSxSR8uorE7W9w5IdsPB+a75QjyK7EWmth1z+XEb/5ZTyVlTz/KGwT55Lcu5fRpV0W53l4KH5B2WzY3nsN20N32QMf0Q7TglcwpY5HqyfwAJ5eXiRPnsKRaS9ysnUY0cWHCZ75R3JefhmbTRpyXo7Co8f5YeIYEj98CU9l5avE4YS+sIaOLhp4kCu9U1LFp7A9/yj81OVUS7kVbewUtBYtG7T/VdckUx77BrlPzyPhmw/pvf55Dn6RyXm/xj36rG0TSMex9xEc6RwzycD+iOzrde+hdmxB033ikqLj0Vy61p6nxMefwrEz6HvDb3U+pv4k9E5Gbd+M7R9zofwc+Pljuv9RtH6DGv0+rf3bkPj4k+SuH0CHVU/R+dR+OLW/0e9T+u0nfP0/04m/+aZG79vUzhWf4eBTc+j1wycOPe63na6m/fTH6BHaPOaLSOidhKqqRC1fgMp6z76hT39MD8xGCwi+ovdNGDmcM9dczbc7s1GNucVXCo8t64g9vhv/fz5Czs5P6f7QDFr6tb6iei7Xd598RsCyOfQ6X8x5D2++SxmDV3hb3Y/rExhEz/5XO9U02isloXcSauNqe+C9vNFGT0a76Q8Xna3YWAGhIQQMv7nR+1mH38xXL79M3Kbl9P46kxP37+HEnx8npp/jGj/UVFWRu+hpen/xNiYUh0KvotVf55HcpbPDamhuJPTOotK+7JV26xhMQ1MNLsbObDbT9557OJJ8DerZGbQ/cxTLggyyr/8jnVPT0HRelPvMiRPwwmMklhzBopnYfd3d9Ln/ATw8PXU9bnMnoXc2V7gMsR6i4+Oo/sdqdi16hsQdb5G4dSVsXan7cdv89N+TrcOo+PNjJF+drPsx3YGEXjSId4sWJE+fwb6tv8Hn1WfxO69/8xOFxpHY/nSfNI1IP1/dj+cuJPTOoqzU6AoapPuggTBooMOO1zzGy52LhN5gqqIM9c8nUR9vtG8IDjO2INHsSegNpPbttk+xLSoALx+0sZPRrh9mdFmimZPQG0DV1qLeWIZ652Ww2aBzLKbJ89Aio40uTbgBCb2Dqfwj2J55BA59B5qGdttYtLR70eQxlHAQ3aYZjR07ltDQUHr0+L/VN2fPnk1kZCQJCQkkJCSwadMmvQ7vdJRS2DLfxDbpDnvgQyIwzX0J0x8fkMALh9It9KNHjyYzM/OC7ZMmTSI3N5fc3FyGDh2q1+GdiiotwfbEg6gX50FNFdr1N2N67g20uD5GlybckG639wMHDuTIkSN6vb3LUF9+im3JHDhbAq180SbMwDTgd0aXJdyYw79FsGTJEuLj4xk7duyvrm7j6i2wVXUlthfnYXtioj3wPftiem6tBF4YzqGhnzBhAocOHSI3N5eIiAimTJly0de6cgtsVXAM2+Q7UZlvgocH2uhJmOa8iBbiPN9LF+7LoaP3YWH/N/Fk/PjxDBvWPJ9Jq6z3If8IRHXENGU+WkdpVyWch0Ov9D/3uwd49913fzGy36zY7AtQatffLIEXTke3K/0dd9zBxx9/zOnTp4mKimLOnDl8/PHH5Obmomka0dHRLFu2TK/DCyEuQrfQr169+oJt48aN0+twQogGaj49gJyEqqpEHfre6DKEuCiZhtuE1IG92J59BE4cAw9PtNgEo0sS4gIS+iagrBbU2y+j1iyzD+K1j7F/gSa6i9GlCXEBCf0VUoX52J6bCd/lAqCNuAvt7gfQvLwNrkyI+knoL5NSCvXxBtTyJ6GyAgJDMP3lMbSEq40uTYhfJaG/DKrsLGrpE6jtm+0brhmCacJMND9/YwsTogEk9I2k9uzAtuhRKCkCn5Zo46ehDR7eZD3qhdCbhL6BVE016rUlqPdes2/oGo9p0hNo4VHGFiZEI0noG0AdPWjvdvPzctGjxqPdPu6iq8cK4czkt/YS1J4d2OZOhNoa+3LRk+ahXdVMvzMg3IKE/hJU7k574JN+g2nKggYvFy2Es5JpuA2kde8tgRfNgoReCDfj0G64JSUlpKSk0KVLF1JSUn61XZYQQh8O7Ya7YMEChgwZwoEDBxgyZAgLFizQ6/BNQh3Zj9q51f6DJjdFonnQ7Td54MCBBAYG/mLb+vXrSU9PByA9PZ1169bpdfgromw2bOtfxfbQ3XDiKLTtgHbtb40uS4gm4dDR+8LCQiIiIgAIDw+nsLDQkYdvEHW60D7j7ptsALQbb0cbPRnNp4XBlQnRNAx7ZKdp2q9OXV2+fDnLly8HcFgLbLVtM7alc6H8HLQJwHT/LLTk6xxybCEcxeHdcAsKCoiIiKCgoIDQ0NCLvjYjI4OMjAwAkpKSdK1LnS+3Lxe9dYN9Q+IATA/MRvMP0vW4QhjBoaNTI0aMYOXKlQCsXLmSkSNHOvLw9VLf5WJ7cJQ98F4+aH96GNPM5yXwotlyaDfc6dOnk5qayooVK+jQoQNr167V6/CXpCy1qDeWo97+l3256E6xmCY/gRbV0bCahHAEh3bDBdiyZYteh2wwlX8U23Mz4MBeWS5auB23mnuvlEJ9+DbqX09DdRWEhGOa+DhaD33HDIRwJu4V+g/esi8XDWjXDUUbPx2tta/BVQnhWG4Vek7mA6ANuxPTPX81uBghjOGec0sDXWsVXCGaknuGXgg35l6hVzajKxDCcG7xmV4phcp8E/WfN+0bvH2MLUgIAzX70KvSYmxL5kDOZwBog4ah/db4mYBCGKVZh15lf4LthTlw9gy09kO7dwamATcYXZYQhmqWoVdVlaiXn0Z98LZ9Q89kTBMfQwsOM7YwIZxAswu9OrgX2zMz7M0vPDzR/vgA2vC70EzuNWYpxMU0m9ArqxX1zk/LRVst0L6zfQWajl2NLk0Ip9IsQn/BctHD7kT7n7/IctFC1MOlQ3/BctEBwfblontfY3RpQjgtQ0IfHR2Nr68vZrMZDw8PcnJyGv0e6nw56oXHUds+tG+4ejCm+/4my0ULcQmGXem3bt1KcHDwZe+v1r9mD7xPS7TxU9EGj5DlooVoANe9va86D4CWeg+mITLZRoiGMuQ5lqZp3HDDDSQmJtZ1vL1sJnPTFCWEmzDkSv/5558TGRnJqVOnSElJoVu3bgwcOPAXrzGiBbYQ7sCQK31kZCQAoaGh3HLLLWRnZ1/wmoyMDHJycsjJySEk5Jfff1dKwTlZB0+Iy+Hw0FdUVFBWVlb35w8//PAXi1xeijpXim3h1Loe9VpIhC51CtFcOfz2vrCwkFtuuQUAi8XCnXfeyY033tigfVXuDmzPPwolRdCiFVrGNJA15oRoFIeHvlOnTuzZs6dxOymF7V9/R723yv5zt172KbZhkU1foBDNnGs8sss7bA+82QMt7U9ot45GM7tG6UI4G9dITnUVtG2PadI8tC5xRlcjhEtzjdCbTJieWSPLRQvRBFzmS+YSeCGahsuEXgjRNCT0QrgZCb0QbkZCL4SbkdAL4WYk9EK4GdcIvVKoH742ugohmgWXCb3t4bHYVr+IslqMrkYIl+YaoQ8IAmVDvbEM28NjUQXHjK5ICJflGqEPCsP02DIICoP932CblIZt87v2ZhpCiEYxJPSZmZl07dqVmJgYFixY0KB9tJ59MS1aizbgBqiqRL3wGLYFU1DSQUeIRnF46K1WK/fffz//+c9/2LdvH6tXr2bfvn0N2ldr7Yc2ZQHapCegZWvYuRXbxFTU7u06Vy2Ec1K7t6PWv9qofRz+Lbvs7GxiYmLo1KkTAGlpaaxfv57u3bs3aH9N09CuG4qKTbAvZbVvN7Y596PdnIY9yrVUAAAEfElEQVQ2aBggve+FO1CojzeiNqy2/9i9d4P3dHjo8/PzadeuXd3PUVFR7Ny5s9Hvo4W2xfT4P1HrVqJeX4rauAa1cU1TliqE8zN7oN05Ae336Q3exWm/T//fLbC///57kpKSLrGHfv3vi4qKLujI627kHNg533lQMP8fMP8fBAcHk5mZeck9HB76yMhIjh8/XvdzXl5eXUvs/5aRkUFGRoYjS7uopKSky1pvrzmRc2DXHM6Dwwfy+vbty4EDBzh8+DA1NTWsWbOGESNGOLoMIdyWw6/0Hh4eLFmyhN/97ndYrVbGjh1LXJz0vRPCUQz5TD906FCGDh1qxKEvi7N8zDCSnAO75nAeNCXT2oRwK64xDVcI0WQk9MDYsWMJDQ39xZp6s2fPJjIykoSEBBISEti0aVPd382fP5+YmBi6du3KBx98YETJTa6+cwCwePFiunXrRlxcHFOnTq3b7i7nYNSoUXW/A9HR0SQkJNT9ncueAyXUJ598onbt2qXi4uLqts2aNUstXLjwgtfu3btXxcfHq6qqKvXjjz+qTp06KYvF4shydVHfOcjKylJDhgxRVVVVSimlCgsLlVLudQ7+2+TJk9WcOXOUUq59DuRKDwwcOJDAwMAGvXb9+vWkpaXh7e1Nx44diYmJqXepbVdT3zlYunQp06dPx9vbG7AvLQ7udQ5+ppRi7dq13HHHHYBrnwMJ/a9YsmQJ8fHxjB07ljNn7N/mq28acX5+vlEl6mr//v189tln9OvXj+uuu44vv/wScK9z8LPPPvuMsLAwunTpArj2OZDQX8SECRM4dOgQubm5REREMGXKFKNLcjiLxUJJSQk7duxg4cKFpKamum0Pg9WrV9dd5V2d0869N1pYWFjdn8ePH8+wYcOAhk8jbg6ioqK49dZb0TSN5ORkTCYTp0+fdqtzAPb/+b3zzjvs2rWrbpsrnwO50l9EQUFB3Z/ffffduhHdESNGsGbNGqqrqzl8+DAHDhwgOTnZqDJ19fvf/56tW7cC9lv9mpoagoOD3eocAHz00Ud069aNqKioum0ufQ6MHkl0BmlpaSo8PFx5eHioyMhI9dJLL6m7775b9ejRQ/Xs2VMNHz5cnThxou71c+fOVZ06dVJXXXWV2rRpk4GVN536zkF1dbW66667VFxcnOrdu7fasmVL3evd5RwopVR6erpaunTpBa931XMgM/KEcDNyey+Em5HQC+FmJPRCuBkJvRBuRkIvhJuR0AvhZiT0QrgZCb1osC+//JL4+HiqqqqoqKggLi6Ob7/91uiyRCPJ5BzRKDNnzqSqqorKykqioqJ4+OGHjS5JNJKEXjRKTU0Nffv2xcfHh+3bt2M267fIiNCH3N6LRikuLqa8vJyysjKqqqqMLkdcBrnSi0YZMWIEaWlpHD58mIKCApYsWWJ0SaKR5Pv0osH+/e9/4+npyZ133onVauXaa68lKyuLwYMHG12aaAS50gvhZuQzvRBuRkIvhJuR0AvhZiT0QrgZCb0QbkZCL4SbkdAL4WYk9EK4mf8FcqlWLqz7gQ8AAAAASUVORK5CYII=' style='max-width:100%; margin: auto; display: block; '/>
+<div id='140059227680272' style='display: table; margin: 0 auto;'><img src='data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAPkAAAD2CAYAAAAUGSFFAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4xLjEsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy8QZhcZAAAgAElEQVR4nO3deVyVZf7/8dd9zkFwQ0B2EFdSRBEFscVxXIZGzWVaBmmZL+6TzbSgTVo6uWRqOS0WTenklFOmZVNa6ZdSaRtNCRNLsyRzA5FVFJDtnHP9/jjG79uIisZ9bs7h8/wnub3PuT+PO97e97nu63wuTSmlEEK4LZPRBQgh9CUhF8LNSciFcHMSciHcnIRcCDdnMbqAxhg5ciTp6elGl9Gi2ZXijYNlPLe3hDr71T+Q6evvxeIbgojwbtWE1YlLcYmQFxcXG11Ci1Z4zspfd5wi81QVALdGenNzZAe0K3iPgkorT3xZxDfF1SRvPs6D8QHc3MMbTbuSdxFXQ3OF5+Tx8fFkZWUZXUaLtPVYOYt3FXK21o6Pp5n51wUytFO7q3qvszU2lmQW8uHRCgCGdWrLX68NwtfL3JQli/8iIW8Bamx2ck7XYr+C/9UK+PehM7z/YzkAN4S2YcH1Qfi3/mU3f0op/vdIOUszi6ios+Pf2syD8QGEtG2am0qTptHDpxVeFhlu+omE3M1lF1Yx9z+nOFlpvarXe5o1Zsb58/trOjTprfXJijrm7TjF3sLqJnvPn4S2tbB4cDD9A1s3+Xu7Igm5m6qzK1Z9Xco/95diV45f/I5XeBXu6GXm3gH+dOugzyCZza5Y+10Z249X0FS/haXVVvIqrJg0mBTtyx/7dcTD1LI/90vI3dCxs7XM/c8pDpTUoAGT+vhyd0xHPMzu/8teZ1Os/LqEf+4/jQJ6d/Tk8RuC6aLTP1SuQELuRpRSvJNzlr9lFVFtUwS3tbD4hmDiglrebetXBVXM23GK/EorXmaNWfEB3BrZMkfzJeQuZtuxcj7NrWzw9ja/0spXhY7HXDd1bc/shADat2q5I9fltTae+LKIzecHD4eEtWX+dYH4/cLBQ1cjIXcR5bU2lmUWseVI+SX3a9/KxCMJgYzs2t5JlTV/Hx4t5/HdhZTX2vHzMrPguiB+Fd7W6LKcRkLuAvacv/U8df7Wc2pfP4IaeORkAgYGtyGgTcu6UjXGqco65u8sqJ/Qc9s1HZgZ50/rFvCoTULejNXZFC/uK+HVA45BpOiOnjw+OJjOMiX0qtiV4vWDZaSdn5rbxduDxwcH07ujl9Gl6UpC3kwdOeMYIT9YWoNJg8l9/Jge49fiHwc1he9La3jkP6f48UwtFg3u7teRpJ4NT9P1NJtc/qmEhLyZUUrx1qEzPLOnmBqbIqydY4Q8ViZ2NKlqq53n95bwxndll9yvjUXjvgH+JDXxZCBnkpA3I8VVVhbsLGDHyXMAjO3WnocGBtCuBY+Q623nyUqWf1lEUZXtgr9TSnHO6ohHU03rNYKEvJk4WFLNPdtPUlZjw7uViXnXBpLYWUbIjfbfX9B59LpAhl3lF3SMovvQos1mo3///owZMwaAI0eOMGjQICIjI5kwYQK1tbV6l+ASMo5XUFZjo6+/F2+NiZCANxOJnduzYWxnBgW3pqzGxsxP8nnsiwLO1dmNLq3RdA/5ihUriIqKqv959uzZpKamkpOTg6+vL6tXr9a7BJfw0+3UkPC2BLX1MLQW8XOBbSz8/TdhzIrzx8Ok8c4PZ0nefJz9xU3/5Ro96Bry3NxcNm/ezNSpUwHHZ5yMjAxuu+02AFJSUti4caOeJQjRJEyaxl29fVk7uhORPq04UV7HxPQTrPq6BOsv6JTjDLqG/IEHHuDJJ5/EZHIcpqSkBB8fHywWx+BFeHg4eXl5Db521apVxMfHEx8fT1FRkZ5lCtFokb6evDa6E3dG+WBT8OK+UqZ+lEtueZ3RpV2UbiH/4IMPCAwMJC4urn5bQ2N8F3ssMX36dLKyssjKyiIgIECvMpuF4ipr/Uws13xI07J4mk08GB/Ai78JI6C1mX1FjpZW7x0+2+DvuNF0ex6wY8cO3nvvPbZs2UJ1dTVnz57lgQceoKysDKvVisViITc3l9DQUL1KcAkfn6hg0ReFlNXY6NDKxA1hbYwuSTTStSFt2DC2M4t3FbLteAXzdxbweW4lc68NxMez+Tz21O1KvnTpUnJzczl69Cjr169n+PDhrF27lmHDhvH2228DsGbNGsaPH69XCc3auTo7j31RwMxP8imrsXFtSBveGtuZXn7uPcXS3XTwNPPkkGAWXR9EWw8T245XkPT+MXblnzO6tHpOn53/xBNP8PTTT9OjRw9KSkqYMmWKs0sw3Dfnb+/e+eEsrUwaf4n354URoQTKF0tckqZpjO3uzZs3RdAvwIuiKhsztuXxt6wiamzGP2qTyTBOtubAaZ7fW4xNQaRvK5bcEEwPX0+jyxJNxGpXvLL/NCu/LsGmoIdPK54dGkpYe+Mei7r/9+yaEatdseIrR8D/0NuH10d1koC7GYtJY1qMH6+O7ESn9h78UFbLuz+cMbQmCbkTKeWY9GIxwcy4AFqZ5fS7qz7+XtzcwxsAm8H3yvJbJoSbk5AL4eYk5E50oMQ15joL9yLPbJzAale8/E0pL39TCkD/AGkAIZxHQq6z42drmbejgG+Kq9GAlN6+3BPrZ3RZogWRkOtEKcXGH86yPKuIKqsiqI2Fx24IYmCwTFsVziUh10F5rY0FOwvIOFEJwI2d2zF3UCDezWg+s2g5JOQ6WPddGRknKmnnYeLhhABGdW3vsk0AheuTkOug+nzzv5RoX0Z38za4GtHSySM0Hcm1WzQHEnIh3JxuIa+uriYhIYF+/foRHR3N/PnzAZg4cSJdu3YlNjaW2NhYsrOz9SrBEEopiqqsRpchmpGic1ZDO8bo9pnc09OTjIwM2rVrR11dHYMHD2bUqFEALF++vL6Zozsprbay6ItCPs11jKp3MvDrhcJ44ef//28+Uk55nd2xbLKX84fBdLuSa5pGu3aOJvR1dXXU1dW59Qjzf/IqSXr/OJ/mOkbVlwwO4sYu0ju9JUvs3J4lg4Np52His1zH78fneZVOr0PXz+Q2m43Y2FgCAwNJTExk0KBBAMydO5eYmBhSU1Opqalp8LWu0q21ympnWWYh92acpKTaRlxQa94cE8GorjKqLmBU1/a8NTaC+KDWlFTbuC/jJEt3F1JldV7HGKd0hikrK+Pmm2/m+eefp2PHjgQHB1NbW8v06dPp3r07jz766CVf31w7w3xXWs0j/yngyJlaLCa4p19H/qe3L2ZZeVT8F5v9/LLJ2cVY7dDF24Mlg4OJcsKyyU4ZXffx8WHo0KGkp6cTEhKCpml4enoyadIkMjMznVFCk7PZFdM+yuPImVq6dmjFa6M6MamPnwRcNMhs0kiJ9uX1URF07dCKo2frmL41zykLM+gW8qKiIsrKHMvCVlVVsW3bNnr16kV+fj5wfm73xo306dNHrxJ0ZVWKijo7FhOsHd1JuqyKRunp58kbozvhYdKoqLNT54SQ6zbUl5+fT0pKCjabDbvdTlJSEmPGjGH48OEUFRWhlCI2NpaXXnpJrxKcwoRGa4tMNxCN52UxYdbAWWuu6BbymJgY9u7de8H2jIwMvQ4phGiAXIKEcHMSciHcnIRcCDcnIRfCzUnIhXBzEnIh3JyEXAg3JyEXws1JyIVwcxJyIdychFwINychF8LNSciFcHMSciHcnNNbMh85coRBgwYRGRnJhAkTqK2t1asEIQQ6hvynlsz79u0jOzub9PR0du3axezZs0lNTSUnJwdfX19Wr16tVwlCCAxoyZyRkVHfcz0lJYWNGzfqVYIQAie3ZO7evTs+Pj5YLI6GNOHh4eTl5TX4WldpySxEc6dryM1mM9nZ2eTm5pKZmcnBgwcv2OdiCy5Mnz6drKwssrKyCAgI0LNMIdyaU1sy79q1i7KyMqxWx1phubm5hIaGOqMEIVosp7ZkjoqKYtiwYbz99tsArFmzhvHjx+tVghACA1oy9+7dm+TkZObNm0f//v2ZMmWKXiUIITCgJXO3bt1cdtUUIVyRzHgTws1JyIVwcxJyIdychFwINychF8LNSciFMNAHP55FKX2XL5aQC2GA8T28AViyu4jUT/IprbbqdiwJuRAGmJMQyJLBQbTzMPFpbiVJ7x/n87xKXY4lIRfCIKO6evPmmAgGBLampNrGfRknWZZZSJXV3qTHkZALYaDQdh6sSgzj/gEdsZjgze/PcP26wzz3VXGTHUNCLoTBzCaNidF+vDaqU/22Vw6cbrL3l5AL0Uz08vPi7n5+AIzr3r7J3ldCLkQz4mV2RNLH09xk7ykhF8LN6RbyEydOMGzYMKKiooiOjmbFihUALFiwgLCwMGJjY4mNjWXLli16leAUVqU4UFJtdBlCXJRu3ye3WCw89dRTDBgwgPLycuLi4khMTAQgNTWVBx98UK9DO0Urk0afjp7sL6lh4v+e4O5+HZkY7YvZ1HDPOiGMotuVPCQkhAEDBgDQvn17oqKiLtqZ1RVpmsbLvw3njl4+WBWkZZcwbWsueeV1RpcmxM845TP50aNH2bt3L4MGDQIgLS2NmJgYJk+ezOnTDT8qcIWWzJ5mE38ZGMDfR4Ti39rM3sJqJmw+7pT5yEI0lu4hr6io4NZbb+XZZ5/F29ubGTNmcPjwYbKzswkJCWHWrFkNvs6VWjJfF9qWDWM7MzyiLZV1dv66o4A5n5/iXF3TzlwS4mroGvK6ujpuvfVW7rzzTm655RYAgoKCMJvNmEwmpk2b5jb93nw8zfxtSAgLrgukjUXjo2MVbPzhjNFlCaFfyJVSTJkyhaioKGbOnFm/PT8/v/7P7777Ln369NGrBKfTNI3xPTqQ1NMHgCqr3LKLX0aVn0FZf9k4j26j6zt27OC1116jb9++xMbGArBkyRLWrVtHdnY2mqbRpUsXVq5cqVcJhpHxdfFLaXYb9g2rUetfgqBQTKlL0CKjr+q9dAv54MGDGxx8Gj16tF6HFMIthFYWcuu/FqJOHHBsOHkc+5yJaMl/RLtlEpr5ymbDyYw3HRWes8oou7gifnmHeGPbXwg9cQB8/THNXYE27k6wWVFrX8A+byqq4MoeRUvIdRDh7QHAW4fO8NBnpyirsRlckXAVwT9+RTtrFSc7RWNasQFt4BBMkx/EtPBF8AuAg9nYH5iAPeO9Rl9AJOQ6GN/dm0XXB9HWw8S24xUkvX+MXfnnjC5LuJD88Cg0b5/6n7V+12J69i24bgRUVaKem49aPhtVfvknOBJyHWiaxtju3rx5UwT9ArwoqrIxY1sef8sqosYmz87F1dG8fTA9tBzt3oXg1Qa1cyv2B5JQ+3Zf8nUSch2Ftffg5RvDuadfR8warD1Yxl1bTnDodI3RpQkXpWkaphHjMD37JvTqByWF2Offje3Pt1z0NRJynVlMGtNi/Hh1ZCci2nvwQ1ktd205wevfnsYug3Li/8g/fBSfrO2OH7RLR1MLDsf0+Mtot89wbMg9ctF9JeRO0sffi3U3RXBLD2/q7Iqn9hQzY1sehef0a8UrXIPdbmfP+rdoO/sOuhUfpri1H4Ejx172dZrZgmnCdLQbbrzkfpcNeVpa2kW/RCKuTBsPE3+9Lohnhobg42km81QVv3//GFuPlRtdmjBIWXEJ+2bfT+z6pbS1VvF15GC80jbQJeYKZoJeZpLMZUN+6tQpBg4cSFJSEunp6fLctwkM7dSODWMjGBzWhrO1dh767BTzd56iolYetbUk327/hJp7k4jJ+Q/nLF5kJz9MvydW0KGjX5Me57IhX7x4MTk5OUyZMoVXX32VyMhIHnnkEQ4fPtykhbQ0/q0tPDcslIcTAvA0a7x3uJzkzcc5drbW6NKEzmqqqshc+hg9n0/Fv6qUnKBeVD6xjrjkJEympv8E3ah31DSN4OBggoODsVgsnD59mttuu42HHnqoyQtqSTRNI6mnD2/cFEH3Dq3Iq7Cy7ViF0WUJHR39+gAn77mduN3vYNVM7Bk+iR5p/yK4exfdjnnZuevPPfcca9aswd/fn6lTp7J8+XI8PDyw2+1ERkby5JNP6lZcS9GtQyuGdmrL4TO1yIch92Sz2fhq9Wr6pP+DVnYrJ71DqPnzYyQkxOl+7MuGvLi4mHfeeYfOnTv/bLvJZOKDDz7QrTAh3EVx7kkKlj3CgNx9AHwVO5o+sx6hdfu2Tjn+ZUO+aNGii/5dVFRUkxYjhLvJ3vQ+ndc+Sa/aCso8vclLeZiBo0c6tQant2QuLS0lMTGRyMhIEhMT5fHcf/mqoEpG2d1ARdkZ9sz9C31feRTv2goOdImHZ98kxskBBx1D/lNL5oMHD7Jr1y5eeOEFvv32W5YtW8aIESPIyclhxIgRLFu2TK8SXMq1oW3wMmt8kX+OCR8cZ29hldEliat06ItMzvx5ArEHtlFj9mDv+Pvo8/RKOoYEG1KP01syb9q0iZSUFABSUlLYuHGjXiW4lPigNqy7KYIoP09OVlqZ+lEuL+wtps4uQ3Guoq62lsynn6LLE3cTXFHA0Y7dKF78GvGTJunyaKyxnN6SuaCggJCQEMDxD0FhYWGDr3GFlsxNrUuHVqwZ2YmpfXwBeHn/aSamn+DoGXl23tzlff8DR/90F3GfvY4G7Ll+AhEvrCMiqqfRpTm/JXNjuVJL5qbkYdb4U39//pEYTkhbC9+W1HD75uNsOFQmsw2bIbvdTta/XqfDI3fRrSiHwrb+HJ71PAkPzcHDq5XR5QEGtWT+qWNrfn4+gYGBepbgsgYEtebNMRHc1LU91TbFkt1FPPBxPqVV8oWW5uJ0YRHfPHgP/d95ita2Gvb1Gkq7tA30+tUNRpf2M7o1crxYS+Zx48axZs0a5syZw5o1axg/frxeJbi89q3MLB4czK/C2/L47kI+y6vkD+9+z1z/Enw9L+wJq5lMdI6Nddrz15Zs/0fbCPrn4/SpLqPCow0/TpjJgNtuNbqsBjm9JfOcOXNISkpi9erVREREsGHDBr1KcBu/7dKefgFevLE+ndu3PkNg9cUfOxa29efY3Qua3dXEXVRVVrL/6ScYsOd9AL4P7UPH2Uvo37mTwZVdnNNbMgNs375dr8O6JVVbQ+D657n//bUAnPIN50xr3wv2a1dRQtjZk/g/dS+ZXyTR/76ZzeZzoTv48at9mJ+bx4CyXOo0M18nTiJu2h8xe+gWoybRvKsTqKM52J+ZC8dywGRGS/4jobdOIsx84f+6utpa9qQ9T+xna4nb+SZHv8/E48GlzWKE15XZ6qzs+cdKYra+goeykesTjv3+xST072d0aY0inWGaKWW3Y3/vdewP3ukIeEgnTMtexZQ0Da2BgAN4tGpFwsxZHJ39EqfaBdGl5Aj+8/5A1iuvYLdLA8mrUXDsBN/fP4m4j17GQ9n4Km4sgS+sp6uLBBzkSt4sqZJC7M89Cue7cGo33oo2aSZa6zaNev011yVQEfUm2U8tIfabj+i/6Tl++CKdc95X9iiyroMfXSffg3+YMTO1GmK32/l643uoXdvRdJ8opOh6LJuedeco9fKhYPJcBt74G52P2fQk5M2M2rkV+98XQ8VZ8PbB9Of5aAlDr/h92vl0IO6xJ8jeNJjOa5+ke+EhKDx0xe9Ttv9Tvv6fOcTcNOqKX9vUzpac5ocnF9Lv+0+detz93a4lYs4i+gS65nwNCXkzoaqrUKuWoTLec2yIG+wIuK//L3rf2PFjOX3dtezfnYm6klt2pbBs30jUib34/OMRsnZ/Ru8H59LGu90vqudqHfz0c3xXLqTfuRLOWTw5mDiJVsGhuh/Xy68jfW+41tBpqb+UhLyZUJvXOQLeyhNt4ky0Ub9H05pmfVTfwAB8x950xa+zjb2Jr155hegtq+j/dTon/7SPk39+jB6D9G908JPa6mqyVzxF/y/+jQnF4cBraPuXJSREdndaDa5OQt5cVDmWUdJumYRpdJLBxTiYzWYGTp3K0YTrUM/MJeL0MazLppM59A90T0pG03mR5tMnT8ILi4grPYpVM7H313cx4E/3YvHw0PW47kZC3txc4bK0ztAlJpqav69jz4qnidv1NnEfr4GP1+h+3A7n/3uqXRCVf15EwrUJuh/THUnIRaN4tm5Nwpy5fPvxr/B67Rm8z+nf7EOhcTTqBnqnzibMu73ux3NXEvLmorzM6AoapfewITBsiNOO55rj2c2LhNxgqrIc9Y8nUJ9sdmzwDzK2IOF2JOQGUt/udUxZLcqHVl5ok2eiDR1jdFnCzUjIDaDq6lBvrkS98wrY7dA9CtPMJWhhXYwuTbghCbmTqbyj2J9+BA4fBE1Du3UyWvLdaPJYSOhEt2k8kydPJjAwkD59/v/qjAsWLCAsLIzY2FhiY2PZsmWLXodvdpRS2NM3YE+93RHwgBBMi1/G9Id7JeBCV7qFfOLEiaSnp1+wPTU1lezsbLKzsxk9erReh29WVFkp9scfQL20BGqr0YbehOnZN9GiBxhdmmgBdLtdHzJkCEePHtXr7V2G+vIz7GkL4UwptG2PNmMupsG/Nbos0YI4fdZ9WloaMTExTJ48+ZKrp7h6S2ZVU4X9pSXYH7/fEfC+AzE9+5YEXDidU0M+Y8YMDh8+THZ2NiEhIcyaNeui+7pyS2aVfxz7zDtQ6RvAYkGbmIpp4UtoAc3ne9mi5XDq6HpQ0P+f6DFt2jTGjHHPZ8Iq433IOwrhXTHNWorWVdovCeM49Ur+U791gHffffdnI+9uxe5YsFAbepMEXBhOtyv57bffzieffEJxcTHh4eEsXLiQTz75hOzsbDRNo0uXLqxcuVKvwwshztMt5OvWrbtg25QpU/Q6nBDiIly3p00zpaqrUIe/M7oMIerJtNYmpHIOYH/mETh5HCweaFGxRpckhIS8KSibFfXvV1DrVzoG3SJ6OL5w0iXS6NKEkJD/UqogD/uz8+BgNgDauDvR7roXrZWnwZUJ4SAhv0pKKdQnH6BWPQFVleAXgOm+RWix1xpdmhA/IyG/Cqr8DOrFx1E7tzo2XDcC04x5aN4+xhYmRAMk5FdI7duFfcWjUFoEXm3Qps1GGz62yXqkC9HUJOSNpGprUK+nod573bGhZwym1MfRgsONLUyIy5CQN4I69oOjm8tPywdPmIZ225SLri4qRHMiv6WXofbtwr74fqirdSwfnLoE7Ro3nXMv3JKE/DJU9m5HwON/hWnWskYvHyxEcyHTWhtJ691fAi5ckoRcCDcnIRfCzTm1JXNpaSmJiYlERkaSmJh4yR5vzYE6egi1+2PHD5r8eyhck1NbMi9btowRI0aQk5PDiBEjWLZsmV6H/0WU3Y5902vYH7wLTh6D0M5o1//G6LKEuCq6hXzIkCH4+fn9bNumTZtISUkBICUlhY0bN+p1+Kumiguwz5+BeuVpsNahjbwN09Pr0ILCjC5NiKvi1EdoBQUFhISEABASEkJhYeFF9121ahWrVq0CcFpLZrVjK/YXF0PFWejgi+lP89ESfu2UYwuhl2b7nHz69OlMnz4dgPj4eF2Ppc5VOJYP/vgDx4a4wZjuXYDm01HX4wrhDE5vyZyfn09ISAj5+fkEBgY68/ANUgezHcsHF550LB88KRVt5O/lCyfCbTh1yHjcuHGsWbMGgDVr1jB+/HhnHv5nlLUO+9oXsM+d4gh4tyhMT7+BaVSSBFy4Fae2ZJ4zZw5JSUmsXr2aiIgINmzYoNfhL0nlHcP+7FzIOSDLBwu359SWzADbt2/X65CXpZRCffRv1D+fgppqCAjGdP9jaH30/cwvhJGa7cCbHtSHbzuWDwa0X49GmzYHrV17g6sSQl8tKuScygNAG3MHpql/MbgYIZyjZc7V9HOtVVKF+CVaZsiFaEFaVsiV3egKhHC6FvGZXCmFSt+A+t/zj+w8vYwtSAgncvuQq7IS7GkLIetzALRhY9B+Y9wkHCGcza1DrjI/xf7CQjhzGtp5o909F9PgG40uSwincsuQq+oq1CtPoT78t2ND3wRM9y9C8w8ytjAhDOB2IVc/HMD+9FxHsweLB9of7kUbeyeaqWWNMQrxE7cJubLZUO+cXz7YZoWI7o4VTrr2NLo0IQzlFiG/YPngMXeg/c99snywELh4yC9YPtjX37F8cP/rjC5NiGbDZUOuzlWgXngMteMjx4Zrh2O656+yfLAQ/8WQkHfp0oX27dtjNpuxWCxkZWVd8XuoTa87Au7VBm3aQ2jDx0mzByEaYNiV/OOPP8bf3//q36D6HABa0lRMI2RyixAX4/rPlUxmoysQolkzJOSapnHjjTcSFxdX33b5v61atYr4+Hji4+Od1pJZCHdkyO36jh07CA0NpbCwkMTERHr16sWQIUN+ts+lWjIrpeBs815iSYjmwpAreWhoKACBgYHcfPPNZGZmNvq16mwZ9uUP1fdI1wJCdKlRCHfh9JBXVlZSXl5e/+ePPvroZ4siXorK3oX9gSTYuQ1at0W7fxHIGmVCXJLTb9cLCgq4+eabAbBardxxxx2MHDny0i9SCvs//4Z6b63j5179HFNWZX0yIS7L6SHv1q0b+/btu7IX5R5xBNxsQUv+I9otE9HMLjuPRwinco2k1FRDaASm1CVokdFGVyOES3GNkJtMmJ5ej+bV2uhKhHA5LjMZRgIuxNVxmZALIa6OhFwINychF8LNSciFcHMSciHcnIRcCDfnGiFXCvX910ZXIYRLcpmQ2x+ejH3dSyib1ehqhHAprhFy346g7Kg3V2J/eDIq/7jRFQnhMlwj5B2DMC1aCR2D4NA32FOTsW9919E8QghxSa4RckDrOxDTirfQBt8I1VWoFxZhXzYLJR1ihLgkQ0Kenp5Oz5496dGjB8uWLWv067R23mizlqGlPg5t2sHuj7Hfn4Tau1PHaoVovtTenahNr11yH005+Z7XZrNxzTXXsHXrVsLDwxk4cCDr1q2jd+/eF31NfHz8Bb3ZVeFJx9JI3+4FQLspGW3YGEB6r4uWQKE+2Yz6YJ3jx979MS/5Z4N7Ov2rppmZmfTo0YNu3boBkJyczKZNmy4Z8oZogaGYHvsHauMa1BsvojavR21er3k+lYMAAARLSURBVEfJQjRfZgvaHTPQfpdy0V2cHvK8vDw6depU/3N4eDi7d+++YL9Vq1bVt2v+7rvvLujYeiH9+q8XFRUREBCg2/u7AjkHDs3vPChY+ndY+nf8/f1JT0+/YA+nh7yhTwcNLW/0f1syG62hjwstjZwDB1c8D04feAsPD+fEiRP1P+fm5ta3aBZCND2nh3zgwIHk5ORw5MgRamtrWb9+PePGjXN2GUK0GE6/XbdYLKSlpfHb3/4Wm83G5MmTiY5u3s0Zm8vHBiPJOXBwxfPg9EdoQgjncpkZb0KIqyMhF8LNSciByZMnExgY+LM12RYsWEBYWBixsbHExsayZcuW+r9bunQpPXr0oGfPnnz44YdGlNzkGjoHAM8//zw9e/YkOjqahx56qH57SzkHEyZMqP8d6NKlC7GxsfV/5zLnQAn16aefqj179qjo6Oj6bfPnz1fLly+/YN8DBw6omJgYVV1drX788UfVrVs3ZbVanVmuLho6BxkZGWrEiBGqurpaKaVUQUGBUqplnYP/a+bMmWrhwoVKKdc6B3IlB4YMGYKfn1+j9t20aRPJycl4enrStWtXevTocUVLLzdXDZ2DF198kTlz5uDp6Qk4lpqGlnUOfqKU4q233uL2228HXOscSMgvIS0tjZiYGCZPnszp046vtDY0LTcvL8+oEnV16NAhPv/8cwYNGsSvf/1rvvzyS6BlnYOffP755wQFBREZGQm41jmQkF/EjBkzOHz4MNnZ2YSEhDBr1iyg8dNy3YHVauX06dPs2rWL5cuXk5SUhFKqRZ2Dn6xbt67+Kg6u9XvgGgseGiAoKKj+z9OmTWPMmDFAy5qWGx4ezi233IKmaSQkJGAymSguLm5R5wAc/9i988477Nmzp36bK50DuZJfRH5+fv2f33333foR13HjxrF+/Xpqamo4cuQIOTk5JCQkGFWmrn73u9+RkZEBOG7da2tr8ff3b1HnAGDbtm306tWL8PDw+m0udQ4MHfZrJpKTk1VwcLCyWCwqLCxMvfzyy+quu+5Sffr0UX379lVjx45VJ0+erN9/8eLFqlu3buqaa65RW7ZsMbDyptPQOaipqVF33nmnio6OVv3791fbt2+v37+lnAOllEpJSVEvvvjiBfu7yjmQaa1CuDm5XRfCzUnIhXBzEnIh3JyEXAg3JyEXws1JyIVwcxJyIdychFw02pdffklMTAzV1dVUVlYSHR3N/v37jS5LXIZMhhFXZN68eVRXV1NVVUV4eDgPP/yw0SWJy5CQiytSW1vLwIED8fLyYufOnZjN+q1cI5qG3K6LK1JaWkpFRQXl5eVUV1cbXY5oBLmSiysybtw4kpOTOXLkCPn5+aSlpRldkrgM+T65aLR//etfWCwW7rjjDmw2G9dffz0ZGRkMHz7c6NLEJciVXAg3J5/JhXBzEnIh3JyEXAg3JyEXws1JyIVwcxJyIdychFwIN/f/AFf1SAvrE3n8AAAAAElFTkSuQmCC' style='max-width:100%; margin: auto; display: block; '/></div>
 </div>
 
 </div>
@@ -12619,8 +14395,7 @@ experiment.roi_polys[c][t][n][0] # n = 1, 2, 3.... the neuropil regions</code></
 
 </div>
 <div class="cell border-box-sizing text_cell rendered"><div class="prompt input_prompt">
-</div>
-<div class="inner_cell">
+</div><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
 <h4 id="FISSA-extracted-traces">FISSA extracted traces<a class="anchor-link" href="#FISSA-extracted-traces">&#182;</a></h4><p>The final extracted traces can be found in <code>experiment.result</code> as follows. For cell number <code>c</code> and tiff number <code>t</code>, the final extracted trace is given by:</p>
 
@@ -12637,12 +14412,12 @@ experiment.roi_polys[c][t][n][0] # n = 1, 2, 3.... the neuropil regions</code></
 <div class="prompt input_prompt">In&nbsp;[6]:</div>
 <div class="inner_cell">
     <div class="input_area">
-<div class=" highlight hl-ipython2"><pre><span></span><span class="n">c</span> <span class="o">=</span> <span class="mi">2</span>
+<div class=" highlight hl-ipython3"><pre><span></span><span class="n">c</span> <span class="o">=</span> <span class="mi">2</span>
 <span class="n">t</span> <span class="o">=</span> <span class="mi">1</span>
 <span class="n">hv</span><span class="o">.</span><span class="n">Curve</span><span class="p">(</span><span class="n">experiment</span><span class="o">.</span><span class="n">raw</span><span class="p">[</span><span class="n">c</span><span class="p">][</span><span class="n">t</span><span class="p">][</span><span class="mi">0</span><span class="p">,:],</span> <span class="n">label</span><span class="o">=</span><span class="s1">&#39;raw&#39;</span><span class="p">)</span><span class="o">*</span><span class="n">hv</span><span class="o">.</span><span class="n">Curve</span><span class="p">(</span><span class="n">experiment</span><span class="o">.</span><span class="n">result</span><span class="p">[</span><span class="n">c</span><span class="p">,</span><span class="n">t</span><span class="p">][</span><span class="mi">0</span><span class="p">,:],</span> <span class="n">label</span><span class="o">=</span><span class="s1">&#39;decontaminated&#39;</span><span class="p">)</span>
 </pre></div>
 
-</div>
+    </div>
 </div>
 </div>
 
@@ -12652,12 +14427,12 @@ experiment.roi_polys[c][t][n][0] # n = 1, 2, 3.... the neuropil regions</code></
 
 <div class="output_area">
 
-<div class="prompt output_prompt">Out[6]:</div>
+    <div class="prompt output_prompt">Out[6]:</div>
 
 
 
 <div class="output_html rendered_html output_subarea output_execute_result">
-<img src='data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAQMAAAD6CAYAAAClOyKuAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDIuMS4wLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvpW3flQAAIABJREFUeJztnXl8VNX5/z93ZrITEkJWE4iJiSxZSEggKEKBiCJqKDsWNRSEVttqtYja0irVFuoKVWubr/w0UFtKqSYqi8omYRPCvggETCA7Wck2k9nO74+ZO1tmMnMnM3cm8LxfL15Jbu6c++Ryz+c8z3Oecy7HGGMgCOKWR+JpAwiC8A5IDAiCAEBiQBCEHhIDgiAAkBgQBKGHxIAgCAAkBgRB6CExIAgCAIkBQRB6+rUYTJs2zdMmEALJ3FiGzI1lWLm/ztOmEBb0azFobGz0tAmEkzQrNJ42gbCgX4sB0X+hBTHeB4kB4RG0tD7O6yAxIDwCaYH3IfO0Aa7m+vXrWL58OS5cuACtVutpcwgLrneqAADfSCTIDpDaPV8ikWD48OF48803ERkZ6W7zbmluOjFYvnw5Jk+ejPXr18PHx8fT5hAWnG9SAAACZRLcHuJr93yVSoWNGzdi+fLl2LBhg7vNu6W56cKECxcu4NFHHyUhuEnw8fHBY489hgsXLnjalJuem04MtFotCcFNho+PD4V8InDTiQHRP6D8offhNjFYvHgxIiMjkZqaajjW3NyMqVOnIjk5GVOnTkVLSwsAgDGGp59+GklJSUhPT8fx48fdZRZBEDZwmxgsWrQIO3bsMDu2Zs0a5ObmoqysDLm5uVizZg0AYPv27SgrK0NZWRkKCgrw5JNPusss0WGMkYtrBbWWoVGuhlpLPoK34DYxmDhxIsLCwsyOFRcXIz8/HwCQn5+PoqIiw/HHH38cHMdh3LhxaG1tRW1trbtMczsVFRUYNmwYHn/8caSmpmLJkiXIzs5GSkoKXn75ZQDA0aNHMWvWLAC6vz8gIABKpRIKhQKJiYmeNF8UVFqG611q1HSoPG0KoUfUqcX6+nrExMQAAKKjo1FfXw8AqK6uxpAhQwznxcXFobq62nCuKQUFBSgoKAAANDQ09Hq9zI1lrjLdjBOPJds9p6ysDIWFhRg3bhyam5sRFhYGjUaD3NxcnD59GpmZmTh58iQAoKSkBKmpqTh69CjUajVycnLcYrc30qEir8lb8FgCkeM4cBwn+HPLli1DaWkpSktLERER4QbLXEN8fDzGjRsHANi8eTNGjx6NzMxMnDt3DufPn4dMJsMdd9yB77//HkeOHMFzzz2Hffv2oaSkBBMmTPCw9cStiKieQVRUFGpraxETE4Pa2lpDRVlsbCwqKysN51VVVSE2NrbP13NkBHcXQUFBAIDy8nK8+eabOHr0KAYNGoRFixZBodAV3kycOBHbt2+Hj48P7r33XixatAgajQZvvPGGx+x2J/S+Hu9GVM8gLy8PhYWFAIDCwkLMmDHDcHzDhg1gjOHw4cMICQmxGiL0R9ra2hAUFISQkBDU19dj+/btht9NmDABa9euxV133YWIiAg0NTXh4sWLZjMwNxMkBd6N2zyDRx55BHv37kVjYyPi4uKwatUqvPjii5g3bx7Wr1+P+Ph4bN68GQAwffp0bNu2DUlJSQgMDMRHH33kLrNEZ9SoUcjMzMTw4cMxZMgQjB8/3vC7nJwc1NfXY+LEiQCA9PR01NXVORU+9QdsOQZaxiC5Sf/m/gTXn9+1mJ2djdLSUrvHCO9ArWW41NLd43hSqC98pb07qfT/6n6oApEQDVvjDpUaeAckBoRo2OrzrtACuVqLx7dX4v2TTS5o7daExIAQDVsBqSsC1aLLbTjTqMCHZ5r73tgtCokBIRrujAbONSrc2PqtAYkBIRo2PQMXyMSF5p6JSUIYJAaEaNjMGbjAZaimNQ59hsRABF555RW8+eabbr/Oxx9/jJqaGpe1d/fdd7vUFluzCfzRioqKm7bgqj9AYnAT4WoxOHjwoEttcWfOQEI1S32GxMBN/OlPf8Kdd96Je+65BxcvXgQAXLlyBdOmTUNWVhYmTJhg2Nevvr4eM2fOxKhRozBq1ChDJ3z77beRmpqK1NRUrF27FoBu9BwxYgSWLl2KlJQU3HfffZDL5diyZQtKS0uxcOFCZGRkQC6X449//CPGjBmD1NRULFu2zDAyT5o0Cc8++yyys7MxYsQIw3Lq5ORkrFy50vA3DBgwAACwd+9eTJo0CXPmzMHw4cOxcOFCQ1vWrmHNlmPHjmHavZMxd8rdWDr3YTTU6Zaonzt5HHdnj8aoUaPw/vvvO32/qYLRBbB+TFZWVq/H1DMy3PLPHqWlpSw1NZV1dnayGzdusDvuuIO98cYbbMqUKezSpUuMMcYOHz7MJk+ezBhjbN68eeydd97R2axWs9bWVkMbHR0drL29nY0cOZIdP36clZeXM6lUyk6cOMEYY2zu3Lls48aNjDHGfvSjH7GjR48a7GhqajJ8/+ijj7LPP//ccN6KFSsYY4ytXbuWxcTEsJqaGqZQKFhsbCxrbGxkjDEWFBTEGGNsz549bODAgayyspJpNBo2btw4VlJSYvcavC1KpZLddddd7EplLTvXKGdv/t8GNvMnj7NzjXJ258hUtvWb3YwxxpYvX85SUlKs3lNr/9emTNx0mWVsuMQyNlzq9TzCNjfdVuneQElJCWbOnInAwEAAuoVYCoUCBw8exNy5cw3ndXfrMuC7d+82bAMulUoREhKC/fv3Y+bMmYbVj7NmzUJJSQny8vKQkJCAjIwMAEBWVhYqKiqs2rFnzx68/vrr6OrqQnNzM1JSUvDwww8bbAKAtLQ0pKSkGBaGJSYmorKyEoMHDzZra+zYsYiLiwMAZGRkoKKiAvfcc0+v1+C5ePEizp49ixkPToNKy6DVaBARFY22G61ou9GK8RN0azMee+wxs4VcQjD1CzRaBinFDYK5qcVAWnTC0yYY0Gq1CA0NNWxo0hf8/PwM30ulUsjl8h7nKBQKPPXUUygtLcWQIUPwyiuvGJZOm7YhkUjM2pNIJFCr1XavqVar7V6DhzGGlJQUbN+732xno7YbrfrfC/nrraMxaUPNGKQgMRAK5QzcwMSJE1FUVAS5XI729nZ88cUXCAwMREJCAv773/8C0HWQU6dOAQByc3PxwQcfAAA0Gg1u3LiBCRMmoKioCF1dXejs7MRnn31md9OT4OBgtLe3A4ChU4aHh6OjowNbtmxx+d/Z2zVMbRk2bBgaGhpw5NAhALoXo1y+cB4DQ0IxMCQUhw6UAAA++eQTp20xfXejmjZPcgoSAzcwevRozJ8/H6NGjcIDDzyAMWPGANA97OvXr8eoUaOQkpKC4uJiAMC6deuwZ88epKWlISsrC+fPn8fo0aOxaNEijB07Fjk5OXjiiSeQmZnZ63UXLVqEn//858jIyICfnx+WLl2K1NRU3H///QYbXEloaKjNa5jaotFosGXLFryy8iXM/NFYzJ6UgxNHDgMAXvvrP/D8s08jIyOjT5ufmC52ok1WnYOWMBOi0aJQo7azZwgSHShDWEDvEau9/9ecTy5DqReBnXMSMNhOe0RPyDMgRMOdqxZNwwQVeQZOQWJAeBxXdF2zBCLlDJziphMDiUQClYrq1L0RZ5cwq1QqSCS2H1XGzJc6Uc7AOW46MRg+fDg2btxIgnCTwL+Sffjw4TbPsez7JAbOcdNlWd58800sX74cf//73+m1Zl5Gp0qLNqWmx/EBPlIE+1oflyQSCYYPH2620EvLGH61uwZDgn3w4tjIHmJAOQPnuOnEIDIy0lDNR3gXhedasPZ4Y4/ji1MH4VeZ4Q63c7VNhYM1XQCAF8dGQmMRZ1DOwDluujCB8F4sOy2PULfesrawR5jQf2fLPQqJASEatvq8RuBIbrnsQGvR+VUaEgNnIDEgRMOy0/IIHclNlytrGSPPwEWQGBCiYcszEBomaCwKjCwdAZpNcA4SA0I0bHnvQhN+pn1dpWE9PA5KIDoHiQEhGnynlVk8dbYSi/baAQCltmeYQFOLzkFiQIgG30dlFluUCU0gmo78am3PXASFCc7hETF45513kJKSgtTUVDzyyCNQKBQoLy9HTk4OkpKSMH/+fCiVSk+YRrgRvtNOTwg2Oy404WfmGWgoZ+AqRBeD6upq/PWvf0VpaSnOnj0LjUaDTZs24YUXXsCzzz6Ly5cvY9CgQVi/fr3YphFuhu+08SG+KJmfiDcmRuuOC+y8ZjkDK2EC5QycwyOegVqthlwuh1qtRldXF2JiYrB7927MmTMHAJCfn4+ioiJPmEa4Eb7TSjlggK8UMn3BgNDOq+7hGVjUGZBn4BSii0FsbCyWL1+OoUOHIiYmBiEhIcjKykJoaChkMl11dFxcHKqrq8U2jXAzvHvP1wkYxEBwmGD8Xq1lPVY9UpjgHKKLQUtLC4qLi1FeXo6amhp0dnZix44dDn++oKAA2dnZyM7ORkNDgxstJVwN30f5CkKZ/mtf6gyU2p6eARUdOYfoYrBz504kJCQgIiICPj4+mDVrFg4cOIDW1lbDrrxVVVWIjY21+vlly5ahtLQUpaWliIiIENN0oo8YPQPdz/x25kKrh01nH3R1Bua/p5yBc4guBkOHDsXhw4fR1dUFxhh27dqFkSNHYvLkyYbddQsLCzFjxgyxTSPcjMaQMzAPE4QnEI3nNys0aFGYL4umnIFziL6EOScnB3PmzMHo0aMhk8mQmZmJZcuW4cEHH8SCBQuwcuVKZGZmYsmSJWKbRrgZZhEmSJ0OE4zfv7S/rsfvKWfgHB7Zz2DVqlVYtWqV2bHExEQcOXLEE+YQIqGxkUAUHib0/gHyDJyDKhAJ0bBMIPLhgtCR3N7pSlrC7BQkBoRo8J4BHx7waxTUQj0DO7MFJAbOQWJAiIbRM7CoM+hDzsAaJAbOQWJAiEbPOgNnw4Tez+8mMXAKEgNCNCwrEH308YLQhB95Bu6BxIAQDY2FZ+CnFwOhndfebEK30DXRBAASA0JEtBYJRF+Jk2Jg43R/XlxoatEpSAwI0eD7KGcRJnRrmKDXsduaTfDXT09QzsA5SAwI0TBdwgzoZhNknO7Fq0KmF20N/AEy5zwNQgeJASEalglEwOgdCOnAtlICAeQZ9AkSA0I0NBaeAWBMIgpJ+tkKE8gz6BskBoRo8J6B6X6ovlLdIyjkLUi2wwTyDPoCiQEhGsacgVEN+BkFIR3YvmdAU4vOQGJAiIZlBSIA+DpReGQvZ0BhgnOQGBCiYVyoZFQDP6lwz8BWObKPlIOU081M0J4GwiExIESDGeoMjMecmk2wcaqUM/E0yDsQDIkBIRqWS5gBwM+JKkRbOQMOnNHTIM9AMCQGhGhYLmEGjCO5kM5r61SdZ0B5A2chMSBEw1qdga9TYYL1cyUSzqm6BUIHiQEhGsxKBaJTYmCjn0s55xc/ESQGhIhYLmEGTJcx970CkYNJ2EFiIBgSA0I0LF+iAgA+/EjukpwB59RUJaGDxIAQDcuXqACAnxMJP1ubm0gkxsIjOb1WSTAkBoRoWL5EBXDOrbddZ8AZSpK7VCQGQiExIETD8iUqgHNFQrYqEDkAAT68Z0BhglBIDAjRsLo2wamFSrqvr9wViU+mDzEcl3JAIIUJTkNiQIiGtQSiM5ui8h6Gr5TDsEF+xl+YhgkkBoIhMSBEw9oSZn7fQoWAqUXTdqQmyiJXa008AwoThEJiQIiGtTAhUD+SdwpI+PGzCabtALqkIZ8zoASicDwiBq2trZgzZw6GDx+OESNG4NChQ2hubsbUqVORnJyMqVOnoqWlxROmEW7EWgIx0NB5hecMTD0MQCcofJhAOQPheEQMnnnmGUybNg0XLlzAqVOnMGLECKxZswa5ubkoKytDbm4u1qxZ4wnTCDdi3TPQi4GAzmt4/4LF09upojChL4guBjdu3MC+ffuwZMkSAICvry9CQ0NRXFyM/Px8AEB+fj6KiorENo1wI10qbY+t0gEgSO8ZCAoTrKx+BHSCYhAXChMEI7oYlJeXIyIiAj/96U+RmZmJJ554Ap2dnaivr0dMTAwAIDo6GvX19WKbRriJkupOTPjPFcPWZpy1MEGAZ8DnDKQWOQPTMIFmE4Qjuhio1WocP34cTz75JE6cOIGgoKAeIQHHcWYPjCkFBQXIzs5GdnY2GhoaxDCZ6CPnmxRm6wmkVhKIQkZyy1mJ8bcFAgCmDBlARUd9QHQxiIuLQ1xcHHJycgAAc+bMwfHjxxEVFYXa2loAQG1tLSIjI61+ftmyZSgtLUVpaSkiIiJEs5voAxb90moCUUDnVfOJSP3T+/rEGLw75TYsTgujoqM+ILoYREdHY8iQIbh48SIAYNeuXRg5ciTy8vJQWFgIACgsLMSMGTPENo1wE72tSDSN8R1936KlZxDoI8E9sUHwkXCGhUqUMxCOzBMXfffdd7Fw4UIolUokJibio48+glarxbx587B+/XrEx8dj8+bNnjCt3yJXa9Es1yA22MfTpvSgt23QpRIO/lIOCg2DQs0Q4GM9PDTF2qwEjyHsoDBBMB4Rg4yMDJSWlvY4vmvXLg9Yc3Ow5KsqfN/cjU/z4pEQ4utpc8ywV2oc6COBQqNBp9pYNNQbvLj4WFGDIF/d5ztUGjDGbOaeiJ5QBeJNwvfN3QCAfVWdHrakJ/beYSB0epFf1ORnOZ0A3f4IgTIOaq2w6UqCxMCjKDVaNMrVLm1T4YWJM34kHxMVgLd/FNPj90L3IOCXO/taEQMACPWTAgBaujWCbb2VITFwEMaYy9/h9+rh65j+aQXONSn61I7pyNvphWLAhwk/ThqIyUMH9Ph9kMAZBX7nY19rSQMAof46MWhVeN+98GZIDBzk9wfq8cCnFajtVLmszS9/aIdKy7Dmu+t9aqdNaRwBr3e51tPgKbp8Ax+canI4428KP+D72BjJg310nbfNwZFcafAMrD++vGfQSp6BIEgMHGRreTuaFRq8XdrokvbaTTrwpRalU52M50a3cQSs69SJQYtCg80XW13ymjGNlmHVoesoON2MH24oBX+et8Fawg8ABgfoOm+jwjEh46cqreUMAGAQhQlOYVcM3n333Vt+BaFpRy2tl7ukzSutxk6l1LI+PbimIyAvBs/urcHqIw1Yd7zv4lXVYfSGKtuFe0Z8zsBWjD84QDep1SQX5hnY8jTIM3AOu2JQX1+PMWPGYN68edixY0efRrD+imlpa4dSY3MPPiGYigFg7MTO0KowPvTNCt2U2qkGXR5iT2WH0+3ylLV0G74vd8IzUPYyFQgA4bxn4EAyVa1l0DBdjYHMxqyhMWfgOTFgjOHrinY0uThB7E7sisFrr72GsrIyLFmyBB9//DGSk5Px29/+FleuXBHDPq+gxeShUjPd6PjM7hrs7UNHs3S36/siBiYjoErLXF5wc6nFaKszYtBbXQAAhOs9g0YHPAPDTILE9voVb5hN+NeFVrxQUoeXSurQodSFbN5eIu1QzoDjOERHRyM6OhoymQwtLS2YM2cOVqxY4W77vALLh2r1d9exr7oTz+6tdbrNK6260TYqUNcRavqQmLR0h+tM2uqt+s8RVFqGbeVthp+dEgM7bv1g/UjuyCjabSfkENqeu/jk+1YAwNF6OT441YzVRxqw5dINj9njCHbFYN26dcjKysKKFSswfvx4nDlzBh988AGOHTuG//3vf2LY6HFaLNxN3gUHhG3xbcoVfafiV9y9WdqIi83dvX3EJqYJRAD4/Iqx8zbINU6NSCoNg0KtxRdX2lDdoUaon+5RKW9TCQ4VDTkDF3gGSjs1BgAQGaRr73qXZzwDuUqLepNZnX9d0AnD1TbhQiomdsuRm5ub8emnnyI+Pt7suEQiwZdffuk2w7wJS89AYSIAl1q7kTLYX1B7bd0aNMo18JdyuOu2QHx6Wdd5d1S0Y1iYn51P98TSM9hwvtXs572VnXggIdjh9jpVWvy4uAJNco1hweGKMRF4/WgDWru1aJBrEBnoeCW7/TDBmDNQaZhNDwIwioGtmQTA6G3Vu2ma1R51XWqrr4Cr7UMoKAZ2PYNVq1b1EAKeESNGuNwgb8TSMzDlmBOzC3xIEBfsg0lDBmDGHQMBAIdqupyyjxeDAIuMGr9GYeN5YbNBpxvkaDQRgtgBMtwXH2xoT+j0or3R3F8mQcJAH6gZcMGOd6S042UAQJi/FDJOd1888Wr2ehshX78Xg1ud1482YK1+ei52gHE05EembyuFrwXgs9xh/lLIJBxeyomAn5TDxZZuNDsR5/JiEBNkvmLx1bujMNBXgu+bu3GpxfEQ5Gyj+bm/ygyHVMIhYaBODITmDXjPQNZLB06PCAAAnG7sXVz5KlBbBUeAbr+EcL130OBgqKDSMDQ7WOdgjzq9RzLUYgVpXafwEEtMSAx64VyTAv++YHS5/3RPNCbGBSF2gAwf3R8HmQQ42SA3KyByhBZ9jM9nvf2kEoyO1HWG7+qEewe8GJg+ZlOGBGHkYD/cf7suPPjmquMzH2f15dErxkTg7/fGGtqI13sG1wTGvvaKjgAgPUIXah3Xe1qdKi2utvUsxup2IGcAwBDGOBoq/OXodeT+txyXWrqxYl8t5nx+FXInFzrx15wYF2R2XK5muKH03hkFEoNe+NQk++sr4ZAe7o91k2/DlzMTMGKwPxJCfKFlwLU2YTMBfOflxQAAxsXoEonOhAo39O2lh+s6lL+Uw1uTbgPHcRgTrROZi82Or3/4QV8DMS4mEDl6uwBgiH6kE1p4ZK/oCADu0idSD9V2oVujxXN7a/Dj4qt4oaTOTBDsLVLiidaLgaPl4/8r0+Vt5n95Dd9c7cCVG0ocqHFuBSg/TTwk2Ae/HxeJX2YMxh16Ia1zYTm7KTe6NX1e9NbvxeDDM81Y/FUlzjb2bbGPNfhqw/tvH4D198f1mNceMsC5zmEQA3+jGIyP1XWGPZWdglYearTMMJvwbFY4FqcOwr8eHGr4fVKoLiF5sKbLITeYMWYY2aKDzJOEQ50WA93X3rYqiAnywfAwP8jVDL/cVYMjdbp7/83VDuy61mHI2/S2fNmarVcdEGpbnl3B6WanFqeZ3r9ZySFYkhaGGH2IWdvh+rzBd7VdeODTcsz94qphYHCGfi0Gai3D+yebcOK6Aku/rjLM3buCZrka19pV8JdyeHV8NFLDe84YDAnWqT3fOdRa1muykYfPGQwy8QzuCPVDymA/dKi02H3NcZe+XaUFAxDsK0GInxS/ygw329yEH801DJj3xTW7MWuLQgOVliHEV2LYQownVi9+19pVDt9rxpjd2QSe/JGDAPQs+X5+Xx0WbL2Gbo3WmIy009bt+nvgyHTeRRv5lLJWJf7vjPBSfN4ziAo05gz4fE5fkogXm7utrnD9+FwL5GqG1m4tJm3+ARM2XcEbRxsE5YmAfi4GprXsCg3D/ztr/h/XodTgbKPCLCn3j9NN+NXuamwvb8f/Lt2wWZRzUl9LkB7hb/MhjtN3tILTTXhs2zWM+eQy7tvyA0rtxP3WwgQAmJGkm1UoNqkTsAfv0lu2xSOTcLh9oM7OJoXG7sPIj2qRQT2nDv1lEkMnnPPFNcz94qrB7dUyhsst3T3EhndyZBLY3XVoWkIwHkw0ToGumRBt+P56lxolVZ3G2QQ7ngEvBhX6ZOfpBjmqbHg0pxt6djDesxAizDz8PYwyuYe8l1XX5VyYUFLdiYXbriF/e6VZAlfLWA+vuEOlxb8utGL+l9dw8rrjs139WgyauzWQcMCr46MAANvK2/GHA3WGzv/rvbV4bHsl7t1SjpdKarHzajv+73Qz9ld34bf76/Dad9fx8gHr72c4ob+Jo/RZbmvwo66aAWebug3fL/2mGuP/fRnby9shV2mx51oH/n6qCasO1aNdqbEaJgDAtNuD4S/lcKRObpi+u9jcjT8eqre6xqBLpcWrh3X2jxxsuz7h5buiDN8/+FlFr6Ol4UG2UUfwY71gAcDlViUKz7WgWa7G3042Ye6X1/C3k01m5zsyFWgKX4QFALlDB+AP44y7ZH99tcPhBGK8/v+mrFWJfVUdyN9RhdmfX7V6Lr871MS4IDyfHYHXxkdh88NDMcBHgh9uKAUVg3UoNehQaeEv5RDia+xeBs9AYJjw1+ONuP9/5Xh6dw00TOfhvXq4HpdbutGu1OBMowIdKi0iAqR4cWwExkabP68fnXXcs/HIHoiugjHg3qED8GBCMH6v79Rf/NCOqg4VwvxlOFYvh6+Eg1LLsKOiAzsqdB0qUMYZ6ve3V7TjQrMCaRH+ePmuKHDQjWB8lWFmpO2Cot4KhLrUDL/dX4fYATJUmzwAA3wkhlBikMVoHuwrxUN3DMSWSzfw3olG/Cx9MFYdqsf3zd347HIbpicEY0laGN451oApQwbgix/aUNGmQlKoL36XY31reQDIiAzA4tRBBs9p59UOLEoZBKWGIcBHApWWob1bg8O1XWjV5x9sicFLOZGo7lDhgD7ReapBgWXfVBsqKj8824ImhQaPDA9F8iA/h0MEnnvjg/F9czeyIgMgk3CYmRyC9Ah/zPniGs40KpATrRMLezmDAb5SZET442SDAs/s0ZWNK7UM17vUZgVTN7o1ON2ggI+Ew5/viTZstAIADyUGY9PFG1iw9Rrm3hmCZ7PCodEy/ObbWmRHBWJpepjh3P9duoEPzzRjlP55iQyUmXlCMbxn4GACsUulxR8O1mOXiWcSGSiDRstw4roCc7+8ZnZ+ZmQA5g8LxfxhofjmajtW7KsDAOyrdjwJ2q/FAAByYgLBcRx+mjIIH53TPewnrhvdpkdHhqK2Q43tFe2GY6vujsLoqACs/q4BO691oLxNhfI2FQJkEhys6UJ0oAxnGhWQcECalVwBj6Vr/tfJt6G6Q4W/HDW+3KXaYiT4p75mXcoZHxBTlqaFofhyG/ZUdmKPRQ3DtvJ2bCvX/R37q3WdMTxAir9MjEGwr/UwgWd6QrBBDMpau7H46ypcbunGb3Misf5MM8otEm2WNQumPJcdgfJd1ajpVBv2XjTls8tt+PxKG97PjTVUF/ZWVWiKj4TDc1nm78O4faAvAmQc6jrVhjl8R8TlrUkx+M2uMq2lAAAUyElEQVTeWkPIBwCnGuS4c5Afdl7tQHZ0AOo71WAAhof5mQkBAPwyMxxFl9ug0DD899INlNbLDS76kTo5FqUOgpQDPi1rw5/0G9TU6QecHsnXgT7gAFxsUeJwTSeCfaUY4CtBh0qLlMH+uNGtwQenmvDjpIEYHuaPdccbzYQgQMbhr5Nvg0KjxaIdVWZtjxzsh19lhht+nhofjK0z/fHhmWZ8K2BPTI55cxWEHQIT0vD9qWOI1xfDqLQM68804x+nmxEeIMUTaWGYmTQQUo5Dk0KDQf5SNHSpcZs+EfZdbRd+vrPaZvujIwOw/v64Xm342TdVOFInx5QhQXhr0m1gjOFgTRc0jGHlgXq06+eVp8YPAGPATv1/cFq4PzY8MMRqm+uON+Ljc0b37qHEYDyQEIxf7KoxO0/CAf+aPtThEuaT1+X46VdVds+TcMCnefGG+2qLP313vcfim39OH4KN51vwVUXPsObEY8kO2WmNxV9V4sR1BdLC/XGmUYH8kYPw66xwu59TaRmm/vcHu/P7s5MHYuW4qB7H5315FWUt1sOql8ZGoOhym0EQpZzxPZAPJQbj1fHRZucv/7bWrIMDOlHbOvN2bNZ7FgDwXFY43jvRZAixpicE44m0MENi+G8nm3CqQY4HEoLxo7gBGOTf+0DgKP3aMwj2lZhVeflIOPwsPQyzkkMwyE9qNhrxriEvBIDOq9g5JwEhflL87WQTdl7rgJQDKvSjpCP1/H+ZGINNF1rxyPBQALoQY3ysrtikeEYA1hy5DqWG4ZW7ohAg47BiXx12XuvATJPY25JfZAzGyMF+GBMdiNoOFRJCfOEr5RAeIDUs5lkzIRph/lJBaxnuCDV27iAfCSbEBhpCp/G3BaJJocGF5m7MSg6xKwQAsHB4qJkYLBweipTBunDr5HWFWcFPWB8f2DHRgThxXYEz+mSZox3AR8LhPw8NxYGaLrx62Pb2cncOsn4f7wz1sykGq4/oPECZBHg+OwL3xg/A/C+voVGuQXZUz1zTjKSBPcRApWU4VNuFnVeNnuvbx3QVr2nh/nj5rkjcPtAXUhNP6KmMwTb/jr7Qrz2D7Oxsq+9f6Ct7rnVgf3Unlo+J6DG91lfUWobzTboRTuie/t/VdmH5t7UYEeaHgvt691hs8bv9dajuUOH34yJxR6gfvrnajv3VnXhxTCT8ZbqXmQj5m9efacb7J5tQMDUW2dHG5F9luxLvnWhCTkwgLrV0Y1REgKDFUpYo1Fr8cncNjtXLMXKwHz7IjcVAGzMo1mCMYfQ/Lxt+npk0EJOHDMDTe3Te1vr74jDaSgdukqvx5yPXsftaJ4YG++Cf04egpkONFftq0SBXIzxAhp+lh+HBRJ24q7QMcpXWqm0dSg0m/OcHALpZqsYuNWo6zfNJmZH+KNGHgL/MGIwlaWE92nEXJAb9DLlaC18JZzZSeJpujRZ+vawVcBVaxtAo1yAiQOrUy1GO1nWhpLoTT40aDH+94JVUd+L7JgWWpoX12qaWMWi0juc+bJG5sQyArtR7/G2BmFFsnOH4XU4kJsQG4vl9dRga7IPfjYt0+WDUGyQGBCEipxvkKKnqxLJRg+Ej4ZDzyWVDbuD4o0kefQNUv64zIPof2v1fQ/PMPLB624nbm5n0iAD8IjPcMBuyekI0fCUc3v5RjMdfBUeeASEqmh9n6r4ZNwXSF9/yrDGEGeQZEJ5B6bp1JIRr8JgYaDQaZGZm4qGHHgIAlJeXIycnB0lJSZg/fz6USu/eL47oI/R2ZK/DY2Kwbt06s23TXnjhBTz77LO4fPkyBg0ahPXr13vKNEIMSAy8Do+IQVVVFbZu3YonnngCgG4OePfu3ZgzZw4AID8/H0VFRZ4wjRANEgNvwyNi8Otf/xqvv/46JBLd5ZuamhAaGgqZTFclGBcXh+pq69nmgoICZGdnIzs7Gw0NDVbPIfoBpAVeh+hi8OWXXyIyMhJZWVlOfX7ZsmUoLS1FaWkpIiIi7H+A8E4oTPA6RF+bcODAAXz++efYtm0bFAoF2tra8Mwzz6C1tRVqtRoymQxVVVWIjY0V2zSCuKUR3TNYvXo1qqqqUFFRgU2bNmHKlCn45JNPMHnyZGzZsgUAUFhYiBkzZohtGiEq5Bl4G15TZ/CXv/wFb7/9NpKSktDU1IQlS5Z42iTCnVCY4HV4dAnzpEmTMGnSJABAYmIijhw54klzCDHhODDGPF6CSxjxGs+AuPlhapPdlA7vhnbhRLBT33nOIMIMEgNCPFQWVaVdHdD++deesYXoAYkBIR7dVtYjdLv+5TeEc5AYEOKhosVJ3gyJASEetPjMqyExIMRDSSGBN0NiQIiHZQKR8CpIDAjxoA1NvBoSA0I8bIgBoxkFr4DEgBAPWwnE9hvWjxOiQmJAiAazNbXY2W79OCEqJAaEeGg01o9TYtErIDEgxENrQwzUwsSAMQbtOyuh/fffXWAUwUNiQIiH1sabkFUq68dtUXMN7NutYP/5R99tIgyQGBDiYVMMBIYJzHo7rKEOTCEXaBTBQ2JAiIdGbf24UDGQ9HxsWUMdtEsfgPYp2iHLWUgMCPGw4RkwoWECZ3xsmb5NdvGU7kAz7ZjtLCQGhHi4KkwwbYffMKX/vjLUayAxIMTDRbMJ0JqEGyQGLoPEgBAPV80mmNYr8F4FaUGfITEgxMOWZyA0TDAVA7W6R9vMVnET0SskBoR4uKoC0ZpnYLpXAq2OdAoSA0I8bIUJahtTjjbbsSIGpisfaRMVpyAxIMTDLWGCPt/QTZ5BXyExIMTDZVOLpp6BXgxMKw9pfwSnIDEgxMPm1GIfZhPIM3AZJAaEePCegWU5seAwwSTHYMgZmHgGlDNwChIDQjx4z8DH1/y4K2YTTD0DChOcgsSAEA++E/v6mR8XWnRkVo6s8xLM9lG09uYmwi6ii0FlZSUmT56MkSNHIiUlBevWrQMANDc3Y+rUqUhOTsbUqVPR0tIitmmEu9F3Ym5Knu5nmQ8AgAlOIBrDBMaXMpskEBnlDJxCdDGQyWR46623cP78eRw+fBjvv/8+zp8/jzVr1iA3NxdlZWXIzc3FmjVrxDaNcDd8mBAdB8mmg5C8+JbuZ6E7HWmszCYoKUzoK6KLQUxMDEaPHg0ACA4OxogRI1BdXY3i4mLk5+cDAPLz81FUVCS2aYS7MSQQpeD8AwAfnWfQp7UJVjwDSiA6h8yTF6+oqMCJEyeQk5OD+vp6xMTEAACio6NRX19v9TMFBQUoKCgAADQ00Nr1foXlbIJMn0jsSwLx4hmw+GSaWnQBHksgdnR0YPbs2Vi7di0GDhxo9juO48BxnNXPLVu2DKWlpSgtLUVERIQYphKugg8TJFLdVx8nxcA0Z7CzCNoVjwPyTuPvSQycwiNioFKpMHv2bCxcuBCzZs0CAERFRaG2thYAUFtbi8jISE+YRrgTS8/A2TDBWiVjR5vxe8oZOIXoYsAYw5IlSzBixAg899xzhuN5eXkoLCwEABQWFmLGDNrL7qaDLxaSWngGfalA5DH1LkgMnEL0nMGBAwewceNGpKWlISMjAwDw5z//GS+++CLmzZuH9evXIz4+Hps3bxbbNMLNMJMEIgDAR19vINStt7dfAe2Q7BSii8E999wDZmOLql27dolsDSEqfJ0BHyb4++u+dgvsvLZ2WeZRdAk0jACoApEQE8sEon+g7qvQkdzWgic9TKi4EABIDAgxsUwg+voBHAeolGD2RntTKExwCyQGhHgYPAPdY8dxnHPegR3PQHDYQQAgMSDERKP3DPjZBADwD9B9FdKB7XkGchIDZyAxIMTDMmcAGMVASAe2JwbkGTgFiQEhHtbEwM+FnoFMPzlGOQOnIDEgxMPaTkcB+pyBXMB0oNZGsjFIX9ZOnoFTkBgQ4sF7BlKTx86VnkFQsO6rQm4scCIchsSAEA/LCkTAmDMQUihkq6P7+gG++kImWqwkGBIDQjw0PcMETi8GTEicb8sz8PE1VjVS3kAwJAaEeBgSiCZV8AbPQMDiIlsFSjIf58IOAgCJASEmFkVHAEyKjoSECbZmE3ycS0gSAEgMCDHhY313JRB9ZOQZ9AESA0I8rNUZODOS26wz8AECg3Tfd3UIt+8Wx6N7IBK3GFYSiAjQd17TbcvswHoJEziZLxgA1tkO6xvnEbYgMSDcDmuoA/vkPaC+SnfA1DPQ1wawznbHG7ThGXCmCUTTbdAIh6AwgXA7bGcR2N6txgOmU4t8oZCQzttbAnHAQOHtEQBIDAgxUFkUAJmuWuQ7rxOeATf3CXBTZ5r/bgAvLgLaIwCQGBBiYLnhqVmYMED3tVNAwk9fZ8ClZkHyiz8YjysVJuJCnoFQSAwI92O5PNk0gciHCUI6r8ZK8RIAplQacxAUJgiGxIBwP5Zz/lYSiOhst7lRbg+0VjZJAQBlN7ggJ8IOAgCJASECzLK60DSBKPPRlSRrtY5XIfJLmCUWj69pmEA5A8GQGBDup0eYYDGiC51R4AuU+BoFHmW3SQ6CwgShkBgQ7qdHmGDx2Al17dtv6L4Gm7+jE8puYECI+TmEw5AYEO7H0v23jPUFeAaMMWNH50XkzjQAAJcxThcmyHyArg5hy6IJqkAkRMCyU1qGCSGDAACstcl+CXG3QjdV6esPzk+3d4Fk5TqwoyXg7pmqe1tTeDRQVwk01gFxCa75G24ByDMg3I+FZ8Bx5l2eC4/WfdNYb78tKyECN3AQJLl54PhS5PAo3deGOqfMvVUhMSDcj72NSyL0YtBQa7+tDr0Y8LkBK3D69lgjiYEQvEoMduzYgWHDhiEpKQlr1qzxtDmEC2AajW7Krxd4z4AJ8QwGDLR9jhBPgzDgNWKg0Wjwi1/8Atu3b8f58+fx73//G+fPn/e0WURfcWSTEYNn4MBIznsGwbY9A4MY1FXab48w4DUJxCNHjiApKQmJiYkAgAULFqC4uBgjR460/aFuBdjl/isYrK4KqL0GLm2MLgN+M8KP5IPCwU2ba70T8zF++QWwc8eMy5CtwMovAQC4XsSAG5Gh29Pg2H6wsnO6l7vewnBJvfQhE7xGDKqrqzFkyBDDz3Fxcfjuu+96/1DlD9AuX+hmy9yPg0W4/Rv/AEjmL7P+u9Bw4LahQM01aH/3hGPt9ZYzGHoHcHsyUFEG7fOPOmHszYW06IRD53mNGDhKQUEBCgoKAABnFVrkVEntfEIcGhoaEBER4WkzAHipLVU1QHa2nbMF/F++u1H3T2B7Xnlv3Ez4tGnYsWOH3fO8RgxiY2NRWWmM8aqqqhAbG9vjvGXLlmHZMt0Ik52djdLSUtFs7A2yxTreZAvgXfZ4ky2AFyUQx4wZg7KyMpSXl0OpVGLTpk3Iy8vztFkEccvgNZ6BTCbDe++9h/vvvx8ajQaLFy9GSkqKp80iiFsGrxEDAJg+fTqmT5/u8Pl8uOANkC3W8SZbAO+yx5tsAQCOObyjBEEQNzNekzMgCMKz9Fsx8HTp8u233460tDRkZGQgWz9l1tzcjKlTpyI5ORlTp05FS0uLW669ePFiREZGIjU11XDM1rUZY3j66aeRlJSE9PR0HD9+3O22vPLKK4iNjUVGRgYyMjKwbds2w+9Wr16NpKQkDBs2DF999ZVLbamsrMTkyZMxcuRIpKSkYN26dQA8c29s2eKpe+MQrB+iVqtZYmIiu3LlCuvu7mbp6ens3LlzotoQHx/PGhoazI49//zzbPXq1YwxxlavXs1WrFjhlmt/++237NixYywlJcXutbdu3cqmTZvGtFotO3ToEBs7dqzbbXn55ZfZG2+80ePcc+fOsfT0dKZQKNgPP/zAEhMTmVqtdpktNTU17NixY4wxxtra2lhycjI7d+6cR+6NLVs8dW8coV96Bqaly76+vobSZU9TXFyM/Px8AEB+fj6Kiorccp2JEyciLCzMoWsXFxfj8ccfB8dxGDduHFpbW1Fb68DqwD7YYovi4mIsWLAAfn5+SEhIQFJSEo4cOeIyW2JiYjB69GgAQHBwMEaMGIHq6mqP3BtbttjC3ffGEfqlGFgrXe7tRrsDjuNw3333ISsry1ARWV9fj5iYGABAdHQ06uvFWzVn69qeulfvvfce0tPTsXjxYoNbLqYtFRUVOHHiBHJycjx+b0xtATx/b2zRL8XAG9i/fz+OHz+O7du34/3338e+ffvMfs9xXI9NPMTCk9cGgCeffBJXrlzByZMnERMTg9/85jeiXr+jowOzZ8/G2rVrMXCg+VJnse+NpS2evje90S/FwNHSZXfbAACRkZGYOXMmjhw5gqioKIObWVtbi8jISNHssXVtT9yrqKgoSKVSSCQSLF261ODuimGLSqXC7NmzsXDhQsyaNctgjyfujS1bPHVv7NEvxcDTpcudnZ1ob283fP/1118jNTUVeXl5KCwsBAAUFhZixowZotlk69p5eXnYsGEDGGM4fPgwQkJCDC6zuzCNuz/77DPDTENeXh42bdqE7u5ulJeXo6ysDGPHjnXZdRljWLJkCUaMGIHnnnvOcNwT98aWLZ66N44a3S/ZunUrS05OZomJiey1114T9dpXrlxh6enpLD09nY0cOdJw/cbGRjZlyhSWlJTEcnNzWVNTk1uuv2DBAhYdHc1kMhmLjY1lH374oc1ra7Va9tRTT7HExESWmprKjh496nZbHn30UZaamsrS0tLYww8/zGpqagznv/baaywxMZHdeeedbNu2bS61paSkhAFgaWlpbNSoUWzUqFFs69atHrk3tmzx1L1xBKpAJAgCQD8NEwiCcD0kBgRBACAxIAhCD4kBQRAASAwIgtBDYkAQBAASA4Ig9JAYEH3m6NGjSE9Ph0KhQGdnJ1JSUnD27FlPm0UIhIqOCJewcuVKKBQKyOVyxMXF4aWXXvK0SYRASAwIl6BUKjFmzBj4+/vj4MGDkEq94+U2hONQmEC4hKamJnR0dKC9vR0Ke69gJ7wS8gwIl5CXl4cFCxagvLwctbW1eO+99zxtEiEQr3pvAtE/2bBhA3x8fPCTn/wEGo0Gd999N3bv3o0pU6Z42jRCAOQZEAQBgHIGBEHoITEgCAIAiQFBEHpIDAiCAEBiQBCEHhIDgiAAkBgQBKGHxIAgCADA/wc+obDR+HeRswAAAABJRU5ErkJggg==' style='max-width:100%; margin: auto; display: block; '/>
+<div id='140059227041920' style='display: table; margin: 0 auto;'><img src='data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAP8AAAD2CAYAAAAZB1ECAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4xLjEsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy8QZhcZAAAgAElEQVR4nO2deXwU9f3/X7O7uU9CTghgYiKEHCQkEBBBDlG0NcitBQ0FoVVbqxaptraitQWPWrAebSo/DZR+qVIlKofKYYlcIVxyEyCB3HfItZs95vP7Y3f2ym72yO5sQt7Px4NHwmR25p3JvOZ9fN6fz3CMMQaCIAYcEk8bQBCEZyDxE8QAhcRPEAMUEj9BDFBI/AQxQOnX4p81a5anTSAcJGNzCTI2l+Cl72s8bcqAp1+Lv6GhwdMmEE7SpNB42oQBT78WP9F/oeYSz0PiJzwCT71lHofET3gE0r7nkXnaAFdTV1eHVatW4eLFi+B53tPmEGbUdagAAN9KJMjyk9rcXyKRYNSoUXjrrbcQGRnpbvMGFLec+FetWoVp06Zh48aN8PLy8rQ5hBnnGxUAAH+ZBLeFeNvcX6VSYfPmzVi1ahU2bdrkbvMGFLdc2H/x4kUsWbKEhH+L4OXlhUcffRQXL170tCm3HLec+HmeJ+HfYnh5eVEK5wZuOfET/QOq93ket4l/2bJliIyMREpKin5bU1MTZs6cicTERMycORPNzc0AAMYYnn76aSQkJCAtLQ0nTpxwl1kEQehwm/iXLl2K3bt3m2xbt24dZsyYgZKSEsyYMQPr1q0DAOzatQslJSUoKSlBXl4ennjiCXeZJTqMMQpZLaDmGRrkaqh5igE8hdvEP2XKFISFhZlsKygoQG5uLgAgNzcX27dv129/7LHHwHEcJkyYgJaWFlRXV7vLNLdTVlaGpKQkPPnkkxg7diyWL1+OrKwsJCcn4+WXXwYAFBUVYe7cuQC0v7+fnx+USiUUCgXi4+M9ab4oqHiGuk41qtpVnjZlwCLqUF9tbS1iYmIAADExMairqwMAVFZWYtiwYfr9YmNjUVlZqd/XmLy8POTl5QEA6uvrezxfxuYSV5luwslHE23uc+nSJXz00Ud4//330dTUhLCwMGg0GsyYMQM//PADxo4di5MnTwIACgsLkZKSgmPHjkGtViM7O9stdvdF2lUUFXmKPlHws7SMIMdxFvdduXIliouLUVxcjIiICHeb5jQjRozAhAkTAACffPIJxo4di4yMDJw7dw7nz5+HTCZDQkICLly4gKKiIjz33HM4cOAACgsLMXnyZA9bTwwERPX8UVFRqK6uRkxMDKqrq/UdW7GxsSgvL9fvV1FRgSFDhvT6fPZ4aHcREBAAACgtLcVbb72FY8eOYdCgQVi6dCkUCm2jy+TJk7Fr1y54eXnhnnvuwdKlS6HRaPDWW295zG53QmvF9i1E9fw5OTnIz88HAOTn52P27Nn67Zs2bQJjDEeOHEFISIjFkL8/0traioCAAISEhKC2tha7du3S/2zKlClYv349Jk6ciIiICDQ2NuLixYtITk72oMXug6Tft3Cb53/kkUfw3XffoaGhAbGxsXjllVfwwgsvYOHChdi4cSOGDx+OTz/9FADwwAMPYOfOnUhISIC/vz8++ugjd5klOmPGjEFGRgaSk5MRHx+PSZMm6X+WnZ2N2tpaTJkyBQCQlpaGyMhIqylPf8ea4+cZg+QW/Z37Mlx/Xrc/KysLxcXFNrcRfQM1z3C5uavb9oRQb3hLew5C6e/qevpEwY8YGFjzMzTU7xlI/IRoWNO4K7QvV/N4bFc53jvV6IKjDQxI/IRoWEswXZF4br/SijMNCnx4pqn3BxsgkPgJ0XBndH+uQeHGo9+akPgJ0bDq+V3wWLjY1L2QSPQMiZ8QDas5vwtCgkqaI+AwJH4RWLNmjShdex9//DGqqqpcdrw777zTpbZYq/YLW8vKykymgBPuhcR/C+Fq8R86dMiltrgz55dQj5DDkPjdxJ/+9CeMHDkS99xzDy5dugQAuHr1KmbNmoXMzExMnjxZvy5dbW0t5syZgzFjxmDMmDF60b399ttISUlBSkoK1q9fD8AwXXjFihVITk7GvffeC7lcjm3btqG4uBiLFy9Geno65HI5Xn31VYwbNw4pKSlYuXKl3vNOnToVzz77LKZMmYKkpCQcO3YMc+fORWJiIl566SX97xAYGAgA+O677zB16lTMnz8fo0aNwuLFi/XHsnQOS7YcP34cs+6ZhgXT78SKBQ+ivkY7ZfvcqRO4M2ssJk6ciPfee8/p600dgk7A+jGZmZk9blPPTnfLP1sUFxezlJQU1tHRwW7evMluv/129uabb7Lp06ezy5cvM8YYO3LkCJs2bRpjjLGFCxeyv/71r1qb1WrW0tKiP0Z7eztra2tjo0ePZidOnGClpaVMKpWykydPMsYYW7BgAdu8eTNjjLG7776bHTt2TG9HY2Oj/vslS5awL774Qr/f6tWrGWOMrV+/nsXExLCqqiqmUCjY0KFDWUNDA2OMsYCAAMYYY/v372fBwcGsvLycaTQaNmHCBFZYWGjzHIItSqWSTZw4kV0tr2bnGuTsrX9uYnN+8hg71yBnd4xOYV99s5cxxtiqVatYcnKyxWtq6W9tzJStV1j6psssfdPlHvcjDNxyS3f3BQoLCzFnzhz4+/sD0E5cUigUOHToEBYsWKDfr6tLW6Het2+ffllqqVSKkJAQfP/995gzZ45+duDcuXNRWFiInJwcxMXFIT09HQCQmZmJsrIyi3bs378fb7zxBjo7O9HU1ITk5GQ8+OCDepsAIDU1FcnJyfqJVPHx8SgvL8fgwYNNjjV+/HjExsYCANLT01FWVoa77rqrx3MIXLp0CWfPnsXsH82CimfgNRpEREWjrfUmWm+24K4pdwMAHn30UZOJT45g7Pc1PIOU8gCb3NLil24/6bFzm0/O4XkeoaGhOHXqlF2fZz2UwH18fPTfS6VSyOXybvsoFAo8+eSTKC4uxrBhw7BmzRr9VGLjY0gkEpPjSSQSqNVqm+dUq9U2z2H8uyQnJ2PXd9+brNzTerMFHMe5pNqvMTqGmjFIQeK3BeX8bmDKlCn4/PPPIZfL0dbWhi+//BL+/v6Ii4vTz2RkjOH06dMAgBkzZuCDDz4AAGg0GrS2tmLKlCnYvn07Ojs70dHRgc8//9zmIh9BQUFoa2sDAL0Iw8PD0d7ejm3btrn89+zpHMa2jBw5EvX19Sg6fBiA9kUcVy6eR3BIKIKCQ3D4YCEAYMuWLU7bYvzuPzUtDmQXJH43MHbsWCxatAjp6emYN2+eXrRbtmzBxo0bMWbMGCQnJ6OgoAAAsGHDBuzfvx+pqanIzMzEuXPnMHbsWCxduhTjx49HdnY2Hn/8cWRkZPR43qVLl+LnP/850tPT4ePjgxUrViA1NRUPPfQQxo0b5/LfMzQ01Oo5jG3RaDTYtm0b1rz0IubcPR7zpmbjZNERAMBr7/wDzz/7NCZOnAg/Pz+nbTGeHESLgtoHTeklRKNZoUZ1R/eUItpfhjC/njNQW3/X7C1XoNSJfs/8OAy2cTyCPD8hIu6c1Wcc9qvI89sFiZ/wOK6QqknBj3J+u7jlxC+RSKBSUZ93X8TZKb0qlQoSifVblTHTqUGU89vHLSf+UaNGYfPmzfQAuEUQXtE9atQoq/uYa53Ebx+3XFXkrbfewqpVq/D3v/+dXpPVx+hQ8WhVarptD/SSIsjbsh+SSCQYNWqUycQonjH8cl8VhgV54YXxkd3ETzm/fdxy4o+MjNR3yxF9i/xzzVh/oqHb9mUpg/DLjHC7j3O9VYVDVZ0AgBfGR0JjljdQzm8ft1zYT/RdzEUq4GiYbt671y3s77+j16JC4idEw5rGNQ56avO2fd5M7CoNid8eSPyEaJiLVMBRT208fZdnjDy/k5D4CdGw5vkdDfs1Zg095o6eqv32QeInRMNaNO5ogc5Y2yoN6xZRUMHPPkj8hGgIIpWZ3XXWCoG2jgMASr572E9DffZB4idEQ9CkzGytA0cLfsaeXc13ryVQ2G8fJH5CNASRPhAXZLLd0QKdiefXUM7vLB4R/1//+lckJycjJSUFjzzyCBQKBUpLS5GdnY3ExEQsWrQISqXSE6YRbkQQ6YgQbxQuisebU6K12x0Uq0nObyHsp5zfPkQXf2VlJd555x0UFxfj7Nmz0Gg02Lp1K37zm9/g2WefRUlJCQYNGoSNGzeKbRrhZgSRSjkg0FsKmW7A3lGxqrt5frNxfvL8duERz69WqyGXy6FWq9HZ2YmYmBjs27cP8+fPBwDk5uZi+/btnjCNcCNCuC6M0+vF73DYb/hezbNuswIp7LcP0cU/dOhQrFq1CsOHD0dMTAxCQkKQmZmJ0NBQyGTaqQaxsbGorKy0+Pm8vDxkZWUhKysL9fX1YppO9BJBk0KHnkz3tTfj/Eq+u+enJh/7EF38zc3NKCgoQGlpKaqqqtDR0WFxuWbz1W8FVq5cieLiYhQXFyMiIsLd5hIuxOD5tf8Xltd2tBvXeHRAO85v+nPK+e1D9Fl9e/bsQVxcnF64c+fOxaFDh9DS0gK1Wg2ZTIaKigoMGTJEbNMIN6PR5/ymYb/jBT/D/k2K7lOEKee3D9E9//Dhw3HkyBF0dnaCMYa9e/di9OjRmDZtmn7p5/z8fMyePVts0wg3w8zCfqnTYb/h+xe/r8HP9pimiJTz24fo4s/Ozsb8+fMxduxYpKamgud5rFy5Eq+//jrefvttJCQkoLGxEcuXLxfbNMLNaKwU/BwP+3v+AHl++/DIYh6vvPIKXnnlFZNt8fHxKCoq8oQ5hEiYF/yE8N9RT21rdyVN6bUL6vAjREPw/EK4L/T4qx31/Daq+SR++yDxE6Jh8Pxm4/y9yPktQeK3DxI/IRrdx/mdDft73r+LxG8XJH5CNMw7/Lx08b+jBTry/K6BxE+IhsbM8/voxO+oWG1V+7scnSM8QCHxE6LBmxX8vCVOit/K7r7Cw4SG+uyCxE+IhqBJzizs79IwOPKyaGvVfl/d8AHl/PZB4idEw3hKL6Ct9ss47Ys6HRnus+bY/WTORRIDFRI/IRrmBT/A4P0dEay1lN6PPL9DkPgJ0dCYeX7AUPRzpEhnLewnz+8YJH5CNATPbzxb21uqvQUdecuO9bCfPL8jkPgJ0TDk/Ab1CxV/RwRr2/PTUJ89kPgJ0TDv8AMAbycafWzl/BT22weJnxANw8Qeg/p9pI57fmvtvV5SDlJOO3JAc/ptQ+InRIPpx/kN25yq9lvZVcoZRRLk/W1C4idEw3xKLwD4ONHlZy3n58AZIgny/DYh8ROiYT6lFzB4akfEam1XreenvN9eSPyEaFga5/d2Kuy3vK9EwjnVNzBQIfETosEsdPg5JX4rupZyzk8WGoiQ+AnRMJ/SCxhP6+19hx8HozSCxG8TEj8hGuYv7QAAL8FTuyTn55waOhyokPgJ0TB/aQcA+DhRoLO2mIdEYmj0kdNre2xC4idEw/ylHYBzYbr1cX5O3+LbqSLx24LET4iG+Us7AOeacqx1+HEA/LwEz09hvy1I/IRoWOztd2pij/brmomR2PLAMP12KQf4U9hvNyR+QjQsFfycWcRTiCC8pRxGDvIx/MA47Cfx24TET4iGpSm9wrp7CgeG+oyPIzV6ksjVvJHnp7DfFiR+QjQshf3+Ok/d4UCBTqj2Gx8H0Bb5hJyfCn62IfETomGp4OevF6vjOb9xBAFoHyBC2E85v208Iv6WlhbMnz8fo0aNQlJSEg4fPoympibMnDkTiYmJmDlzJpqbmz1hGuFGLHt+nfgdEKt+/X+zu7dDRWG/I3hE/L/61a8wa9YsXLx4EadPn0ZSUhLWrVuHGTNmoKSkBDNmzMC6des8YRrhJjpVfLeluwEgQOf5HQr7LcwOBLQPEP3DhMJ+m4gu/tbWVhw4cADLly8HAHh7eyM0NBQFBQXIzc0FAOTm5mL79u1im0a4icLKDkz+z1X9Ul2cpbDfAc8v5PxSs5zfOOynar9tRBf/tWvXEBERgZ/+9KfIyMjA448/jo6ODtTW1iImJgYAEBMTg7q6Ooufz8vLQ1ZWFrKyslBfXy+m6YSTnG9UmPTjSy0U/Bzx1OajBpOG+AMApg8LpCYfBxBd/Gq1GidOnMATTzyBkydPIiAgwKEQf+XKlSguLkZxcTEiIiLcaCnhMsx0aLHg54BY1ULhUHf3vjElBn+bPgTLUsOoyccBRBd/bGwsYmNjkZ2dDQCYP38+Tpw4gaioKFRXVwMAqqurERkZKbZphJvoacaecY5u7/v6zD2/v5cEdw0NgJeE00/soZzfNqKLPzo6GsOGDcOlS5cAAHv37sXo0aORk5OD/Px8AEB+fj5mz54ttmn9GrmaR2WbytNmWKSnZbmlEg6+Ug4MgMJO729p1EBAn0ZQ2G8TmSdO+re//Q2LFy+GUqlEfHw8PvroI/A8j4ULF2Ljxo0YPnw4Pv30U0+Y1m9Z/nUFLjR14bOcEYgL8fa0OSbYat3195JAodGgQ21o0ukJ4WHiZUH9Ad7az7erNGCMmRQXCVM8Iv709HQUFxd32753714PWHNrcKGpCwBwoKKjz4nf1hr6AV4SNCk06FDxCPezfTxhEpCPebkf2vUB/GUcOtUMHSoegd5Sp2weCFCHnwdRang0yNUuPaaiDxa6BE89LsoPb98d0+3njs7BF6b/elsQPwCE+mgF39ylcdjWgQSJ304YYy5/B9wfj9Thgc/KcK5R0avjGHvWjj4ofiHsfyghGNOGB3b7eYCDFX9hZV5vS0k/gFBfrfhbFH3vWvQlSPx28vuDtbj/szJUd7iuqPbVtTaoeIZ1Ry33NNhLq9Lg4eo6XRtJCGy/chMfnG60uyJvjODQvax46iAvrVhb7fTUSr3nt3z7Cp6/hTx/j5D47WRHaRuaFBq8XdzgkuO1GQn2crPSKVEJ3OwyeLiaDq34mxUafHKpxSWvrdLwDK8crkPeD024dlPp8OcFGywV6ABgsJ9WrA0K+x5cwtChpZwfAAZR2G8XJH47MBZmca3cJce82mIQkZJnvbpRjT2cIP5nv6vC2qJ6bDjR+4dVRbsh2il3YjhRyPmt5eiD/bR150a5Y57fWiRBnt8+bIr/3XffHfAz7IxbRduVGqtryDmCsfgBg2idoUVhuMmbFNohrtP12jrC/vJ2p48rUNLcpf++1AnPr+xhaA4AwgXPb0fxU80zaJh2jF9mZRTPkPN7TvyMMXxT1oZGFxd0XYlN8dfU1GDcuHFYuHAhdu/e3avwtL/SbHQTqZnW+/1qXxW+64WwzMPn2t6I38jDqXjm8gaXy80GW50Rf0/j8gAQrvP8DXZ4fn2lX8JZHcPvC9X+f19swW8Ka/BiYQ3aldoUrK+1HNsU/2uvvYaSkhIsX74cH3/8MRITE/Hb3/4WV69eFcO+PoH5TbT2aB0OVHbg2e+qnT7m1RatN43y1974Vb0oJJqHtzVGx+qpu84eVDzDztJW/f+dEr+NMH2wzlPb4yW7bKQQjh7PXWy50AIAOFYrxwenm7C2qB7bLt/0mD2WsCvn5zgO0dHRiI6OhkwmQ3NzM+bPn4/Vq1e7274+QbNZ+CiE1IDz74G/qhORMCPtreIGXGrq6ukjVjEu+AHAF1cNYq2Xa5zyOCoNg0LN48urrahsVyPUR3urlLaqHI7+9Dm/Czy/0sYYPwBEBmiPV9fpGc8vV/GoNRp1+fdF7YPgeqvjD053YlP877zzDjIzM7F69WpMmjQJZ86cwQcffIDjx4/jv//9rxg2ehxzz68wEvzlFscF29qlQYNcA18ph4k68QPA7rI2p+wz9/ybzreY/P+78g6Hjteh4vHA56W48/+u4o9HtMOQq8dFINRHgg4Vj3o7C3MCtsN+Q85v62Gq7KG7T0CIpmrdNOxpi5pOtcVXilX3IrVzBzbF39DQgM8++wxff/01FixYAC8vL+0HJRJ89dVXbjewL2Du+Y057kT1XwjxY4O8MHVYIGbfHgwAOFzV6ZR9gvj9zCpgQpvv5vOOFWx/qJejQa7Rz8QdGijDvSOC9MdzdLjPlrf2lUkQF+wFNQMu2oh+lDaiCAAI85VCxmmviyde1V1rJYXrd+J/9dVXMWLECIs/S0pKcrlBfY03jtVjvW64bGigYSqE4Hn+56BXBQxV6DBfKWQSDi9mR8BHyuFScxeanMhTBfHHBHiZbP/jnVEI9pbgQlMXLjfbH6GcbTDd95cZ4ZBKOMQFa8XvaN4veH5ZD4JNi9A29f/Q0PPDVOiytNbgA2jXCwjXef96O0N/lYahyc4+A1vU6CKO4UGmf4+aDsdTJndC4/w9cK5Rgf+7aAih/3RXNKbEBmBooAwf3RcLmQQ4VS83adixh2Zdji5UpX2kEoyN1N78R2sc9/6C+I1vq+nDAjB6sA/uuy0IAPDtdftHJs7q2o1Xj4vA3+8Zqj/GCJ3nv+Fg7mqryQcA0iJ8AQAndJFUh4rH9dbuzU9dduT8ABDpYOj/+rE6zPi0FJebu7D6QDXmf3EdcifXBBDOOSU2wGS7XM1wU9l3Kv4k/h74zKg66y3hkBbuiw3ThuCrOXFIGuyLuBBv8Ay40epYpV4QqyB+AJgQo839nQn9b+qOlxauFZCvlMNfpg4Bx3EYF619qFxqsn/+wDVdD8KEGH9kxxhqEsN0nszRRh9bTT4A9LWPw9Wd6NLweO67KjxUcB2/KawxeQDYmtQjEK0Tv73t2P8t0RZJF311A99eb8fVm0ocrHI8qgMMw7bDgrzw+wmR+EX6YNyue3DWuLA93JibXRqHJ4n1e/F/eKYJy74ux9mG3k2OsYTQzXffbYHYeF9st3HlYYHOiUEvfl+D+CcN1d78+8s7HJqZp+GZvtr/bGY4lqUMwr9/NFz/84RQ7eusDlV12hXWMsb0nis6wHTG93Cnxa/92tNU/ZgAL4wK84FczfCLvVUoqtFe+2+vt2PvjXZ93aWn6byWbL1ux4PZWuSW90OTU5O5jK/f3MQQLE8NQ4wuZaxud33ef7S6E/d/VooFX17XOwJ76NfiV/MM751qxMk6BVZ8U6EfO3cFTXI1brSp4Cvl8MdJ0UjReVVjhgVpn+aCGNQ867E4KCDk/IOMPP/toT5IHuyDdhWPfTfsD9HbVDwYgCBvCUJ8pPhlRrjJfH7BW2sYsPDLGzZzzmaFBiqeIcRbol8SS2Co7mF3o01l97VmjNms9gvkjh4EoHsL9fMHavDwjhvo0vCG4qGNY92muwb2DK9dslIPKWlR4p9nHO9uFTx/lL8h5xfqMb0p+l1q6rI4A/Tjc82QqxlaunhM/eQaJm+9ijeP1dus8/Rr8Rv3gis0DP/vrOkfql2pwdkGhUkR7R8/NOKX+yqxq7QN/71802oTzCndWH5ahK/VmzZWJ6y8Hxrx6M4bGLflCu7ddg3FNvJ2S2E/AMxO0Fb9C4zG6W0hhOjmxxKQSTjcFqy1s1GhsXnzCV4rMqD7Oi++MoledPO/vIEFX17Xh7E8Y7jS3NXt4SIEMTIJbK6qMysuCD+KD9L/f93kaP33dZ1qFFZ0GKr9Njy/IP4yXXHyh3o5KqxELD/UdxeUEDk48iAWEK5hlNE1FKKomk7nwv7Cyg4s3nkDubvKTQquPGPdot52FY9/X2zBoq9u4FSd9QJqvxZ/U5cGEg7446QoAMDO0jb84WCNXuzPfFeNR3eV455tpXixsBp7rrfhnz804fvKTvz2+xq8drQOLx+stXjsk7qLNibC+tIygldVM+BsY5f++xXfVmLS/13BrtI2yFU89t9ox99PN+KVw7VoU2oshv0AMOu2IPhKORTVyPXDaZeauvDq4VqLPfqdKh5/PKK1f/Rgn24/F3h5YpT++x99XtajN9TfuP6WF3l6SPeAAoArLUrkn2tGk1yN9081YsFXN/D+qUaT/e0ZmjNmklHfw4zhgfjDBMNCrt9cb7e74DdC97cpaVHiQEU7cndXYN4X1y3ue6BCm9tPiQ3A81kReG1SFD55cDgCvSS4dlPpUPNVu1KDdhUPXymHEG+DvPSe38Gw/50TDbjvv6V4el8VNEwbwf3xSC2uNHehTanBmQYF2lU8IvykeGF8BMZHm96vH521Hrl4ZBkvV8EYcM/wQPwoLgi/14n4y2ttqGhXIcxXhuO1cnhLOCh5ht1l7dhdphWQsMwTAOwqa8PFJgVSI3zx8sQocNB6KKGLLyOye7gvMDLMuuA61Qy//b4GQwNlqDT6gwd6SfSpwSAzbx3kLcWPbw/Gtss38e7JBvwsbTBeOVyLC01d+PxKKx6IC8Ly1DD89Xg9pg8LxJfXWlHWqkJCqDd+l219teP0SD8sSxmkj4z2XG/H0uRBUGoY/LwkUPEMbV0aHKnuRIuufmBN/C9mR6KyXYWDusLk6XoFVn5bqe9Y/PBsMxoVGjwyKhSJg3y6hfysuhzs6H5w9y8E59P92t4zIggXmrqQGekHmYTDnMQQpEX4Yv6XN3CmQYHsaO3DwVbOH+gtRXqEL07VK/Cr/do2bCXPUNep1o8EANpC2Q/1CnhJOPz5rmj9wiIA8OP4IGy9dBMP77iBBXeE4NnMcGh4hl//rxpZUf5YkRam3/e/l2/iwzNNGKO7XyL9ZSaRTozg+e0s+HWqePzhUC32GkUekf4yaHiGk3UKLPjqhsn+GZF+WDQyFItGhuLb621YfaAGAHCg0nrRsl+LHwCyY/zBcRx+mjwIH53T3twn6wxh0JLRoahuV2OXUffcK3dGYWyUH9YerceeG+0obVWhtFUFP5kEh6o6Ee0vw5kGBSQckGoh1xcwD7XfmTYEle0qvH7M8DKRSrMn/b90Pd9SznBDGLMiNQwFV1qxv7wD+816CHaWtmFnqfb3+L5SK75wPylenxKDIBtr1T0QF6QXf0lLF5Z9U4ErzV34bXYkNp5pQqlZYcy8Z8CY57IiULq3ElUdav3agcZ8fqUVX1xtxXszhuq794S+fv65RwB5B9DRBm7xU90+6yXh8Fym6fsYbgv2hp+MQ02HWj+Gbqt+AAB/mRqDX39XrU/hAOB0vRx3DPLBnuvtyIr2Q22HGgzAqDAfE+EDwC8ywoGgLXgAABYdSURBVLH9SisUGoZPL99Eca1cH3IX1cixNGUQpBzwWUkr/qRbkKVG52C6FUuDvcABuNSsxJGqDgR5SxHoLUG7ikfyYF/c7NLgg9ONeCghGKPCfLHhRIOJ8P1kHN6ZNgQKDY+luytMjj16sA9+mRGu///MEUHYMccXH55pwv8qbmHxZ0Zpw5ynx4bjifTB2HimCf/4oQnhflI8nhqGOQnBkHIcnskMxyBfKeo71RiiK1zNvyMEe4wu8H8uaYf2hAJeeoSfzQUgx0f7oahGjunDAjA5NgCMMQwL8oKGMbx0sBZtunHdmSMCwRj05xs92BfBFvL0SH8ZFieF4uNzhnDtx/FBuD8uCE/trTLZV8IB704fing7Fuy8PdQHH90Xi59+XYGvywy/80sW0h4JB9wzovtyWwLxId7YMTcOfzpa122yyr8eGIbN55vxdVk7fr6nUr9d37cv196M7Mp5mzYLSCUcRoX54GSdAkertQ89nx6afATCfGXIuzcWMz+9ph9fFzyiOXcM6n4NA7wkGBbshRLdrEbz5qbPS25i+5VW/QNQyhneIxhpFjmF+cowfXgg9t5oxxNGf0cvCYcdc27DJ5dv4j+XtP+ey9Q+dAQeiAvC46lh+kLuitQwnK6X4/64INwdG4hBvt3voyGBXviDUbpniX4t/iBviUkXlZeEw8/SwjA3MQSDfKQms8iEP4YgfEAbNeyZH4cQHyneP9WIPTfaIeWAMp0XvD/OUHyyxutTYrD1YgseGRUKQJsyTBqqbe4omO2HdUV1UGoY1kyMgp+Mw+oDNdhzox1zjHJnc55KH4zRg30wLtof1e0qxIV4w1vKIdxPqhfRusnRCPOV9ph6mHN7qOEGD/CSYPJQf30qNGmIPxoVGlxs6sLcxBCMCLb9QFk8KtRE/ItHhSJ5sDZ9OlWnMGmwCTO/QXnHhtDGRfvjZJ0CZ3TFLUs3vCW8JBz+8+PhOFjVqZ+nYIk7Blm+jneE+ujFb87aIm2EJ5MAz2dF4J4RgVj01Q00yDXIiupeK5qdEGzizQFtD8Th6k7suW6ITN8+ru0oTQ33xcsTI3FbsDekRpHOk+mDrf4ejsCxvtRv6CBZWVkWlwDvLftvtOP7yg6sGhfRbbirt6h5hvONCqSG+zq8pvzR6k6s+l81ksJ8kHdvrFPn/933NahsV+H3EyJxe6gPvr3ehu8rO/DCuEj4yjgoNMyh33njmSa8d6oReTOHIivaUKwrb1Pi3ZONyI7xx+XmLoyJ8MP9cUHQPJSh3WFMNqSv/N3u8yjUPH6xrwrHa+UYPdgHH8wYajFysgZjDGP/dUX//zkJwZg2LBBP79d64Y33xmKsBcE2ytX4c1Ed9t3owPAgL/zrgWGoaldj9YFq1MvVCPeT4WdpYfhRvPZhruIZ5Creom3tSg0m/+caAO0oUkOnGlUdpvWgjEhfFOpSul+kD8by1LBux3EVJP5+hlzNw1vCmXgCT9Ol4e0KwwEYxJ82HtJX/+HQeXjG0CDXIMJP6tTLOI7VdKKwsgNPjhkMX90DrrCyAxcaFViRGtbjMXnGoOGtr0lgLxmbSwBoW6cnDfHH7ALDCMTvsiMxeag/nj9Qg+FBXvjdhEiXOx9j+nXYPxBx583gLPYK3wQnXI6E47rl0o4wLtof44yiEwCYPDQAk4cGWPmE6bklLnj/R/6sWBRWdGD+HSHwknD60SgAmJcYDI7jsOn+Yb0/kR30vTuJGCD024CzV6RF+OGpjHD9aMXaydHwlnB4++4Y0V8tRp6f8Az9N9t0KdOHB+Lo4gSPnJs8P+EZSPwex2Pi12g0yMjIwI9//GMAQGlpKbKzs5GYmIhFixZBqexb650RLobnwRp796Yiond4TPwbNmwwWQnoN7/5DZ599lmUlJRg0KBB2Lhxo6dMI8Tgwknwy+8Dv2Orpy0ZsHhE/BUVFdixYwcef/xxANox2H379mH+/PkAgNzcXGzfvt0TphEiw/75uqdNGLB4RPzPPPMM3njjDUgk2tM3NjYiNDQUMpm2/hgbG4vKykqLn83Ly0NWVhaysrJQX19vcR+ib8I0ltc6YCr3rG5D9Izo4v/qq68QGRmJzMxM/TZLfUbWhj1WrlyJ4uJiFBcXIyIiwuI+RB9FbaWOU33D8nbCrYg+1Hfw4EF88cUX2LlzJxQKBVpbW/HMM8+gpaUFarUaMpkMFRUVGDJkiNimEe7GWhFXRcVdTyC651+7di0qKipQVlaGrVu3Yvr06diyZQumTZuGbdu2AQDy8/Mxe/ZssU0j3I3KyqIYagr7PUGfGed//fXX8fbbbyMhIQGNjY1Yvny5p00iXI01z0/i9wge7fCbOnUqpk6dCgCIj49HUVGRJ80h3I218J7E7xH6jOcnBgDWxE/Vfo9A4ifEQ2kt5+9b77AbKJD4CfGw4vkZhf0egcRPiAfl/H0KEj8hHlTt71OQ+AnRYDTO36cg8RPiYaW33xnx9+OlJ/sMJH5CPHhr4nes2s80GvC/Xgz+Ly+6wKiBC4mfEA9ra/U7Os5fVQZcuwBWuLvXJg1kSPyEeFgTv6NhvyuW0SVI/ISIWA37HRS/leneTKWkWoADkPgJ8XCV5zcSP9Mdk7W3gl80EfyffuWsdQMOEj8hHq7y/MYPEd1n2anD2u3FhU4aN/Ag8RPi4SrPb/wQoR4BpyHxE+JhVfwOTuwx7hegVYCchsRPiIerwn5j8QsPDir0OQyJnxAPjYvG+Y0jCMHz8wbxM2sRBmECiZ8QDyue3+EpvRqjNEH4rPG8AWtzCAgTSPyEeLgl7Nd91nihkC6FY8cboJD4CfFwR7VfSBmMBd9Fnt8eSPyEeAiilZqtG+uKoT5j8VtbLowwgcRPiIdQ8JOZi98FQ30mnp/Cfnsg8RPiIXjswZGm212S8xt7fhK/PXh03X5igKHL+bl75gB1lUDkELBN77hG/BT2Owx5fkI8BM/v7Q3Jz38HLnua9v+uLviR+O2CxE+Ih1DtF+bjy7y1Xx1s0WVG4hd6BBjl/A5D4ifEQy9+3W3n46P96qintlTwMzoGo5zfLkj8hHgIHlvw/D6+2q+Oemoa6nMJVPAjxMPc83sbPD9jDJyVFXq6YeT52bEDYGGRNNTnBKJ7/vLyckybNg1JSUlITk7Ghg0bAABNTU2YOXMmEhMTMXPmTDQ3N4ttGuFu9J5fe9txUpl2zJ/nHSv6GYf9x78H/+dngPabhm3U4WcXootfJpPhL3/5Cy5cuIAjR47gvffew/nz57Fu3TrMmDEDJSUlmDFjBtatWye2aYS7MS/4AYC3E6G/pfX/21sN31PObxeiiz8mJgZjx44FAAQFBSEpKQmVlZUoKChAbm4uACA3Nxfbt28X2zTC3Zh5fgCGvN8RwVqaINTZbviewn678GjOX1ZWhpMnTyI7Oxu1tbWIiYkBoH1A1NXVWfxMXl4e8vLyAAD19fWi2Ur0Hqbz2Jxxb78znt/a7ECBLrmDlg1MPFbtb29vx7x587B+/XoEBwfb/bmVK1eiuLgYxcXFiIiIcKOFhMsxL/gBhuE+R/J0a6/9ElCQ+O3BI+JXqVSYN28eFi9ejLlz5wIAoqKiUF1dDQCorq5GZGRkT4cg+iOuCvs1PU8EYiR+uxBd/IwxLF++HElJSXjuuef023NycpCfnw8AyM/Px+zZs8U2jXA3PRb8HPD8tpbpIvHbheg5/8GDB7F582akpqYiPT0dAPDnP/8ZL7zwAhYuXIiNGzdi+PDh+PTTT8U2jXA3PYb9DgjWVthPOb9diC7+u+66y+orlfbu3SuyNYSomHf4AQbP70hXnq2CH3l+u6D2XkI8LHh+TpfzM6r2iw6JnxAPV3l+qva7BBI/IR4Wc34XdfgBgF+A9iuJ3y5I/IR46BfwtFTwc8FQX6CuX6RLTq/qtgMSPyEePQ31OdTea2Woz9cPkHlpf07v8LMJiZ8QD42bw36Zl/YBAFDobwckfkI8LBX8nBGrtWq/zAvw0R2PKv42IfET4mGp4CcU6eQd9h/HWs7vRZ7fEUj8hHjoC34Gz8/pxM8cEb+1nJ/Cfocg8RPiYSns99d5fuP5+LboMef3137vyMNkgEJr+BHiYang5x+o/SrvtPswzGrY7619AACOPUwGKCR+wu2w9lawXZ8ADTXaDcae30/nqTt7H/ZzMi/AxxdMd047lwMdsJD4CbfD9mwH2/KeYYNJwU/w/A546p6q/QFB2u872hwzcgBCOT/hfprMlluzmPM7Uu3XLQd2/0IgfaLRcTmD+I0X9CQsQuIn3I/5K7mNPb+Xt/bnahWYvV15upyfmzAN0jXvG7arlEAgeX57IfET7se8e894Si/HGcb67S3S6fsFTB8qTKmksN8BSPyE+zGfrmsc9gNGjT52Vvw13fsFAAAqJTid+BmJ3yYkfsL9dBO/2W3naN7Pqy0fR9kFBOhm9lHObxMSP+F2uq3S083zO1jxFxb7FN71J6DsorDfAUj8hPsxn65r7rGFIl3bTdiFkB4IPQICKhK/I5D4Cfdjviy3mefnQsMBAKypwb7jKXTpgVArEPDyBoJDtN+3toDZWuJ7gEPiJ9yPrZw/TCt+tNgpfjPPL3n5feC2OyB56mVwPn7aFX3UKqC1pRdG3/pQhx/hfmyJf5BO/M22xc80au3xJBL9KkBcxkRIM4yafcKjtAW/hhogNKw3lt/SkOcn3I9ZwY/jTLvu9WG/HeLXe31f/27H0TM4Svu1odYhMwcaJH7C/dhan08I++3J+eVW8n0juHCt+Fkjib8nSPyE+7G1Jv8gB3J+a5V+Y8KjtV/J8/cIid/DDIglpm2JPzQckMqAlkYwWy2+ws978Px68ddV2W/jAITEbyesuQGs7LJLj8n/613wy+8Dq7zu0uP2JRjP68Uvyd8LyZYD3fbhvLyAhNHanv3zJ3s+oB2en4uN0567otQ5owcIJH474Vc/Bv6ZRWCVZS47Jtu2EWiqB//m870/1sXT4L/Y0vciCZWhG48LCdP33pvDpY4DALAfino+nh05P3TiR2UpmFrliLVugZ07Ds1zj4Bdu+hpU0zoU+LfvXs3Ro4ciYSEBKxbt87T5uhhHW1AfbX2+9NHe3+8znZonllo2FBWAs3LPwdraXTueIyBf2Ep2P97Czjcx950bK0V1wxON1THvvsKTGVdsEzn+bmePL+fPxA1FFCrgepyBw12DUyjBv/tZ2D1NeB/9zhw7SL4f6z1iC3W6DPj/BqNBk899RS+/fZbxMbGYty4ccjJycHo0aOtf6hLAXblvNttY1cvGL4/cwzsjtTeHe/ofqCsxHTj6aPg338NkoUrHD9gU53h2If3ApFDemWfS7nZpP0qvJzDGkkZQMwwoLoc/LKZ4JY/D3ZgF6DRgLtnNriY4dr9hFC+J88PAMNvB2orwQp3A+On2razvRWsqQ5cVCz4L7cAN5sgWfA4EDzI9mctwL7/Bmx7PkzisKobotyv5nAJljXEsT4SJx4+fBhr1qzB119/DQBYu1b7lHzxxRetfiYr1B9Hp44UxT6ilwwZDun7BT3uwhfuBnv7t4AdtyQ376eQPPq01Z+zI/vBr3vOYTNvRaTbLddR+oznr6ysxLBhw/T/j42NxdGj3UPsvLw85OXlAQDOKnhkV0i77eMJ6uvrERER4WkzAPRRWyoqgawsOz5hZya6YZP2X490vzf65LVxM+GzZmH37t3dtvcZ8VsKQCx1cK1cuRIrV64EAGRlZaG4uNjtttkD2WKZvmQL0Lfs8bQtfabgFxsbi/JyQ3GmoqICQ4b0odyVIG4x+oz4x40bh5KSEpSWlkKpVGLr1q3IycnxtFkEccsiXbNmzRpPGwEAEokEiYmJWLJkCf72t79hyZIlmDdvns3PZWZmimCdfZAtlulLtgB9yx5P2tJnqv0EQYhLnwn7CYIQFxI/QQxQ+q34Pd0KfNtttyE1NRXp6enI0o1fNzU1YebMmUhMTMTMmTPR3NzslnMvW7YMkZGRSElJ0W+zdm7GGJ5++mkkJCQgLS0NJ06ccLsta9aswdChQ5Geno709HTs3LlT/7O1a9ciISEBI0eO1Dd0uYry8nJMmzYNSUlJSE5OxoYNGwB45tpYs8VT18YirB+iVqtZfHw8u3r1Kuvq6mJpaWns3LlzotowYsQIVl9fb7Lt+eefZ2vXrmWMMbZ27Vq2evVqt5z7f//7Hzt+/DhLTk62ee4dO3awWbNmMZ7n2eHDh9n48ePdbsvLL7/M3nzzzW77njt3jqWlpTGFQsGuXbvG4uPjmVqtdpktVVVV7Pjx44wxxlpbW1liYiI7d+6cR66NNVs8dW0s0S89f1FRERISEhAfHw9vb288/PDDKCjouXVUDAoKCpCbmwsAyM3Nxfbt291ynilTpiAszHRtOmvnLigowGOPPQaO4zBhwgS0tLSgurrarbZYo6CgAA8//DB8fHwQFxeHhIQEFBXZmMXnADExMRg7diwAICgoCElJSaisrPTItbFmizXcfW0s0S/Fb6kVuKcL6w44jsO9996LzMxMfbtxbW0tYmJiAGj/+HV1dT0dwqVYO7enrtW7776LtLQ0LFu2TB9mi2lLWVkZTp48iezsbI9fG2NbAM9fG4F+KX5mZyuwOzl48CBOnDiBXbt24b333sOBA90XqegLeOJaPfHEE7h69SpOnTqFmJgY/PrXvxbVlvb2dsybNw/r169HcHCw1f3EsMfcFk9fG2P6pfj7QiuwcL7IyEjMmTMHRUVFiIqK0oeN1dXViIyMFM0ea+f2xLWKioqCVCqFRCLBihUr9OGrGLaoVCrMmzcPixcvxty5c/X2eOLaWLPFU9fGnH4pfk+3And0dKCtrU3//TfffIOUlBTk5OQgPz8fAJCfn4/Zs2eLZpO1c+fk5GDTpk1gjOHIkSMICQnRh8Duwjhv/vzzz/UjATk5Odi6dSu6urpQWlqKkpISjB8/3mXnZYxh+fLlSEpKwnPPGabzeuLaWLPFU9fGmpH9kh07drDExEQWHx/PXnvtNVHPffXqVZaWlsbS0tLY6NGj9edvaGhg06dPZwkJCWz69OmssbHRLed/+OGHWXR0NJPJZGzo0KHsww8/tHpunufZk08+yeLj41lKSgo7duyY221ZsmQJS0lJYampqezBBx9kVVVV+v1fe+01Fh8fz+644w62c+dOl9pSWFjIALDU1FQ2ZswYNmbMGLZjxw6PXBtrtnjq2liC2nsJYoDSL8N+giB6D4mfIAYoJH6CGKCQ+AligELiJ4gBComfIAYoJH6CGKCQ+Ilec+zYMaSlpUGhUKCjowPJyck4e/asp80ibEBNPoRLeOmll6BQKCCXyxEbG9vjm5aIvgGJn3AJSqUS48aNg6+vLw4dOgSptG+8SYmwDoX9hEtoampCe3s72traoFAoPG0OYQfk+QmXkJOTg4cffhilpaWorq7Gu+++62mTCBv0mXf1Ef2XTZs2QSaT4Sc/+Qk0Gg3uvPNO7Nu3D9OnT/e0aUQPkOcniAEK5fwEMUAh8RPEAIXETxADFBI/QQxQSPwEMUAh8RPEAIXETxADlP8P0yFblrZssAwAAAAASUVORK5CYII=' style='max-width:100%; margin: auto; display: block; '/></div>
 </div>
 
 </div>
@@ -12667,8 +14442,7 @@ experiment.roi_polys[c][t][n][0] # n = 1, 2, 3.... the neuropil regions</code></
 
 </div>
 <div class="cell border-box-sizing text_cell rendered"><div class="prompt input_prompt">
-</div>
-<div class="inner_cell">
+</div><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
 <h4 id="df/f0">df/f0<a class="anchor-link" href="#df/f0">&#182;</a></h4><p>It is often useful to calculate the df/f0 of traces. This can be done as follows. By default it is done across all trials, but it can also be done per trial by setting across_trials to False.</p>
 
@@ -12680,10 +14454,10 @@ experiment.roi_polys[c][t][n][0] # n = 1, 2, 3.... the neuropil regions</code></
 <div class="prompt input_prompt">In&nbsp;[7]:</div>
 <div class="inner_cell">
     <div class="input_area">
-<div class=" highlight hl-ipython2"><pre><span></span><span class="n">experiment</span><span class="o">.</span><span class="n">calc_deltaf</span><span class="p">(</span><span class="n">freq</span><span class="o">=</span><span class="mi">10</span><span class="p">,</span> <span class="n">across_trials</span><span class="o">=</span><span class="bp">True</span><span class="p">)</span>
+<div class=" highlight hl-ipython3"><pre><span></span><span class="n">experiment</span><span class="o">.</span><span class="n">calc_deltaf</span><span class="p">(</span><span class="n">freq</span><span class="o">=</span><span class="mi">10</span><span class="p">,</span> <span class="n">across_trials</span><span class="o">=</span><span class="kc">True</span><span class="p">)</span>
 </pre></div>
 
-</div>
+    </div>
 </div>
 </div>
 
@@ -12693,12 +14467,12 @@ experiment.roi_polys[c][t][n][0] # n = 1, 2, 3.... the neuropil regions</code></
 <div class="prompt input_prompt">In&nbsp;[8]:</div>
 <div class="inner_cell">
     <div class="input_area">
-<div class=" highlight hl-ipython2"><pre><span></span><span class="n">c</span> <span class="o">=</span> <span class="mi">2</span>
+<div class=" highlight hl-ipython3"><pre><span></span><span class="n">c</span> <span class="o">=</span> <span class="mi">2</span>
 <span class="n">t</span> <span class="o">=</span> <span class="mi">1</span>
 <span class="n">hv</span><span class="o">.</span><span class="n">Curve</span><span class="p">(</span><span class="n">experiment</span><span class="o">.</span><span class="n">deltaf_raw</span><span class="p">[</span><span class="n">c</span><span class="p">][</span><span class="n">t</span><span class="p">],</span> <span class="n">label</span><span class="o">=</span><span class="s1">&#39;raw&#39;</span><span class="p">,</span> <span class="n">vdims</span><span class="o">=</span><span class="p">[</span><span class="s1">&#39;df/f0&#39;</span><span class="p">])</span><span class="o">*</span><span class="n">hv</span><span class="o">.</span><span class="n">Curve</span><span class="p">(</span><span class="n">experiment</span><span class="o">.</span><span class="n">deltaf_result</span><span class="p">[</span><span class="n">c</span><span class="p">,</span><span class="n">t</span><span class="p">][</span><span class="mi">0</span><span class="p">,:],</span> <span class="n">label</span><span class="o">=</span><span class="s1">&#39;decontaminated&#39;</span><span class="p">)</span>
 </pre></div>
 
-</div>
+    </div>
 </div>
 </div>
 
@@ -12708,12 +14482,12 @@ experiment.roi_polys[c][t][n][0] # n = 1, 2, 3.... the neuropil regions</code></
 
 <div class="output_area">
 
-<div class="prompt output_prompt">Out[8]:</div>
+    <div class="prompt output_prompt">Out[8]:</div>
 
 
 
 <div class="output_html rendered_html output_subarea output_execute_result">
-<img src='data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAQAAAAD6CAYAAABODJmtAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDIuMS4wLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvpW3flQAAIABJREFUeJztnXl8VNXd/z93tuw7CVsQCAFCEpIAAQIIClQRW2NxxQVErUjp8/i0lGr71IVaW9qKFqt9+jwoPxVboYqVYFnqglBUEMKisgdMgJAQsu+z3vP74869ubPcmbmTuZmEfN+vFy+SO3fOPXMz53O/2zmHY4wxEATRL9GFuwMEQYQPEgCC6MeQABBEP4YEgCD6MSQABNGPIQEgiH4MCQBB9GNIAAiiH0MCQBD9mD4nADfddFO4u0CoZM4732LCW2Uo3lIR7q4QbvQ5Aairqwt3FwiVNFocAIDL7fYw94Rwp88JAEEQoYMEgOgxGGjeWW+DBIDoOWj89zoM4e5AKLhy5QpWrlyJU6dOgef5cHeHcONKu036uXCt0e/5Op0OWVlZWLNmDdLS0rTsWr/nqhCAlStXYvbs2Vi/fj2MRv9fMKJnOVFvln7OTon0e77NZsNbb72FlStXYsOGDVp2rd9zVbgAp06dwv3330+D/yrBaDRi0aJFOHXqVLi7ctVzVQgAz/M0+K8yjEYjuXM9wFUhAARBBAcJAEH0Y0gANIAxRuYr0ScgAQgRFRUVGDt2LBYvXozc3Fw8/PDDKCwsRE5ODp555hkAwMGDB3HbbbcBAEpKShAVFQWr1Qqz2YyMjIxwdp/op1wVaUA5E94q06TdI4tG+z2nrKwMb775JoqKitDQ0IDk5GQ4HA7MnTsXX3/9NSZMmICjR48CAPbu3Yvc3FwcPHgQdrsdU6dO1aTfBOGLq04Awsnw4cNRVFQEAHjnnXewbt062O12VFdX48SJE8jLy8OoUaNw8uRJHDhwACtWrMC///1vOBwOzJw5M8y9J/ojV50ABPKk1oqYmBgAQHl5OdasWYODBw8iKSkJS5YsgdksFMPMmjULO3bsgNFoxHe+8x0sWbIEDocDzz//fNj6TfRfKAagAS0tLYiJiUFCQgJqamqwY8cO6bWZM2di7dq1mDZtGlJTU1FfX4/Tp08jNzc3jD0m+itXnQXQG8jPz8eECROQlZWFYcOGYcaMGdJrU6dORU1NDWbNmgUAyMvLw+XLl8FxXLi6S/RjSABCxIgRI3Ds2DHp9zfeeMPreVFRUbBYLNLv69at07prBKEIuQCE5shtG5uDB+1H23sgASB6lLImKy0N1osgASB6HHGNQCL8kAAQRD9GMwF46KGHkJaWppje+tvf/oa8vDyMHz8e06dPx1dffaVVVwiCUEAzAViyZAl27typ+PrIkSOxZ88efPPNN3jqqaewdOlSrbpCEIQCmgnArFmzkJycrPj69OnTkZSUBAAoKipCZWWlVl0JC6tWrcKaNWs0v84bb7yBqqqqkLU3ffr0Hu1LRUUFFUGFkV4RA1i/fj3mz58f7m70SUItAF988UXI+0IlTr2XsAvAp59+ivXr1+P3v/+94jnr1q1DYWEhCgsLUVtb24O9U8dvfvMbjBkzBtdeey1Onz4NADh37hxuuukmTJo0CTNnzpTWuaupqcGCBQuQn5+P/Px8aeC9+OKLyM3NRW5uLtauXQtAeEqOGzcOjzzyCHJycnDjjTeis7MTmzdvRmlpKe677z4UFBSgs7MTzz77LCZPnozc3FwsXbpUyrlff/31+MlPfoLCwkKMGzdOmpo8evRoPPnkk9JniI2NBQDs3r0b119/Pe644w5kZWXhvvvuk9rydg1vfTl06BCuu+463D53Oh658xbUXq4GABw/elj63H/+85974C9DKMI0pLy8nOXk5Ci+/tVXX7GMjAx2+vTpgNucNGmSz2P2Wws0+eeP0tJSlpuby9rb21lzczMbNWoUe/7559mcOXPYmTNnGGOM7d+/n82ePZsxxthdd93F/vjHPwp9tttZU1OT1EZbWxtrbW1l2dnZ7PDhw6y8vJzp9Xp25MgRxhhjd955J3vrrbcYY4xdd9117ODBg1I/6uvrpZ/vv/9+tnXrVum8xx9/nDHG2Nq1a9ngwYNZVVUVM5vNbOjQoayuro4xxlhMTAxjjLFPP/2UxcfHs4sXLzKHw8GKiorY3r17/V5D7IvVamXTpk1jV65cYSfrO9maVzewBfcuZsfrOtmY7Fz2ya7djDHGVq5cqfgd8fa3JkJL2EqBL1y4gNtuuw1vvfUWxowZE65uhIy9e/diwYIFiI6OBgAUFxfDbDbjiy++wJ133imdJ5YB79q1S1ryWq/XIyEhAZ999hkWLFggzSq87bbbsHfvXhQXF2PkyJEoKCgAAEyaNAkVFRVe+/Hpp5/iD3/4Azo6OtDQ0ICcnBzccsstUp8AYPz48cjJycHgwYMBABkZGbh48SJSUlJc2poyZQrS09MBAAUFBaioqMC1117r8xoip0+fxrFjx3DDDTfA4mBwOBxIHTgILc1NaGluwnTn9OdFixa5TJYiehbNBOCee+7B7t27UVdXh/T0dPzqV7+CzSZsELFs2TI8++yzqK+vx/Lly4WOGAwoLS3t9nX1W450u41QwfM8EhMTpUVAukNERIT0s16vR2dnp8c5ZrMZy5cvR2lpKYYNG4ZVq1ZJ05Dlbeh0Opf2dDod7HbP6jz3a9rtdr/XEGGMIScnB/v27cPJerO0KVBLcxMAgKdq4F6BZjGAjRs3orq6GjabDZWVlXj44YexbNkyLFu2DADw2muvobGxEUePHsXRo0dDMvjDyaxZs7BlyxZ0dnaitbUVH3zwAaKjozFy5Ei8++67AIRBIdY7zJ07F3/5y18AAA6HA83NzZg5cya2bNmCjo4OtLe34/333/e7UEhcXBxaW1sBQBqIAwYMQFtbGzZv3hzyz+nrGvK+jB07FrW1tdi3bx8AYbOPs6dOID4hEfEJifjss70AhHoQInyEPQh4tTBx4kTcfffdyM/Px/z58zF58mQAwhd8/fr1yM/PR05ODkpKSgAAL730Ej799FOMHz8ekyZNwokTJzBx4kQsWbIEU6ZMwdSpU/GDH/wAEyZM8HndJUuWYNmyZSgoKEBERAQeeeQR5ObmYt68eVIfQkliYqLiNeR9cTgc2Lx5M5544gl8/7opuP36qThyYD8A4Lk//R9++l+PoaCggCYGhRmO9bG/QGFhoYe14O0Y0TtgjOFkg8XjeHqsEfERep/vpb+r9pAFQPRpXj/WgHdON4W7G30WWhCE0BQl8zIUZmdthx1/OlIPALhrbGIIWux/XBUWgE6nkzIMxNWBzWaDTuf763mpjf7m3eWqEICsrCy89dZbJAK9kGAiTOL24FlZWT7Pq6aFRbrNVeECrFmzBitXrsT//u//0pZcvQyeATUdnsKcGKFHlMH780en0yErK8vvZKrL7V3tMsZoYdUguCoEIC0tTaqqI3oXDZ12zN1c7nH8V9MHonhUfLfarpJZADwD9DT+VXNVuABE78Wh4AI4QlAKWC2LAVBlYXCQABCa4lAIAoRivJpl6qJ0HcI3JACEpjgUQjKhGLA8kwtAt5vrl5AAEJqiNNBDbbLzZAEEBQkAoSlKT+ZQCIC8DbIAgoMEgNAUpWBfKJ7Y8hZ4igIGBQkAoSlaWgCMLIBuQwJAaIqWMQC5FUExgOAgASA0RcssgLwFsgCCgwSA0BReIeMfige2vA0KAQQHCQChKUoDPTR1AKFtrz8Str0BGWN47LHHkJmZiby8PBw+fFirrhBhROnJHJIgoMy6IBcgOMK2N+COHTtQVlaGsrIyrFu3Dj/84Q+16goRRpTGZaizAJQGDI6w7Q1YUlKCxYsXg+M4FBUVoampCdXV1Vp1hwgTSktOhiJqT4VA3SdsMYBLly5h2LBh0u/p6em4dOlSuLpDaITSgzkUA9alEIhiAEHRJ9YDWLduHdatWwcAvXpvQMITxTUBQ+ICyOsAut9efyRsFsDQoUNx8eJF6ffKykoMHTrU67lLly5FaWkpSktLkZqa2lNdJEKAkgsQkixAiNvrj4RNAIqLi7FhwwYwxrB//34kJCRIe9URVw9KC7RRHUDvIGx7A958883Yvn07MjMzER0djddff12rrhBhRMs6AHkLdrIAgkIzAdi4caPP1zmOo73h+wFKFkDo04Ddb68/QpWAhLYwYFB7LX789QakdjZIh0MxXmkyUPfpE1kAou/CM4a1X/wOmS0XkdtQhh9c/2vheAhMANcgYLeb65eQBUBoCg8gs0XI9mQ1dS0PHpIBS0HAbkMCQGiLwsBkIVgXmNKA3YcEgNAU+SBl6Nq5IxgL4HSDBUevdHa1TYVA3YZiAISmKAXngnlgL9x2AQDwxcJRiDK6PrvIAggOsgCIHsN1BZ/gB2yHXbArXCYDURowKEgACE3RYj0A8b28SxCQLIBgIAEgNEU+SJls997uCADz8hOlAYODBIDQmNCvByC+lyyA7kMCQGiKiwXQzSyAe5u0IEj3IQEgNEV5PQB1I9bf3H9KAwYHCQChKaFaEcjbCsA0F6D7kAAQmqL0pFc7Xr3V/dPGIN2HBIDQFPm4lGcB1NYByIVE3HDUZW9A8gGCggSA0JRQ1QF4dwGCb48QIAEgNEXpQa92wLo+7Z3HZK9TKXBwkAAQmuLiAkBeCKRuwMpjAOLyX7QqcPchASA0RWmgq88CyGMAzmMu7ZECBAMJAKEpTOln1UHArp8dzDMISBZAcGgqADt37sTYsWORmZmJ3/3udx6vX7hwAbNnz8aECROQl5eH7du3a9kdIgzIB2mCrR07m9/DiJZK9RaA7GcHEwSE0oDdRzMBcDgc+NGPfoQdO3bgxIkT2LhxI06cOOFyznPPPYe77roLR44cwaZNm7B8+XKtukOECfcn84CP/463dv0iiCyAaxrQ/e2UBgwOzQTgwIEDyMzMREZGBkwmExYuXIiSkhKXcziOQ0tLCwCgubkZQ4YM0ao7RNjwHJhRDgt4lUuCubsA7h4Ejf/g0GxFIG+bf3755Zcu56xatQo33ngjXn75ZbS3t+Pjjz/22hbtDdh3UawDULmAh/viH+5vpyBgcIQ1CLhx40YsWbIElZWV2L59OxYtWgTeyzeD9gbsuyhuDKKyHfddgNyDiGQBBIdmAhDI5p/r16/HXXfdBQCYNm0azGYz6urqtOoSEQ4UC4FU1gG4pQE9YgBkAQSFZgIwefJklJWVoby8HFarFZs2bUJxcbHLOddccw0++eQTAMDJkydhNpvpCX+VwXi71+PdLQV2fz9ZAMGhmQAYDAa88sormDdvHsaNG4e77roLOTk5ePrpp7F161YAwAsvvIBXX30V+fn5uOeee/DGG2+Ak00YIfo+zOHwelytBeAaBPQsMabpwMGh6bLgN998M26++WaXY88++6z0c3Z2Nj7//HMtu0CEGc7uXQDU1wH4SQPS+A8KqgQkNIXTxAXwfOJTHUBwkAAQ2mK3eT3MeO+WgRJUB6ANtDMQoSmcwkA32q2q2pGnDX93oBavft3g8jplAYLDrwCcOnUKJSUluHTpEgAhvVdcXIxx48Zp3jmi78PZvbsAJptFVTvuef96s6uwkAUQHD5dgN///vdYuHAhGGOYMmUKpkyZAsYY7rnnHq+TewjCHaUYQISt0+txJfwNcDtZAEHh0wJYv349jh8/DqPR6HJ8xYoVyMnJwc9//nNNO0f0fZSyACabWVU7fgWA9gYMCp8WgE6nQ1VVlcfx6upq6HQUPyT8wzm8BwEjVVoAnok/V+zkAwSFTwtg7dq1mDt3LkaPHi1N7Llw4QLOnj2LV155pUc6SPRtFF0Au7oYgL/xTWnA4PApAGPHjsWZM2dw4MABlyDg5MmTodfre6SDRN9GyQVQmwXw5+LbafwHhU8BuOOOO3Do0CH88pe/lGr2CUIVzLtzrpQeVMJ/DIAUIBh8CgDP8/jtb3+LM2fO4MUXX/R4fcWKFZp1jLg6UFr7j1O5IIC/BURIAILDZyRv06ZN0Ov1sNvtaG1t9fhHEH5RGOgGZlc1gYcxwOiwKcYOKAsQHD4tgIaGBjz++OPIy8vD/Pnze6pPxNWEwiDX8zwcPKALMJTEM+DDbY8gztaBqQvehkPn+tWlSsDg8GkBbNiwAZMmTcKbb76JN954A5cvX+6pfhFXCwoxAD1zqDLbeTDE2ToAAPHWdo/XyQUIDp8WwF/+8hcAQjnwjh07sGTJEjQ3N2P27Nm46aabMGPGDMoGED5hCi6AnjlUVe/JT9XJ4gEchNWByAUIDp8WQHl5OQAgKysLP/nJT7Bz507s2rUL1157Ld59911MnTq1RzpJ9F04Hy6AmkErf8BzMqvCqBMWkCELIDh8CsAdd9wBAJg7d650LCoqCjfffDNefvlllJaWats7ou+jGAR0qPLb5dkE+ZpRPzr2Nh44vYXmAgQJpQEJTVFKA6qOAcja0TktgDhrG+47+T4AoCTv9m70sv8ScBqwra3NJQXY1tbWU30k+jJKQUC1LoDMktA72zTIionIBQgOnwKwbds2GI1GLF++HLGxsYiLi5P+xcbG+m3c396AAPDOO+8gOzsbOTk5uPfee4P7FETvxYcFoCp1JxvgeufA17MuAeAV1h0gfOPTBRCLfU6fPo2DBw/i1ltvBWMMH3zwAaZMmeKzYXFvwI8++gjp6emYPHkyiouLkZ2dLZ1TVlaG1atX4/PPP0dSUhKuXLkSgo9E9CoUBrlBrQsgW11YHPhyCwAKk44I3/gUgGeeeQYAMGvWLBw+fBhxcXEAhC29vvvd7/psWL43IABpb0C5ALz66qv40Y9+hKSkJABAWlpa8J+E6J0opQF5hyoXQB5LEF0Ao2zQ68gCCIqAJvXX1NTAZDJJv5tMJtTU1Ph8j7e9AcUZhSJnzpzBmTNnMGPGDBQVFWHnzp1q+k70BXwVAqnJAvByC8ApAKxr0Ot5B00JDoKAFgVdvHgxpkyZggULFgAAtmzZgiVLlnT74na7HWVlZdi9ezcqKysxa9YsfPPNN0hMTHQ5jzYH7cMougC8qgHLXIKAghjILQADb4edMehBG8uoISAB+OUvf4n58+dj7969AIDXX38dEyZM8PmeQPYGTE9Px9SpU2E0GjFy5EiMGTMGZWVlmDx5sst5S5cuxdKlSwEAhYWFgXSZ6C0oZgHUuQByV0IMAhplqw0JMQUgggpTVRHwsuATJ07ExIkTA25Yvjfg0KFDsWnTJrz99tsu53z/+9/Hxo0b8eCDD6Kurg5nzpyRYgbE1QGn8JRXmwVgXtKAcgvAyNspFRgEYd0bcN68eUhJSUF2djZmz56N559/HikpKVp1iQgDTDEGwKvLAsjONSi4ABQDUE9Y9wbkOA4vvvii1ypD4ipBcS6AWhdAFgTkPQXAyNtpWbAgoKV9CU1RmgxkUJ0F8FYJKLMAVNYVEAIkAIS2KLgAages1ywAc7UAbCQAqiEBILTFOSh5vevmMkLePvBmmJcsgMkhjwE4aIvwICABIDRFnLvvMEW4HNczPmgXwEBZgJBBAkBoi3OwMr1rvFnPVFbueXEBDO6FQCQAqiEBIDRFfMgzt9U/Vc8FkM8GVKoEJAFQDQkAoSni+v+eFgCvckUgeRrQiwvA7LQuYBCQABDaouACqE7beUkDmnhZKTCvcn0BAgAJAKE1zkHpIQAhcAEMFATsNiQAhKZIK/i6LR+vdjqwSyWg1xiAyspCAgAJAKExnIIFoHYugIsF4C0GQBZAUJAAENriHKz26DiXw3q1hTvMz3oAzE5LgweBppOBCEKMAXQOG4PE3DzAZgXb+jfVy4LDpRBIKQYQmi73J8gCIDTGOcg5DrpFj4Gb+30A4opAaprxnwWguQDqIQEgtEUcuDrnV80ZDBQKgYKcDORlOjAVAgUHCQChKdKKQJxzrT5RAFRnAfzFAByw0mwg1ZAAEJrCQRi4HOf8qumEsFO3sgBe1gMw8nZYyQJQDQkAoS3ioHRzAQxqg3bM24pAXccMvB02sgBUQ1kAQlOkQiAPF0DdXAC5C3B3+YdItLbCxFulY0bejhayAFRDAkBoi3OQc5IAiC6A2iBg17kRdguKz+92eZ1iAMGhqQsQyOagAPDee++B4ziUlpZq2R0iDHAKWQDVK/jI9wH0gpFcgKDQTADEzUF37NiBEydOYOPGjThx4oTHea2trXjppZcwdepUrbpChBPJAhAFILggoNLagiIGWhMwKDQTAPnmoCaTSdoc1J2nnnoKTzzxBCIjI7XqChFGpLkAOi9pQFWVgL7PpSxAcGgmAIFsDnr48GFcvHjR707D69atQ2FhIQoLC2lvwL6GuwWg63IBVPnsCrsMi5gc5AIEQ9jSgDzPY8WKFXjhhRf8nrt06VKUlpaitLQUqampPdA7IlSIMQDOGQPg9HowTgcdGOwqtvRW2mFIxMjbyAIIAs0EwN/moK2trTh27Biuv/56jBgxAvv370dxcTEFAq8yPNKAAJhBiAPwNpu3t3jHjwVg5O2UBQgCzQRAvjmo1WrFpk2bUFxcLL2ekJCAuro6VFRUoKKiAkVFRdi6dSvt/nuVIcYARAsAAJjBJPxvtXp9j1f81AyYeBsFAYMgrJuDEv0A9zoAADAKm4QwmwoBCCANSBaAesK6Oaic3bt3a9kVIkyILoCUBQAAo2AB8CoEgPMTAzA5KAYQDDQXgNAWyQKQrQnodAE4FTEA5mdw01yA4CABIDSlKwbQZQFwkgsQuiCgibeRCxAEJACEJpjtPF4orUW71ZnqkwUBRQHg7GqCgP4EgCoBg4EEgNCEf1e2468nm7osAE5uAQguAOw2sABnBHJ+LAADVQIGBQkAoQni01gnrgkoswDEIKDRYQt8TYBA0oDkAqiGBIDQBHEo6twqAQFIAmDi7bAEujKo3xiAHVZVq4wSAAkAoRHi1t8clOsAVE3g8REDYKK4qAkqEgBIAAiNEK1xMQYgLwWGQRQAFZF7HxYAZ4oAADA7CYBaSAAITRCX+xJjAJyuqw6Ak1wAFQKgZAHo9JJLoXfYaGlwlZAAEJoguuPesgBSDMARePmuYhZAr5csChMVA6mGBKAPU9dpx87yVsnf7k1IFoD7kmCALAagonxXKQug03UJgMMGSy+8F70ZWhS0D/PgzkpUttnQZEnFwqzEcHfHBckCcLoAOvlcAGcpsJoJPEzRAjBIFoWBt6PTziMxQu/9XMIDsgD6MJVtQtBrX1VHmHviiV2yAIT/bfDiAqiIASgKgE7n0l6HjVKBaiABuArojSWw0n4gThcgIdLY9aJzQRAjbw/cZPcVAzB2xQA67b3vXvRmSACuAnqjAIhxiZHxwuDUeQ0CBl69p7gkmE7vklYkC0AdJAA9TIeNx9e1nSFtszcKgPgglkqBOS+lwLwNlm67AHpZe3Z0qNpvjCAB6GGeL63FAzsr8d6Z5pC12RsFQKoEFKP3Ou+VgAH3PRAXwGFDJwmAKkgAfFDVZsOO8paAZ6wFwpazLQCAPx+tD1mbvVIA3AqBvFkAJt4Oc6AD1mcdgMwCsPW+e9GbIQHwwX/sqsJ/f1aDv51sCnnbjRZHt4RF/l67RsUvfz/dhKUfVqIzCL9aTAPqvKwK3DVgbWgLsG1fLgBn6LIoyAVQR1j3BnzxxReRnZ2NvLw8zJ07F+fPn9eyO6opbxYWrNhcFjpzPcHUdcsbLb4XuvSFvICmQ6PI9+8O1OJgTSd2VLSqfq9oAXS5ALKvmqxwpz1QcVESS71eZlFYSQBUEta9ASdMmIDS0lJ8/fXXuOOOO/D4449r1Z1ucb4lNJNMrA4ezdauL2iLJfgvqzzd1ewUkvJmKx79qDLkQUZzEALj8BEE5GQxgDZroC6Agljq9ECEsK1cpMOKTnIBVBHWvQFnz56N6OhoAEBRUREqKyu16k5QDI3tKpQMRY15Xafrl7jZGrwFIE93mR0MVgePpz6/jAOXO7H0o0s+3hkYcrM/mAk2XUFA0ReQuQDO2XsRaiwApT7IBcBOFoBawro3oJz169dj/vz5WnUnKOQpqlZb8INVpK7TdSuslkCffl5wj3a32xiq24X2A02t+eKKrK/15sC38BKRLADJdJcJgHPARvDWgGMAirMB9TqZBWAhAVBJr5gL8Ne//hWlpaXYs2eP19fXrVuHdevWAUCPbg4qf8q2WXkkd3MD41o3C6ClGzEA94q3UKe/rnTIBKBTfT/FUmDO25Jg0hPbErgAKLkAjHUJisMSVMAylJxptCA1yoCkyL4xHyFsewOKfPzxx/jNb36DrVu3IiIiwmtb4dgclGfMJbjWZuNxrsnSrUFb2+H6JG3uRgzAveKtw8bLn7HdRi4AtZ3qLYDYplp8sGM5Us4dFQ5w3lwAa/eDgHabSwxAq4BoIByvN+Puf17Aox/3LlfWF2HbGxAAjhw5gkcffRRbt25FWlqaVl0JCvfA17E6M+744ALu235R4R3+cXcBWrsRA3B/4ofa9K1q654FkFX2OQZ31HUd4LxYAA5L4EFAJRfAbnexKAIWFA349EIbAKCs0YorHXas3FONb2rNYetPIIR1b8Cf/exnaGtrw5133omCggIPgQgn7gNqT2U7gK4ZeMEgPkkzEoS0VXM3YgDuT7oOO5NSb0D3g5b7q7tmGAYTA+gwRbse8OYCOFTEAJx1APYbbgc348au4w47YJILSvdjNcFSI7Oa/n66CZ9caMN7IUwha0FY9wb8+OOPtbx8t3B/kjSYu75YHTYe0Ub12ilmAUYlmvBtsxUHqjvg4Bn0OvXGu7sF0GZ1uLgUjRYH0qKD+/M2Wxz4qrYTOk4IvjdZeNgcDEZ94P3Uua/P5+ICRAFwDlibUBDlsmKQF8QVgbiMsdDNvxOOzz8UXrDbwEVEgkEQlNYwWgAn6y3Sz7svCg+M5m64jD0BVQIq4D7AzjZ2/XGr24OzAsQYwCinBXCu2YqScy0h6V91ux3yZ359EH67yBdV7XAwoHBgFAZECcEstVaAzuF2j1wsgK4YgJ1HYKsCiaXFOrfgmswFiHBYu1Vb0V2qZN+Lb51FZN1J9fYEJAAKtLsVlMgt7kuNOhKJAAAZ10lEQVRBugFiFmBcSlew88vq4BbzcK95f/FQncvvZU0qtt1ysvFUE369rwZvHhdKn2elxyA1SrAi3GsY/KHzWKLbbVVgnQ4m3g4970CrH1eIZ0yqJ9C5W0uOLgGIdlhg5Vngew2EEBvPvK5FEE5BCgQSAAV8BdXkAbJAsfEMTRYHdBwwY0gMbhgeCwBS7l4t/tJ++6raVbf3h4O1+MfZFpx2Wjszh8YgxWkBuAcw/aF3uAmQfHNQjpP89giHFZf93AMHL19b0JsFILgU0bxwTX+CogWtCqY+WQB9FF/55IoW9U9XMaYQa9RBr+Pw88lCOrO82RrUpCBRoOJMrn/C71wjCMv+6g5V7boLUVKEHtfEmzDAaQGozQR4uACc21fN6QZEOiyobPVtUdkZk20x5sMCcApAdwqsgkXpmi0WPqSzSUMNCYAC4oCN9BL4OiOLBwSK+MSONgi3PClSjwSTDm023qNASE17A9wKTq4fFoMBUXo0WXhc8DOw5FS5uTV5qZEu7au2ADyCgG5fNZkF4M+lsvNMNqnIzQKQCUCkQ/i7dCe9GiwtzmsmuAmylWcw9+KlykkAvPA/R+vx7P4rAIBrh8ZIx+ePiAMg5HnVqrpYuBPlzB5wHIeRzmCgOOtQDaK/KT6hRQbFGJE3QBgQX6nIQYsCMCrBhFnpMfj5FMFCSXG2r7YYyEMA3J/cslTgRT9C5WAK04oB1yCgPXwugGgBjEnyLGbrTvGY1pAAuGHjGV79pkH6/eaMOPxmxkDkpUbi0fxkJEfq0WbjVccBxAEbbej6AndHACRBMXT9Ce8fl4iJaZHISxV84m/q1AiA8HluGhmHl2YPwaAYYcaeGANQO3VZ53C7Px4uQNdT219thZ1n0LvHAOSWgCQA6iyA0poOPPpRJS62WnG6wYJ/lDUHba6L10yO8iwB7k69h9b0irkAvYljboMmOzkCA2OMuDkjHgAwPN6IBrMDVe02DI0zemvCK+KAjZYN2IwQWADy4p+fFgpP7YxEoV1/vrUcMYU1JMb1K5HkXGO/0axOAAweaUC3J7epq3rv2ybBorIz4WmZ4mbV2Hkmmfecc7DDYATEge4sLTbaLQBjAVsAj3woTE5b/WUt9jmzMQkResx1xlHUIFoA8SY9bh8dj90X25EYoce5ZmuvrgUgC8CNQzWuc+ndi2mSI4Xf1Q4IMWgXJSsgEi2Ab4MSAKG9Uc7BLifNOYCudARupYifx33wiZNa1H5evd8goDCQEzk7Gi0O1HY68PKROnxnczl+va/G5VQHD0Q5n+6IFKwbcWlxAOD0BsBghI7xMPJ2NKkccPtkqVj3B0CgiOm+eJMOTxYNxL9uH4lrnCsi92YBIAvAjQrnYLw+PQYPj0/2qFCTBoTKP2pXELCrPXHwljVaAqqGkyMKSvGoeKREGTB1UFfprShaavx2MYgV7xbEClYADO5pQPfP5hSAjCgen0IIrH58Xqil/8fZFizOScLweOH+2FmXBSCm/KA3eLZntyHabnap2lSL2s8p0nX/hPul13HSz1plJY5c6cTZJgvuGJ2g6rsjp09aAJtONeHWLRU4UR/6iRYXnf7ofdmJyB3gOf83WJNYLNyRuwADow0YEKVHs5VXveqQ6ALEGnVYnJ2EscldwafECB2MOg6tVj7gacJyE1ZOgkkPDoIfq2bxUb1HDMD1Cyqa8tdECPfxf47Wu6QiP7vUVcdg5xmi7M6/tegCpA4S/hctgVjBRYu1tQeUslTy9Q9c7ghqARTR7ZCnZRMihJ+1sABON1jw0L8q8dsva3G8Xn1WSqRPCsALpbW40GrDfdsvBr6qbIBcdA7EYbHe/ftgn4jeXACO45DvDNgdVbmMl7cgoLzdVGcwatnHlwIKbImz8uIjXNvT6zhprz01X2SDvzSgcyBPSeRg1HE42eD6JV5TWodVX9TAwTPYeSFbAEByAXQ/+z0wcQZ0v31dOB4jCECCtS2gsmWlv191ux3/71iD19d8IVkAsn0JtbQAPpCVkB+u6USDWb3rA/RBAbDzzKUsN5SzrdptPBotDph0HFIVJtJIFoDKm91h9wwCAkBBqvqUHWNMEj5vAgAAl53+/9e1ZulnJRw8Q5tzPYEYL5OcRNH7yGmiB4KB9zEXAACihUBbGsyYN6Ir6PbdkXHSzyXnWnCs3gwHk1sAggBwg6+B/ulXwI3JFY7HCQIQF6AFUOPjngSz16I4yOOMcgtAvXC6c7rBgl0XPO+7vHbij4frMPfdctz9zws416TOGuhzAuA+S+8TLzfHndMNFrx9stHvFFkxap4eZ3TdykqGOBguttpQcrYZq7+8gpmbzuHIFd9PcHGxymija7uiBfCVn/fLsTlF0KjjFGfojZe5L/4KbcQZdLEmndfPLd7zPxysxW+/vBJQms3oEQR0a9dpsqOt2SV3Lq+7AIDjdWbBBXC4BQHd4FwsAP/985Z6XJAptHG2SX2dR5cF4MUFCLIwqcXiwMJtF/DTPdU46ebuXvIyIe1Khx13fHABeysDLwPvcwIg5lQfzEkCAFQ0u96I6nYb3jrRiD0X26QB/9z+GjxfWocpb5/FLe9XeNxMkQutgpmZ7iO9JwrAqQYLVu27gnfONKPNxuO/9172OQlFyQLISo5AhJ5DeYstYBPu8BWh/wkRyn++Z6YNlH6+5CcdKBaquAcARa4d2hVgfPdMM/5wUFiWzcEzvHem2Wu2wTMG4Na2JAAtyJRlMnIHROLZ6V19P1ZngcPBd7kAJu+rRokWQKK9He02Ifbx5vFG/O1ko9fTzzonS6XHGrEsLxnrb0zHL6amSXUeaudotFo8YygJogsQxIQgxhjePtW1H8WHMuuLMSbVbTxVlIZJA11FUV7H4o8+JwDtNh4GHbAoOwlRBg6NFgd+uqdKCnb94UAtXjxUhx/vrsbTXwiD8pgsSFLZZsPP914G70XhRQtgmA8BSFZY6+1yhx1Fb5+TfLMmiwOnGyx49esGtFkdXTEANwEw6jnkpAhPazEF2WC24/VjDbjgZc4BYwx/OizM/Fs4NlGxnyMTTPhBriCSq/Zd8TnrsFUhACjy44kDkC6LiYjuypazLXjuyytY+M8LHu8x+nMBRAFobcFomQUwNNaAW0bF4+2bhQVlTzVawFuE61kNJnDu7bi1N4gXPueZRgvWHq7DmtI6r4HQMmc59/KCFDyan4KJA6Ng1HEY7RSj4yoDzKIF4BoEDM4F+OuJRly76Rz+7+uugbyjvFV6wLRYebTbeMQYdViQGY/XbkxH8agu10lNQqDPCQBjQrllUqQeJmdxya4L7Vj95RXYeIYDl7u+6Dsr2lD09jmPNi602lDRYoPV7YkdqAB4mx8g8vQXNfjbyUYs2XkRC7ddwP98VY+XjtRLk4u8LSQyw/mE3XNRUPm3TzbhT0fqcWvJeWlJKdEkPXSlEycbLEiM0OO+ccoCAACDZYN2wwnvT0Kgq4rNfWKRSKxJjznXuJrm/yhrxnNfCuXSjRaHx+Qpfy4AF5sAAGDtLRgQZcDr89Kx+ZZrpHSW+DeobrOBNwvCaDH4WJXV2d5IvXDugzu71uVzn+cACOXcADAmybWOYrrTBdnqtk5Dg9nuUdLLGMOJejM6bDw67Aw6zjWGEi+5AOosgBcO1UkrPiWYdMhIMKHG+YBZsvMiHvu0CgAwJNYg3a8FmQnS+79WEU/qcwIAACOc+eEhsi/4jopW3L71PDrsDMPjjdJCFiJzronBtgUjJHP29q3ncdN7FS4LZ4g16ekKGQBA2OZaHiBcMWkA5gxzHRxrSutc0nqfnG+Tlr6KMniKx+xhQhDs35XtaLM6XP6AK/ZU4avaTsx+51s8t78Gz+4TBt2dYxIQqRAAFBkkq+rzNrjNdh7bvm3BlU5RAJRXss11iyn82jlXQqS4pEKqoQC8WABws7hkFgAAFKRFYVRilyUQa9Ij1qiD2cHQ0iL4tFajLwEQnoCFMXZEGziXq7lPirI6eFS22aDngGviXQXglox4GDjgs0sd+H5JBb5ttqLTxmPe5nKP9SA3nGjCfdsv4s4PhB2t4oyuMRTRBWgOcBs4q4PHvdtcranvjYrHD/OTpd+/qjVL34/vOatTAeH+vVc8HINUrgLVJwVArLB6sigN80bEIjFCDzvfNYBnD4vF45NTkRypx/Qh0RgQpcf3RsZjSKzRJTjWaHFg98V2vHykDv/3db30fl8WAADJ8gAEV+THkwa4HHOnyeLAgcvCk2moF3EZmWDCiHgjmq08Zv79Wxx0ugIj4o2o63TgkQ8vodnK472yFlxstWFkggkPOc17XxQNjsZkp39Y3+nA68cacFtJBc63WPHHQ7WYtvEcnvy8Br8/IAzmRB8xhe9cE4vnZgxEtIHzukdHXacDd/3zghQMNbrHAGxuv4sC0K68ItJg58YstY3C1mQ2HwIgWhRR5lb88fohLq+5Tzaq7RAELzXKAKPOs9BLFIXzLTYs/bASt2ypgJ0J7qOYPmww27Hua2GD1ypnvECeAgQEsU+M0MHiYIozMzttvOSOfny+zSUdGm/S4cGcJI/AKAAsy0/G/W4WYEaCCa/flI4VkwZ4vZY3+mQloGgBZKdE4nczB+OVI3VYf0wwcR/NS8YPxifDoONww/A4j/dmp7h+iUQzViRSz7lYFt5wj7wPizPhveLhaLfxWLmnWoowzxgSDZOew6fO9eGiDZyiuMwYGoOKFtdNSFdNH4glOys9CnDuHuv/6Q8I1soTU1JxxwcXcK7JilKnsPznriqXQSGam+IkIm9wHIfvZsTjeL0FG0+59nPjd4fhj4fqcOByJ9453YS0KANi3C0Ao9tXTRYEVGJwjBFljVY0Nguukc2oEAAEJBcArU2YPMj1c1S22rC/ugNPf34Zs4fFSpWSaTHev/7XxBml8mz3jML5FiviTJFYc7DOY2FWdyuL4zhMGRSND8+34anPa1A4MAr5qZE4Xm/BsvxkXGy14c4PLuB7GXF4etpA/PPbrj0YI/Qc/lE8XCrNXpydiC1nW/DjiQNww/BYxCpYa4NijFiU7f/hIBLWzUEtFgvuvvtuZGZmYurUqaioqAio3eHxroPogZwk/OeEFPxp9hAsy0+BwcfTeMaQaPxk0gC8NHuwV19+XEqEz/cDwD1ZgvLKc9bpcUaMTY7AisIu9Z1zTSyelkXjrTxTTC/ePjoBMUYdbh0Vj+vSY/DLqWnISo6Au8eQGKHHjV6ETQnxyy6vW1Cafjt9SLTX43ImD/QUiYwEE54sEpZ131nRhu9tqZBiANx//RrcDx4Hl+y27Ht0rBAXaG8Fc3gPkg12DtDGZkFAfVkAGDpc+P/8WYAxPFXUdb13zzTjhx9fQm2nA++cacYrzq3Z06K8C4CvLFBFixXrjzVgR0UrDBzwzLSu63gLohYNFu7pN3VmvH68ET/eXY1Xv2nAgeoO7Klsh41neP9sCz4414KTDYJpP2NINF67Md1lXsZPJqViz92jsGB0guLgDwbNLABxc9CPPvoI6enpmDx5MoqLi5GdnS2ds379eiQlJeHs2bPYtGkTnnjiCfz973/32e6gGAOGx7n6bXEmPR7KTVZ4hyscx2GxUyFfmTsUfz5ah+HxJmw5KzyJUhW+FHJuyYhDRoLJJX0lcn16DJ4qSkNZowXzR8YhyqDDd0fGYVt5K24dFQ92pQrsqy/BzbwJnCynPTLBhL13Z3jUdI9OipDMwldvHIqc5EiXakJ/xLqd+3RRmrTWwQ3DYxFv0uG9shZcnx7jsbaANwrdnq7zR8TBpNdhWJwJoxNNwlqEjMHEC2YxN2s+OL3nF5bT6wURaG8FGuuAAQM9zhEtveoG4clo9+UCJKcCKWlA/RWg6jxuGz0Ss9JjcMPmcsX3DFTwl/U+wui/2tdlMf7m2kGYe00sNpxoQnmzFeOSPS0U+fqPcipabC6zQJ/+QpgAFW/S4eU5Q4Ku7VcLxzRar2jfvn1YtWoV/vWvfwEAVq9eDQD4xS9+IZ0zb948rFq1CtOmTYPdbsegQYNQW1vr88MXpibgywXXhry/LVYerVYHBkQZEKFi+etAYBB8vUiDDrpaIYILowlI8u+rtdl4KY00OMboMas2EK502GHjGWKMOiRG6NFscaDNxkuflTF1qaPqdjt4xjwqJq0OhrpOO3QcMKi9Fg5OB9P7hxTbcTz3GFC6F4hPBCI9rQ+eCRV7EXYzki0tqCmYjSGrXlRu73c/BfbvAhJTpHoB9yKoKINOSgvGm/Reg6NWnrns4pQYoYdBx7msimTUcZJ1xSAsXOpNOBhzXS1YJMaog83BPFZEjtBzAQmxP/TrtgV0nmYWgLfNQb/88kvFcwwGAxISElBfX48BA1wHhsvegO2dwJWqkPc33vkPwS3S6xMOgMfX22YN6HPEOv8BCLpv7nsuJTj/ie2p1ZTB8l9khZgmAPLwG5eR5bMd3QM/Bn+sFGhpEv65v+52rUHjx/tsj5t8Hdj+XUBTvXTMczM6GQr30+T+vg6FtpyfnQOgZJRz/vrgjVb/p4SKPhEEXLp0KZYuXQoAKMzPh+7//hnmHnUDvQFISgHqavyf28fRpfje7o0blgHd+n/5DARKGIzg/LSnm1sMNnE6YO2KpB+vM+O9smb8qCBF8qmP1HTgkwvt+I+CFEQGscGLWr73fgUAYESCEc8UpeHBf3Xtkj1tSBSW5aVg6YeVSIjQ47fXDsIgP0HoUKKZAASyOah4Tnp6Oux2O5qbm5GSkuK7YaMR3EDVmtr7uBo+QwjgYuKAmMCDmn7bc3OrcgcCuTmu50wcCEzMC9kl/TI4g+FQTSeKc5KROiIZ5hReWrNg3pShGDAoGq8tGopYkw4mfc9m5sO6OWhxcTHefPNNAMDmzZsxZ86cHgt+EERP8fyswfj1jIF4MCcJHMe51ILkO2eDJkcZenzwAxpaAPLNQR0OBx566CFpc9DCwkIUFxfj4YcfxqJFi5CZmYnk5GRs2rRJq+4QRNhIitS7VO0NjzdKC7aGY9DL0SwLoBWxsbHIyvIdXOopamtrkZqaGu5uAOhdfQF6V3/6Y18GDBiAnTt3+j2vTwQB5WRlZaG0tDTc3QAAFBYWUl8U6E39ob4o0yfnAhAEERpIAAiiH6NftWrVqnB3Qi2TJk0KdxckqC/K9Kb+UF+80+eCgARBhA5yAQiiH9OnBMDf9GKtGTFiBMaPH4+CggIUFhYCABoaGnDDDTdg9OjRuOGGG9DYqLz0Vnd46KGHkJaWhtzcXOmY0rUZY3jssceQmZmJvLw8HD58WPO+rFq1CkOHDkVBQQEKCgqwfft26bXVq1cjMzMTY8eOlSaHhYqLFy9i9uzZyM7ORk5ODl566SUA4bk3Sn0J170JCNZHsNvtLCMjg507d45ZLBaWl5fHjh8/3qN9GD58OKutrXU59rOf/YytXr2aMcbY6tWr2eOPP67Jtffs2cMOHTrEcnJy/F5727Zt7KabbmI8z7N9+/axKVOmaN6XZ555hj3//PMe5x4/fpzl5eUxs9nMvv32W5aRkcHsdnvI+lJVVcUOHTrEGGOspaWFjR49mh0/fjws90apL+G6N4HQZyyAAwcOIDMzExkZGTCZTFi4cCFKSkrC3S2UlJTggQceAAA88MAD2LJliybXmTVrFpKTXdc8ULp2SUkJFi9eDI7jUFRUhKamJlRXV2vaFyVKSkqwcOFCREREYOTIkcjMzMSBAwdC1pfBgwdj4sSJAIC4uDiMGzcOly5dCsu9UeqLElrfm0DoMwLgbXqxr5urBRzH4cYbb8SkSZOk6ck1NTUYPFiYtDpo0CDU1PTcLD+la4frXr3yyivIy8vDQw89JJncPdmXiooKHDlyBFOnTg37vZH3BQj/vVGizwhAb+Czzz7D4cOHsWPHDvz5z3/Gv//9b5fXOY4L22SmcF4bAH74wx/i3LlzOHr0KAYPHoyf/vSnPXr9trY23H777Vi7di3i4+NdXuvpe+Pel3DfG1/0GQEIZHpxT/QBANLS0rBgwQIcOHAAAwcOlEzI6upqpKX5nrMeSpSuHY57NXDgQOj1euh0OjzyyCOSKdsTfbHZbLj99ttx33334bbbbpP6E457o9SXcN0bf/QZAQhkerGWtLe3o7W1Vfr5ww8/RG5ursuU5jfffBO33nprj/VJ6drFxcXYsGEDGGPYv38/EhISJHNYK+R+9Pvvvy9lCIqLi7Fp0yZYLBaUl5ejrKwMU6ZMCdl1GWN4+OGHMW7cOKxYsUI6Ho57o9SXcN2bQDvdZ9i2bRsbPXo0y8jIYM8991yPXvvcuXMsLy+P5eXlsezsbOn6dXV1bM6cOSwzM5PNnTuX1dfXa3L9hQsXskGDBjGDwcCGDh3KXnvtNcVr8zzPli9fzjIyMlhubi47ePCg5n25//77WW5uLhs/fjy75ZZbWFVVlXT+c889xzIyMtiYMWPY9u3bQ9qXvXv3MgBs/PjxLD8/n+Xn57Nt27aF5d4o9SVc9yYQqBKQIPoxfcYFIAgi9JAAEEQ/hgSAIPoxJAAE0Y8hASCIfgwJAEH0Y0gACKIfQwJABMXBgweRl5cHs9mM9vZ25OTk4NixY+HuFqESKgQigubJJ5+E2WxGZ2cn0tPTXXZ+JvoGJABE0FitVkyePBmRkZH44osvoNcr7ZFL9FbIBSCCpr6+Hm1tbWhtbYXZbA53d4ggIAuACJri4mIsXLgQ5eXlqK6uxiuvvBLuLhEq6XNbgxG9gw0bNsBoNOLee++Fw+HA9OnTsWvXLsyZMyfcXSNUQBYAQfRjKAZAEP0YEgCC6MeQABBEP4YEgCD6MSQABNGPIQEgiH4MCQBB9GNIAAiiH/P/AfqAJWstLYjEAAAAAElFTkSuQmCC' style='max-width:100%; margin: auto; display: block; '/>
+<div id='140059295746480' style='display: table; margin: 0 auto;'><img src='data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAPwAAAD2CAYAAADyMOoBAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4xLjEsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy8QZhcZAAAgAElEQVR4nO2deXgUVbr/v1XV3dkTEiBsYYtBIAlJgAABBA0oAjPGYVNcUEZHVLzXOzCoMz83dPDiKDqo6HhRroqjchUHg8MyigiirAGUYQ+QkISErGRPr3V+f1RXdfVelXSls5zP8/DQqa4+dbq6vud9z3vecw5DCCGgUCjdAjbYFaBQKO0HFTyF0o2ggqdQuhFU8BRKN4IKnkLpRnQ6wc+cOTPYVaCoZNrnlzD643zkfFUY7Kp0ezqd4KuqqoJdBYpKrplsAICrTdYg14TS6QRPoVBaDxU8pd0goDlewYYKntJ+UL0HHV2wKxAIKioqsGLFCpw9exY8zwe7OhQXKpos0uvMtXq/57MsixEjRmDNmjWIj4/Xsmrdji4h+BUrViA7OxsbNmyAXu//gaK0L6erjdLr5J6hfs+3WCz4+OOPsWLFCmzcuFHLqnU7uoRLf/bsWdx7771U7F0EvV6PRYsW4ezZs8GuSpejSwie53kq9i6GXq+n3TMN6BKCp1AoyqCCp1C6EVTwGkAIoe4opUNCBR8gCgsLMXLkSCxduhRjxozBgw8+iMzMTKSkpOD5558HABw+fBhz584FAOTm5iIsLAxmsxlGoxGJiYnBrD6lm9AlhuXkjP44X5Nyjy8a5vecc+fO4YMPPsA777yDmpoaxMXFwWazYfr06Thx4gTGjBmD48ePAwD27duH1NRUHDlyBFarFRMmTNCk3hSKnC4n+GAyePBgZGVlAQA+//xzrF+/HlarFWVlZTh9+jTS0tKQlJSEM2fO4PDhw1i+fDl++OEH2Gw2TJkyJci1p3QHupzglVhirYiIiAAAFBQUYM2aNThy5AhiY2OxePFiGI1C8smUKVOwY8cO6PV63HzzzVi8eDFsNhvWrFkTtHpTug+0D68B9fX1iIiIQExMDMrLy7Fjxw7pvalTp2Lt2rWYOHEievfujerqapw9exYpKSlBrDGlu9DlLHxHID09HaNHj0ZKSgoSExMxefJk6b0JEyagvLwcU6dOBQCkpaUhPj4eDMMEq7qUbgQVfIAYMmQITp48Kf394YcfejwvLCwMJpNJ+nv9+vVaV41CkaAuPUVz5L6LxcaD7n0SPKjgKe1Kfq2ZLnUVRKjgKe2OuMYdpf2hgqdQuhFU8BRKN0IzwT/wwAOIj49Hamqqx/c/+eQTpKWlIS0tDZMmTcIvv/yiVVUoFIodzQS/ePFi7Ny50+v7Q4cOxd69e3HixAk8++yzWLJkiVZVCQorV65sl+y5Dz/8EKWlpQErb9KkSe1al8LCQq9GgRJ4NBP81KlTERcX5/X9SZMmITY2FgCQlZWFkpISrarSpQm04Pfv3x/wutCUoo5Dh+jDb9iwAbNmzfL6/vr165GZmYnMzExUVla2Y83U8dJLL2H48OG4+eabce7cOQDAxYsXMXPmTIwdOxZTpkyR1mkrLy/HnDlzkJ6ejvT0dElor7/+OlJTU5Gamoq1a9cCcEy9feihh5CSkoIZM2agpaUFmzdvRl5eHu655x5kZGSgpaUFL774IsaNG4fU1FQsWbJEGvO+6aabsGzZMkydOhUjR47EkSNHMHfuXAwbNgzPPPOM9B0iIyMBAHv27MFNN92E+fPnY8SIEbjnnnuksjxdw1Ndjh49ihtvvBHzpk/CQwtuQ+XVMgDAqZ+PIT09HRMnTsTbb7/dDr8MRYJoSEFBAUlJSfF5zu7du8mIESNIVVWVojLHjh3r85j19gxN/vkjLy+PpKamkqamJlJXV0euu+468uqrr5Jp06aR8+fPE0IIOXjwIMnOziaEEHLHHXeQv/71r0KdrVZSW1srldHY2EgaGhpIcnIyOXbsGCkoKCAcx5Hjx48TQghZsGAB+fjjjwkhhNx4443kyJEjUj2qq6ul1/feey/ZunWrdN6TTz5JCCFk7dq1pF+/fqS0tJQYjUYyYMAA6f5HREQQQgj5/vvvSXR0NCkuLiY2m41kZWWRffv2+b2GWBez2UwmTpxIKioqyJnqFrLmvY1kzt33kVNVLeT65FSy67vvCSGErFixwusz4um3prSNoKbWnjhxAr/73e+wY8cO9OzZM5hVaTP79u3DnDlzEB4eDgDIycmB0WjE/v37sWDBAuk8Ma129+7d0hLMHMchJiYGP/74I+bMmSPNups7dy727duHnJwcDB06FBkZGQCAsWPHorCw0GM9vv/+e7zyyitobm5GTU0NUlJScNttt0l1AoBRo0YhJSUF/fr1AwAkJiaiuLjY7TcYP348EhISAAAZGRkoLCzEDTfc4PMaIufOncPJkydxyy23wGQjsNls6N2nLxrq61BfV4vJ9rkEixYtcppcRNGWoAm+qKgIc+fOxccff4zrr78+YOVyXx0PWFlqcZ0Aw/M8evTogZ9//lnR54mPlNOQkBDpNcdxaGlpcTvHaDRi6dKlyMvLw8CBA7Fy5UppWq68DJZlncpjWRZWq3v2m+s1rVar32vIv0tKSgoOHDiAM9VGadOZ+rpaMAwDnmbXBgXN+vB33XUXJk6ciHPnziEhIQEbNmzAu+++i3fffReA0A+srq7G0qVLkZGRgczMTK2q0i5MnToVW7ZsQUtLCxoaGvD1118jPDwcQ4cOxRdffAFAEIE4/Dh9+nT87W9/AwDYbDbU19dj6tSp+Oqrr9Dc3IympiZs2bLF78IYUVFRaGhoAABJeL169UJjYyM2b94c8O/p6xryugwfPhyVlZU4cOAAAGFziQtnTyM6pgeiomPw44/7AAjDs5T2QzML/9lnn/l8//3338f777+v1eXbnTFjxuDOO+9ERkYGBg8eLAn1k08+waOPPopVq1bBYrFg4cKFSE9PxxtvvIElS5Zgw4YN4DgOf/vb3zBx4kQsXrwY48ePBwD87ne/w+jRo72674Aw/PnII48gLCwMBw4cwEMPPYRRo0ZhyJAhGDduXMC/Z48ePbxew7UumzdvxuOPP47ymlrYrFYsevg/kDQiGave/B/84b8eRWREOG699daA15HiHYb48iM7IJmZmcjLy/N7jNIxIITgTI3J7XhCpB7RIZzPz9LfNfB0iGE5CqW1fHCyBp+fqw12NToNdAEMiqZ4cx8D4VZWNlvx5vFqAMAdw3sEoMSuT5ew8CzLwmKx+D+R0mmwWCxgWd+P55VG+purpUsIfsSIEfj444+p6DsgrYkQidtFjxgxwud5ZXQhDdV0CZd+zZo1WLFiBd599126xVMHgydAebN7Q9wjhEOYzrO9YVkWI0aM8Dv56GqTo1xCCF0IVAFdQvDx8fFS1hqlY1HTYsX0zQVux1+Y1Ac510W3qexSmYXnCcBRvfulS7j0lI6LzYtLbwtAql2ZrA9PM/eUQQVP0RSbl058IPRplLUm3q5DcYYKnqIpNi8hlUAIlCdywbe5uG4BFTxFU7wJO9AuOE8tvCKo4Cma4s3yBkLw8jKohVcGFTxFU7wF5wJhkeUl8DRqpwgqeIqmaGnhCbXwqqGCp2iKln14uZdA+/DKoIKnaIqWUXp5CdTCK4MKnqIpPAhSq8/jo91/wvBrl6TjgTDI8jJoF14ZVPAUTSEEePeHF5By7SLe2P+ydDww4/CO1zTxRhlU8BRN4QkQygspsFHmJqfjbYXInHrq0isjaHvLEULw+OOPIykpCWlpaTh27JhWVaEEEbkOGciDbAEoW+7SU59eEUHbW27Hjh3Iz89Hfn4+1q9fj0cffVSrqlCCiHzJRCbAUXWaeKOeoO0tl5ubi/vuuw8MwyArKwu1tbUoKyvTqjqUIOHN8AZCoE6JN7QPr4ig9eGvXLmCgQMHSn8nJCTgypUrHs/tLHvLUdxxdullxwPi0ge2i9AdCJrgPa2O7W3FkiVLliAvLw95eXno3bu31lWjBBDn3zmw01nlQ/w0Sq+MoAk+ISEBxcXF0t8lJSXo379/sKpD0QhvC47RcfjgEDTB5+TkYOPGjSCE4ODBg4iJiZE2N6R0HeSiZEhgLby8BCu18IrQbE27u+66C3v27EFVVRUSEhLwwgsvSKvKPvLII5g9eza2b9+OpKQkhIeH44MPPtCqKpQgIrfw8g5b4Ifl2l5edyBoe8sxDIO3335bq8tTOgreZssFoGg6eUY9NNOOoilyIbLyxJsAmHjnoF2bi+sWUMFTNMWbJQ+IQGnQTjVU8BRt8SJEEoB1a+mwnHqo4CmaEkgLf67GhJ8rWhxl08Qb1XSJnWcoHRdvwbTWGOSF24oAAPsXXocwvbOtohZeGdTCUzSHlw3Izbm0Cz2NtW0SaLNV8BucJs/QYTlFUMFTNMXV1X76+Hqs3/t8m1xw8bO8U9COWnglUMFTNIUn7nG7wY1lbRI88fCKDsspgwqeojEExMOkqLZs6y1ac2rh1UMFT9EUQZTugg9vutbGMukCGK2BCp6iKd50GF9d7OUdL+X4GYKjw3LKoIKnaIqnPjwA6C0tHo76LkfEJrn0NJdeLVTwFE0hxHMfnrHZVJXjKW+ebkShHip4iqZ41aHKoJ3cpRc3qHTaW4769IqggqdoCk+cF74QYXiVFt6jS+/5fYp3qOApmkJ4Aj1xF7dawTtbc/sx2fs0tVYZVPAUTSHEs+uu2sLLXovLWdFVa9VDBU/RFqvV83HVLr28D28/JnufWnhlUMFTNIXhPQueUR20c7y2EfegHbXwytBU8Dt37sTw4cORlJSEl19+2e39oqIiZGdnY/To0UhLS8P27du1rA4lGFg9W/K2uPQ2Yh/uczlG8Y9mgrfZbHjsscewY8cOnD59Gp999hlOnz7tdM6qVatwxx134Pjx49i0aROWLl2qVXUowcIWGAvPuwzLueqbDsspQzPBHz58GElJSUhMTITBYMDChQuRm5vrdA7DMKivrwcA1NXV0Y0ouiDeXfo2ROkJcVtAg+pdGZqteONp77hDhw45nbNy5UrMmDEDb731FpqamrBr1y6PZa1fvx7r168HALq3XGfDS9CObcs4PO++dBYN2ilDMwuvZO+4zz77DIsXL0ZJSQm2b9+ORYsWeZw2SfeW68R4EbbqoJ3stZUQt+eLWnhlaCZ4JXvHbdiwAXfccQcAYOLEiTAajaiqqtKqSpQgwHrJmVefaec8LOfWh6cWXhGaCX7cuHHIz89HQUEBzGYzNm3ahJycHKdzBg0ahO+++w4AcObMGRiNRmrBuxo2i8fDjJeEHG+4pta6WnRq4ZWhmeB1Oh3WrVuHW2+9FSNHjsQdd9yBlJQUPPfcc9i6dSsA4LXXXsN7772H9PR03HXXXfjwww+9bhlN6aR4sfCsl2CeN5yDdu6r3tLpscrQdJnq2bNnY/bs2U7HXnzxRel1cnIyfvrpJy2rQAky3qbBqh6Wg59hOap3RdBMO4q2eOmrs6rH4R2vbcTdotNxeGVQwVM0hXgRdttcejoO31rozjMUbfHSt1YdtJO9fvlwJd47UeP0Po3SK4NaeIq2eBG2WpeeEII/HVuPVw6sAQhBtdG5q0AtvDL8WvizZ88iNzcXV65cAcMw6N+/P3JycjBy5Mj2qB+ls+PVwqvPtJtXIGRi9jA3oDYk2ul9K7XwivBp4f/yl79g4cKFIIRg/PjxGDduHAghuOuuuzzOfqNQXCFeTC/XhqAd68FrsNK95RTh08Jv2LABp06dgl6vdzq+fPlypKSk4I9//KOmlaN0AQK04o18IM7TGnlW6tMrwqeFZ1kWpaWlbsfLysrAsrT7T/GPt+Ac2wqXXvqsh7Vw6bCcMnxa+LVr12L69OkYNmyYNPOtqKgIFy5cwLp169qlgpTOjTeXXn3QTvZZTy491bsifAp++PDhOH/+PA4fPowrV66AEIKEhASMGzcOHMe1Vx0pnRlv4/BqLbxsA3i5Sz+kvgQWVg9r78Gtq183w6fg58+fj6NHj+Lpp5+WJrlQKKrw4tKrD9o5GgjO/tpgM2Pzt8sBAPcvyfX4OYozPgXP8zxeeOEFnD9/Hq+//rrb+8uXL9esYpSugad1EQDBLecJAat0spSsa6CzNyIRsv3paJReGT4jb5s2bUJISAisVisaGhrc/lEofvE2LEdssKkQqXxhFM5Dd8DWhv3muxM+LXxNTQ2eeuoppKenY9asWe1VJ0oXwnuUnoeVJ9Bzyiw8kQ3jcfbXOrnwrZ7n3VOc8Sn4jz76CI899hiuv/56lJeXY+bMmejbt2971Y3SBfC28wzH86qy4+STcMQovV42AYd4WQ6b4oxPwb/77rsAhPTaHTt2YPHixairq0N2djZmzpyJyZMn02g9xTdeRM2BV9XvJh768HLBUwuvDJ99+IKCAgDAiBEjsGzZMuzcuRO7d+/GDTfcgC+++AITJkxol0pSOi/eFrrgeJuqGW5OLr3dldfJBa9yum13xafg58+fDwCYPn26dCwsLAyzZ8/GW2+9hby8PG1rR+n0eJM0R2yq0mHlLr3Uh5eJnPG2hx3FCTosR9EWu1B5lnNai54j6lx6XtY4cNSlbzV+h+VCQ0NhtVrR2NjoNCTX2NjYXnWkdGbs4uR1zhOwOMKrW7TCaVjOXfAMFbwifAp+27Zt0Ov1WLp0KSIjIxEVFSX9i4yM9Fu4v80kAeDzzz9HcnIyUlJScPfdd7fuW1A6LnZR8zqD02FxWE5xMR7G4Z0ET/vwivDp0ovJNefOncORI0dw++23gxCCr7/+GlOnTvVZsLiZ5Lfffivl3+fk5CA5OVk6Jz8/H6tXr8ZPP/2E2NhYVFRUBOArUToUMpdeDsfbVLr07n14ueBZ2odXhE/BP//88wCAGTNm4NixY4iKigIg7Am3YMECnwXLN5MEIG0mKRf8e++9h8ceewyxsbEAgPj4+NZ/E0qHREq8cZlOzREexja69DqX/HobT8CxdF8DXyia1F5UVASDweGSGQwGFBYW+vyMp80kr1y54nTO+fPncf78eUyePBlZWVnYuXOnx7LWr1+PzMxMZGZm0s0kOxmipomrhbcLVHE5fobl9LyVLnOlAEWr1i5atAjjx4/HnDlzwDAMtmzZgvvvv9/nZ5RsJmm1WpGfn489e/agpKQEU6ZMwcmTJ9GjRw+n85YsWYIlS5YAADIzM5VUmdJBEC28u+DVRenlCTw6D314nb2LEELzwHyiSPBPP/00Zs2ahX379gEAPvjgA4wePdrnZ5RsJpmQkICsrCzo9XoMHToUw4cPR35+PsaNG6f2e1A6KnahEpeMTFZllJ73k1qr5610mSsFKF6XfsyYMRgzZoziguWbSQ4YMACbNm3Cp59+6nTOb37zG2nL6KqqKpw/f17q81O6CLxnC69Tm3hjkwft3AWv4610mSsFBHUzyVtvvRU9e/ZEcnIysrOz8eqrr6Jnz55aVYkSDCSX3vlRY9W69B6G5XSyfr2eWOkyVwoI6maSDMPg9ddf95jFR+ki2EXI60KcDnO8Td1sOdmsO099eOrSK4NuNUXRFDFoVz94JGISBoDpMwDkq432oJ2aKL0stZYXh+Wcg3YWKni/0LWmKdoiWnGOA/fUGjB3Piz8SXhVK97Id6H1FLTT8Va6ZbQCqOAp2iK64oz9UbNH6zmi0qX3k1orDMtRxfuDCp6iKW6ZdnbBs4RXF1X3MA7vlnhDBe8XKniKtogiFHOu7MNzOsLDqsIHJ35my+kIFbwSqOAp2iJaZrtLzzAMbKwQK+ZVTGn1twCGYOHbWtmuDxU8RVvs1lieVs3b3XpiUTGHXUEfXtX8+m4KFTxFW0QRyhJvbJywGAavYkqrv1VraR9eGVTwFE1hXKP0AHhOdOnNygtySrxxnx4rpOq2oaLdBCp4iqZIGz/KXXp7H77VLr2HBTB01MIrgmbaUbSF99CH19kF30qXft6lbxBlaYLB5mgwdHQ+vCKo4Cka496H5+19eKJm4UmZmEN5C3Iu74FV1k2gUXplUJeeoimMy7AcABB7Hx4WFevQ8e5bSelcJtTQXHr/UMFTtEWK0jtcelHwaiy8t22nRWiUXhlU8BRtEcfh5S69uEa9Gpfez3bQet4KM5094xcqeIqmOLaLbpuF9yt4mwVmauH9QgVP0RapCy971MQ+vJq15L1sOy2i522wUAvvFyp4iqY4Em9kFt7u0jM2NRbet5gNPLXwSqCCp2iLPdgmt/Ci4KEi8Yb47cNbaB9eAZoKXsnecgCwefNmMAxDt5/ugnhKrZVceg9DbV7L8XOunrdSl14Bmgle3Ftux44dOH36ND777DOcPn3a7byGhga8+eabmDBhglZVoQQRxoOFh+jSB3BYzsBb6Ti8AjQTvHxvOYPBIO0t58qzzz6LJ598EqGhoVpVhRJEpJ1n5JsO2VNrVW3x7C9oR6P0itBM8Er2ljt+/DiKi4vx61//2mdZdG+5Tow0d8bxqDGtyKX3F7TTE+rSK0EzwfvbW47neSxbtgyvvfaa37KWLFmCvLw85OXloXfv3gGtJ0VjPCTeMHr7xqSqLLyfPjy18IrQTPD+9pZraGjAyZMncdNNN2HIkCE4ePAgcnJyaOCui+EpaMdKmXaBs/AGmmmnCM0EL99bzmw2Y9OmTcjJyZHej4mJQVVVFQoLC1FYWIisrCxs3bqV7g7bxXAE7RzeHatvjeD9p9bSoJ1/grq3HKXr4ylKz+rtQTs1iTd+M+3oOLwSgrq3nJw9e/ZoWRVKkPCUacfZ+/DqovS+xawjPCxqPIZuCs20o2iLRwsvptYGxqUn9sZE1ZJZ3RQqeIq2eOjDc5JLHyDBh4QJ/5tVLIrZTaGCp2iC0crjtbxKtFiE4TQii9LrDIJLzwWoD09aM8zXTaGCp2jCDyVN+PuZWmkNeVZu4Q1iaq3Vb8qshJfzrAwH6ATBq5pf302hgqdogjhExoipdpBn2gmCV7OWPOPNpWdZQIwJWKhL7w8qeIomSDL30IcXJ8/oeStMSjeJ9+LS6/S61mXudVOo4CmaYHOx8E6ptTLBK06H9daHZznJwquZX99doYKnaIKYA8N42FtOnC2nZuFJxlvDwOnASuP61KX3BxU8RRPEnVxZafdY2aNmF6iq7DhvC2DI+vA6G12q2h9U8BRNELvmLDz04fUhAIAQmwrBe4vmc5xTTIBOkfUNFXwnpqrFip0FDVJ/uSMhWngpl16WWgv7OLyqhSe99eE5zsljMHXAe9GRoHvLdWJ+u7MEJY0W1Jp6Y+GIHsGujhOihZeCdnKX3iBYeIPNrNjCe13EktVJgjfwFrRYefQI4VpX6W4AtfCdmJJGISp9oLQ5yDVxx+pi4a2QW3hB8KEqBO81tZZjpRV09LwVzRa6o6QvqOC7AB1xHrhYJXEcPiZM5kzKLLJiF9yrhedkMQEzWqwd7150JKjguwAdUfBiXGFgpOBes6zMzZZceovyIJvXPrwOCBEWQA2xmamF9wMVfDvTbOFxorIloGV2RMFbXSy8fD68aOFDbGaYFPfhfUTp5YKnm8T7hAq+nXk1rxL37yzBl+frAlZmRxS8I9POfQEMGASBGniL8rr7WvFGFhNooYL3CRW8D0obLdhRUK98RpcCvrpQDwB4++fqgJXZEQXP26y488J2RNWWCwcY50w7AgYG3gqjWWE6rLc+vNUqWfhQqwnNlo53LzoSdFjOB/+xuxQFdWZUt9hwb3JsQMu+ZrKBEOI8Pq0CeSNk1SjZ5P/O1eK7y414I7s/wvTqbEPi6R/xq18+dByQJd4wDAOrzgC91YSWFpOyAr0JnrcB9gUwqEvvH2rhfVBQJ+Rmb84PnPsdY3Dc8msm5XuruSJPWGnWKDL98uFKHClvwY7CBtWf1RsbnQ8wzo8ab+/Hm4xGReWJDZyl9wDnN6xWmUtvooL3Q1A3k3z99deRnJyMtLQ0TJ8+HZcvX9ayOq3mcn1gZmGZbTzqzI4Hst7U+odTPvxUZ284CurMePjbkoAHBY2taFAsrIvzyDp7Mrx90QpTszoL3/Cre8F+us9x3GZxuPQ2M1qoS++ToG4mOXr0aOTl5eHEiROYP38+nnzySa2q0yoGRDoe2kDkaFe1OFv0OnPrLbx8+MloIzDbeDz701UcvtqCJd9e8fFJZbTIym/NhBS3FWldLbzdKpsVWnjIJuEw4ZGO41YrGEnw1ML7I6ibSWZnZyM8PBwAkJWVhZKSEq2q0yrkQ0YNltaLU6SqxXnRxnpzWyy882ebLARlTUL5Soe6fFEhq2u1Uf3yz24LVLrGKuwuvVLBiyvesJzLI8vb6LCcCoK6maScDRs2YNasWR7fC9ZmknIr2tgGcYpUulj4+jb04V0zygI9HFXRLBN8i/p6ugve+VFj7BbeYlTo0tstPMe55Mk79eHNTp5JMDh/zYRrxrYbB60I2maScv7+978jLy8PTzzxhMf3g7GZJE+IUzCs0cLjYq2pTSKtbHYWQV0b+vCuGWXNFh6ti/d7Ri74ypZWWHjXTSFcfnvGPmPOalLah7fPr2ddHlmbVYrSh1pNmgUwlXCq2og7/1mEh3d1LE9VTtA2kxTZtWsXXnrpJWzduhUhISFaVUc1roGqk1VGzP+6CPdsL/byCf+4uvQNbejDu1r0QLuypY1ts/Cs6xLUrGcLb1MqeOLFpZeNw4fYzGgKooX/vkgYmci/ZkZFsxUr9pbh35UKYxTtRNA2kwSE/eEffvhhbN26FfHx8VpVpVW4CmhvSRMAxwy11iBaysQYwbrVtaGb4GrJmq1EmoMOtD3IeLDMMQOvNX14+OnDc3aRKhU8Iy137cnCO4J2jW1oRNtKucwr+r9ztfiuqBFfBnBINxAEdTPJJ554Ao2NjViwYAEyMjLcGoRg4mopamT9stZO0BCj9Nf1EAR/uKy51YtXuFr4RrPNqYvQljH+OpMNv1S2SCNptSZedQPC+hG8zu7N8WajskxGXuzDs87lEeLUh28IooU/U+1ovPYUCwairg2/gxYEdTPJXbt2aXn5NuEqqAvXHD9mWZMF1/VQ3/0Q+/DXxRjwLYCLdWbkXkoJiocAABtVSURBVKzH3GExba5fWZMVctlUt1gRH966n3d/aRNsBBjfNwyX6syoarGh2mhF3wi94jL8Be3YkBAQADqrGWaeIITzHYHQ8UJ50lbTnM6xLLXMpW9LbkNbKW1yeH+X7ElbbRl61QKaaeeFJpcEDrkHfaWVbr0YpR/Z09FYHCpr3eIVrjnjrx+tcvo7v1b9Cq6fna3Fnw+U46NTtQCAqQkR6G2fx+6aQ+APNwvPeh6WC7GZ0eCna8MTAr29PNZuzcWVbwE4ZdqZbbzyte4DiIUnHufiB7MB8gQVvBd8BcHkAS2lWHiCWpMNLANM7h+BWwYLySPi2Lla/A3DHShtUl3eK0cq8Y8L9Thn92amDIhAzzBhGMw14OgPd5fe5VELiwAARFiMuOrnHth4wMALDZgY7APnEDyj0wM6HXSEh47Y/DYgWtDgxXWnFr6T4Gs8t7BevfUUYwKRehYcy+CP44ThxYI6c6tm44kNUpTB+Se8eZDQkBwsa1ZVrmvDExvCYVC0Ab3sFl5tpN6v4O3ZchHWZpQ0+PaYrITAIEb9xV1mXMfj7VNuw6zGNiU0tRZv16w38QGdbdlWqOC9IAo01EPf8vw1hUNJMkSLHK4TbnlsKIcYA4tGC++WkKOmvF6hzg/+TQMj0CuMQ62JR5EfIckpdemmpPUOdSpftYXn/bj04YKFj7Q0++0iWXmCEN5F8AOGCv9HRtvLi5TKa8twZ2upt18zxqUBNvMExg60dDYVvAfe+bkaLx6sAADcMCBCOj5rSBQAYZxVbastRvbFaaYMw2CofXhOnJWnBrG/2CvMOTDXN0KPtF6CWH9RMQYsCv66GAOmJkTgj+MFD6SnvXy1yTec297vroJ3CLTYT8NkI4BetPB2l55d/hKYG2eDXfW+cDxS+G2iLU1BcelFC399rHswty3JWoGGCt4FC0/w3r9rpL9nJ0bhpcl9kNY7FA+nxyEulEOjhVfdjxcFGq5zPPhtEbzUgOgcP+G9I3tgTHwo0noLmWf/rlIjeOH7zBwahTey+0sRebEPr3aYzz1o55J4E+EQvL/cBk8WnundD+yyl8AMGSYcjxAsfZS5SbGFzytvxsPflqC4wYxzNSb8I7+u1e63eM24MPclstuSbxFo6AIYLpx0EUlyXAj6ROgxO1F4oAZH61FjtKG0yYIBUcqHqUSBhssEmhgACy9PtvlDpmCVE+3j/P76xnLEIaX+Ec6PRKx9jXe1+eFuFt41rTrM3oe3tOBSreAxWYlgDXu6eC1WnsBgs98j0aV3xe7aR1saFVv4h74R5nasPlSJA/bRkpgQDtMHRfr6mEdECx9t4DBvWDT2FDehRwiHi3XmDjUWTy28C0fLneeSu45lx4UKf6sVgBhkk68cI1r4S60SvFCemMQjJ94umIpm5V6I+H1cxRYb2jrBu/XhXYN2dgsfbWvBNZMNlS02vHW8CjdvLsCfD5Q7nSpE6UWX3rPgmUiHha9VKbADsqFR1wZfKeLwW7SBxTNZffCveUMxKFowCB1J8NTCu1BoF99NCRF4cFSc24QfSQAqf0RH0M5RnijW/Gsm1ctdiQ1IznXR6Bmmw4S+4dJ7YiOlpt8tBp2iXYJOrRW8zk8uvdiHj+WFBvb8NRN2XRZy0f9xoR73pcRicLR9go1TlN5LwlOEvQ9vbnLKilRLa2e6Oe6fcL84lpFeazVqcLyiBRdqTZg/LEbxs9MpLfyms7W4/atCnK4O/MSEYnt/8p7kHki1B7/ktNbFFRNl5C59n3AdeoVxqDPzqlfVEV36SD2L+5JjMTzOIYQeISz0LIMGM6942qzcJZUTY+DAQOiHqlksk3Xd7dX1gbQLPsoiWNd3fq52Ghr88Yojj8DKE78WXnTpoyyNioYQvfXVD19tbtWCH2I3Qj5MGhMivNbCwp+rMeGBf5Xgvw9V4lS18lGjTin41/IqUdRgwT3bi2EM8CyxYrvwBkZ67p+31uJ5cukZhkG6PcD2s8plqTwF7eTl9rYHjx7ZdUVRIEqc7x8d4lwexzLSXm1qHlzO1aWHSx3sgg8zN0PPMjhT4/zQrsmrwsr95bDxBFaLFTrCw8awYDgvTqnYhzc3KZrs4+33K2uy4n9P1nh8zxeShZfta6elhf/6Yr30+lh5C2qMVkVdmU4neCtPnNJcAzkbqcnC45rJBgPLoLeXPHTJwqtstZut7kE7AMjorX4IjRAiNXSeBA8AV+399xOVRum1N2w8QaN9Pn2Eh9VpxUbu28uNbu95w03wFpe/Q0IBlgNrMWH2QId38quhUdLr3Iv1OFltBG8WGgML5yNIGiEG7ZoUWfhyH/ekNXv1iaKO0sstvPqG0pVzNSbsLnK/7/Lchb8eq8L0Lwpw5z+LcLHWt7XvdIJ3ncX2nYeb4cq5GhM+PXPN74wvMaqdEKUH66VPJD78xQ0W5F6ow+pDFZiy6SKOV/i20OLiiuF653JFC/+Ln8/LsdgbPT3LQO9l0skoWXfEX2KLOMMs0sB6/N7iPX/lSCX++1CFomEvnWuU3iUzjmEYKXCXHOo4V573AACnqozgzUJcxcp5cecBMFGOoF21Au/L01DgnCShjAu16vMsHBbeg0vfykSgepMNC7cV4Q97y3DGpft6pcm9/hXNVsz/ugj7SrynVXc6wYtjmr9NEdaJL6xz/uJlTRZ8fPoa9hY3SgJfdbAcr+ZVYfynF3DblkK3mydS1CA8WAk+httEwZ+tMWHlgQp8fr4OjRYe/2/fVZ+TNrxZ+BFxIQjhGBTUWxRHl49VCPWPCfH+8z0/sY/0+oqf4TkxMcQ1YCdywwBHQPCL83V45YiwzJiNJ/jyfJ3H0QDO3oc3znkAzL3/AaZXH7dzENsLADCcd7jQqb1C8eIkx7knq0yS4H1a+Chhu+w4cz2aLELs4qNT1/DJmWseT79gn1yUEKnHI2lx2DAjAX+aEC/lWaid49Bgco+BxIgufSsm0BBC8OnZWunvb2TeFSFEypt4NiseY/uEOX1WnkfiSqcTfJOFh44FFiXHIkzH4JrJhj/sLZWCU68crsTrR6vw+z1leG6/IMKTsqBGSaMFf9x3FbyHFly08AN9CD4u1D2xAhBc6KxPL0p9q1qTDedqTHjvRA0azTZH7ru5CeToj5IF0XMMUnoK1lgcEqwxWvHByRoUecjZJ4TgzWPCzLiFw73vCT80xoDfpQqN4soDFT5n5TV4CdiJ/H5MLyTIYhpi9+OrC/VYdagCC/9Z5PYZcTorn50Ddv6Dni/cfzAAYEhjmXRoQKQOt10XjU9nC+shnr1mAm8WrmfVebfwiBNyEHqbBIGfv2bC2mNVWJNX5TFwmW9Pj16a0RMPp/fEmD5h0LMMhtlHTk6pDAiLFt45aNc6l/7vp6/hhk0X8T8nHMLdUdAgGZR6M48mC48IPYs5SdF4f0YCcq5zdIV8Bew7neAJEdIXY0M5GOz52buLmrD6UAUsPMHhq44He2dhI7I+vehWRlGDBYX1FphdLLKr4InFDFLm/DDHhXIe8+tFnttfjk/OXMPincVYuK0I7/xSjTeOV0uTcdJz3wD/5/8E+fJ/pc9MtlvQvcVCK/7pmVq8ebwat+delpZIEhuIoxUtOFNjQo8QDveM9C54AOgnE+nG054tHeDIEnOdiCMSaeAwbZCzq/2P/DqsOiSkH18z2dwmG4l9eEbvvfFkBgwRrltZgg9uTcDm2wZJw0vib1DWaAGxr4pj9WXhe8QBDIMeLXXgeBt+u9OxrpzrPAFASI8GgOtjnRuRSfYuxVZZUAwQGmHXFFlCCE5XG9Fs4dFsJWAZ5xhItOTSq7Pwrx2tklY0ijGwSIwxoNxuUBbvLMbj35cCAPpH6qT7NSfJsabCCR/xoE4neAAYYh+f7S97oHcUNmDe1stothIMjtajl0uK47RBEdg2Z4jkns7behkzvyxEtWysWszpFq0Zv+aP4B+9HeTMz9I5LOMc0Fs+themDXQWw5q8Kqdhtu8uN6LRLog+ed8CAMjf10nvZw8U+rI/lDSh0Wxz+sGW7y3FL5UtyP78ElYdLMeLBwSRLbg+BqFeAnYifWVZc57EbLTy2HapHhUtouA9W3gATkOUVxot+LN9roFITm6hlMMAAHq74DkfgscAwcKjtBAZ8WFOi4pEGjhE6lkYbQT19s0qfFl4htMBMXFgQTDAWuc0JuA6ichs41HSaAHHAIOincu8LTEaOgb48UozfpNbiEt1wkq4t24ucFvPcOPpWtyzvRgLvhY2UInSO2IgxGZF7IEdiDE1oM6+rZg/zDYed29zNjC/vi4aj6bHSX//UmmUno9f27M/ASAjPgxf5gxGXz+LnnRKwYsZTM9kxePWIZHoEcLByjsEmz0wEk+O6424UA6T+oejVxiHXw+NRv9IvVMw65rJhj3FTXjreBX+50S19HnJpT/0PQCAfOe8nr5BNvNrUXIsfj+2l9MxV2pNNhy+KrjrtiiHVSbNgkUfGmPAkGg96sw8pvzfJRyxu/ZDovWoarHhoW+uoM7M48v8ehQ3WDA0xoAHUmPBf7sFtkdyQMo9L/+d1S8c4+z9u+oWGz44WYO5uYW4XG/GX49WYuJnF/HMT+X4y2FBvD18xARuHhSJVZP7IFzHwNMwdVWLDXf8s0gKXop9eJ23VFg4LDwpuuTx/X72jUCq6gSvzarzk8psd+tfSnZ+6F0n51Q2C3XrHaaDnnVPrBIbgcv1Fiz5pgS3fVUIKxG6g+JwXo3RivUnhA1BS+39ffmQHPn0HejXPY+Xj74Fk414nbnYYuGl7uWuy41Ow5PRBha/TYl1C2QCwCPpcbjXxcNLjDHgg5kJWD62l8drAZ1U8KKFT+4Zipen9MO8YY6W7uG0ODyW0RO3DI7CdwsS8fb0Afh2fiKy7fnRyT2dk2lWHarA/568hnd/qcHVZitCOQb9I/U+W2TXyPjAKAO+zBmMTb8a5NTXndw/HNkDIwRrQwieO/4/4BocgRj+r0+DNAn7tk328KOutAevXBNe7hwuWHfy9ovA1WKQT9/xWE+WYfCUfdbbxVoz3jxejYJ6C/5zdyk2nnbUQ3QfxUk3nmAYBr9KjMbtSe7LcX32q4EY3zcMFp7g83O1uNJgkSw8a/Ah0iHXCyvXFF0AaXTfv66ffQJPTYMgeJuPKD0ASfDJjLM7XtJgwcGyZszYfAmrD1Vgp32vvPgIz9ZwkCyGU220OUX9L9ebYeUJ1hypcltINMrAglgsIDwP8q8vAQDjygTv8NmfyvHmsSrsLW7EOz9XgycEl+vNuPHzS1hl95b+eclxD0I4Bv/IGYyeYTqE6ljcl9wD0QYWz2XFY9+diXg4rafHEZW+EXos8rHxaVD3ljOZTLjzzjuRlJSECRMmoLCwUFG5g6OdH6L7U2Lxn6N74s3s/ngkvSd0Pqzt5P7hWDa2F97I7uexLz6yZ4jweZkwRVGK3DVCaFnlY8YJUXoMjwvB8kxH6zptUCSes0fLBzeUIufSd84XO/IDyDurAADzhsUgQs/i9uuicWNCBJ6eEI8RcSHQuVSxRwiHGYOjnBok0uR9aFJMs5XnDXibjjqpf7jH43LG9XFvFBJjDHgmS1h1eGdhI379VaFjDTofVpkJCQWSUgBCpJiG/Hv1swuytsHuHfmx8Eysfc+Cmko8m+VYBfmL83V4dNcVVLbY8Pn5Oqyzb9UdL5s3QCxmkFohSOZrlKaw3owNJ2uwo7ABOgZ4fqLjOoON1eDvnway7gWg0bnR+XeVER+cuobf7ynDe/+uweGyZuwtaYKFJ9hyoR5fX6zHmRrBVZ/cPxzvz0hwmtewbGxv7L3zOswZFoNIH10vfwR1b7kNGzYgNjYWFy5cwLJly/DUU0/5LbdvhA6Do5xb+igDhwdS4zAlwd1KusIwDO5LjsXUhEismz4Ao+ND8Zskh4cgruGGqzI3ubzUqYzbEqPw8ayB0kMu56aECDybFY+Fw2Mwa2gUeoRw+NXQKIyuPuOxPuSnbwAIbv2+OxOxclIfrM3uj/nXxyCEYzFMNr/6vRkDsH3OEGFosEo2waTO+zBMpEsizXOyOt8yOFLyjm5KiHCbW++JzL7Ogp81JAoGjsXAKIMU4QYh0BN7A6PzXSaTMlb4yJYPQY7+CH7FPbD99hbwP/5L8uSuXBMsPO8rSg8ACUOEsk4ewZwBHL6dN8Tn6YOYZpDDe0DMJvAv/R78Q7NALpwC5yPM/cKBCrz7i3C/X7qhL25LjJYmQd1+aRfQ3Aiye6vTZ6LN7g1yYb3FaZbkc/vLUWviEW1g8da0/h7TugMBQzRaf+fAgQNYuXIl/vWvfwEAVq9eDQD405/+JJ1z6623YuXKlZg4cSKsViv69u2LyspKnxMBMuMicWhGesDra+YJLDxBKMcIPzhvA8yyrKVQ/9bPGwSCBXGbI66gbAtPpK2hw3WsYxkJngfMsmisjzJarDx4ADqWQQjLuH1XArflKXzSbOVBICxiEybbGMJGAKONBwthqSkrwyFkS57Pskj9NfCr/gs4/29hgo1sH3hiCEELz4DjbQjhLbg6ejoGPL/Ge1lV5eAfmiUM5QCAIQRNvMvy2AwDq/39CKv9/jGM4zMsB5s+BEbZCI6BZcAycFq5Rv7dif0fazYJz40LLVwIeNdlulkGPCFu8RCOYXyOAimF2/STx+OazZbztLfcoUOHvJ6j0+kQExOD6upq9OrlHHRYv3491q9fDwCoNJoBY+tWevWFwf4Pck3KH8A2XJOBs6CYOx4C+f5roPKq37L19n9wrRvg/KD6KMPVCXf9rmofL6emRdY74ADIfSx2VKbfspjoWLAr3wG/bCFQfkVIuU3NBH4+CMZskq7Fg0G/8eN9l9WrD5gbZ4Ps2QawHGA2wZPP5zbfTm7zeBs4U7PHz7kds393198XABATB2bidJCdXyDMpnJJtMDsTu4RzQSvZG85pfvPLVmyBEuWLAEAZI4ZA/azfW7naALLCUsqBaqB0RuEFVYB4O6lAADS0gy3iSWK68cKizdq0AAGAlahV8SER4J9J1fwWHQGMHo9iMnoZC1ZlgUT4j2oKJ33+1UgD/8/oeEwGfFLRTM+PVuLFZm9peHUI2XN2FHYgCfH9UFoZLhw/zid8M/cxhmYhlBhNxyOA8PpQBYvww2f5gMQpkO/OrUv5m51DL3dODAcvx/TGwv/WYTYUA5vZvdHfxULq6hFM8Er2VtOPCchIQFWqxV1dXWIi4tzLcoZlgUT5r+vHlA0vB4T1vqugkR73w8NYDjO6XuIe763qizxnoaFI2NwODIGO3uM4xMjMD5Rtimp/P4F4l7K5g0woWEYmRCHo+UtmJwUh/ieMQiNipTm7M8Z1R/xPcOx+Y6RiDSwMLjunRdggrq3XE5ODj766CMAwObNmzFt2jRVi0BQKJ2BV6f2w58n98FvU2LBMAwGyIZu0+2zJePCdJqLHdDQwsv3lrPZbHjggQekveUyMzORk5ODBx98EIsWLUJSUhLi4uKwadMmrapDoQSN2FDOKStucLReWmC0PUQuR7MovVZERkZixIgRwa4GAKCysrLd9qv3R0eqC9Cx6tMd69KrVy/s3LnT7XinW9NuxIgRyMvzPdTTXmRmZtK6eKEj1YfWxUGnTK2lUCitgwqeQulGcCtXrlwZ7EqoZezYscGuggSti3c6Un1oXQQ6XdCOQqG0HurSUyjdCCp4CqUb0akE729+vdYMGTIEo0aNQkZGBjIzhYkhNTU1uOWWWzBs2DDccsstuHbN+9pxbeGBBx5AfHw8UlNTpWPerk0IweOPP46kpCSkpaXh2LFjmtdl5cqVGDBgADIyMpCRkYHt27dL761evRpJSUkYPny4NHsyUBQXFyM7OxsjR45ESkoK3njjDQDBuTfe6hKse+MR0kmwWq0kMTGRXLx4kZhMJpKWlkZOnTrVrnUYPHgwqaysdDr2xBNPkNWrVxNCCFm9ejV58sknNbn23r17ydGjR0lKSorfa2/bto3MnDmT8DxPDhw4QMaPH695XZ5//nny6quvup176tQpkpaWRoxGI7l06RJJTEwkVqs1YHUpLS0lR48eJYQQUl9fT4YNG0ZOnToVlHvjrS7Bujee6DQW/vDhw0hKSkJiYiIMBgMWLlyI3Nxc/x/UmNzcXNx///0AgPvvvx9fffWVJteZOnWq28Qib9fOzc3FfffdB4ZhkJWVhdraWpSVlbmVGci6eCM3NxcLFy5ESEgIhg4diqSkJBw+fDhgdenXrx/GjBkDAIiKisLIkSNx5cqVoNwbb3Xxhtb3xhOdRvCe5tf7uplawDAMZsyYgbFjx0rz88vLy9GvXz8Awg9eUVHhq4iA4u3awbpX69atQ1paGh544AHJhW7PuhQWFuL48eOYMGFC0O+NvC5A8O+NSKcRPFE4d15LfvrpJxw7dgw7duzA22+/jR9++KFdr6+UYNyrRx99FBcvXsTPP/+Mfv364Q9/+EO71qWxsRHz5s3D2rVrER0d7fW89qiPa12CfW/kdBrBK5lfrzXi9eLj4zFnzhwcPnwYffr0kVzCsrIyxMe7r3OnFd6uHYx71adPH3AcB5Zl8dBDD0muaXvUxWKxYN68ebjnnnswd+5cqT7BuDfe6hKse+NKpxG8kvn1WtLU1ISGhgbp9TfffIPU1FSnOf0fffQRbr/99nark7dr5+TkYOPGjSCE4ODBg4iJiZHcW62Q94O3bNkiRfBzcnKwadMmmEwmFBQUID8/H+P9LFWlBkIIHnzwQYwcORLLly+Xjgfj3nirS7DujbdKdhq2bdtGhg0bRhITE8mqVava9doXL14kaWlpJC0tjSQnJ0vXr6qqItOmTSNJSUlk2rRppLq6WpPrL1y4kPTt25fodDoyYMAA8v7773u9Ns/zZOnSpSQxMZGkpqaSI0eOaF6Xe++9l6SmppJRo0aR2267jZSWlkrnr1q1iiQmJpLrr7+ebN++PaB12bdvHwFARo0aRdLT00l6ejrZtm1bUO6Nt7oE6954gqbWUijdiE7j0lMolLZDBU+hdCOo4CmUbgQVPIXSjaCCp1C6EVTwFEo3ggqeQulGUMFTWsWRI0eQlpYGo9GIpqYmpKSk4OTJk8GuFsUPNPGG0mqeeeYZGI1GtLS0ICEhwWkrcErHhAqe0mrMZjPGjRuH0NBQ7N+/H5xsE0VKx4S69JRWU1NTg8bGRjQ0NMBobOM2y5R2gVp4SqvJycnBwoULUVBQgLKyMqxbty7YVaL4odPtLUfpGGzcuBE6nQ533303bDYbJk2ahN27d2PatGnBrhrFB9TCUyjdCNqHp1C6EVTwFEo3ggqeQulGUMFTKN0IKngKpRtBBU+hdCOo4CmUbsT/BxWAdMa0PVknAAAAAElFTkSuQmCC' style='max-width:100%; margin: auto; display: block; '/></div>
 </div>
 
 </div>
@@ -12723,8 +14497,7 @@ experiment.roi_polys[c][t][n][0] # n = 1, 2, 3.... the neuropil regions</code></
 
 </div>
 <div class="cell border-box-sizing text_cell rendered"><div class="prompt input_prompt">
-</div>
-<div class="inner_cell">
+</div><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
 <p>Note that this uses the F0 from the raw trace for both</p>
 
@@ -12732,8 +14505,16 @@ experiment.roi_polys[c][t][n][0] # n = 1, 2, 3.... the neuropil regions</code></
 </div>
 </div>
 <div class="cell border-box-sizing text_cell rendered"><div class="prompt input_prompt">
+</div><div class="inner_cell">
+<div class="text_cell_render border-box-sizing rendered_html">
+<h2 id="Data-storage">Data storage<a class="anchor-link" href="#Data-storage">&#182;</a></h2><p>By default the ROIs, the extracted raw traces, and the neuropil decontaminated traces are all stored in the folder defined by the 'folder' option at experiment definition ('output_folder' in the above). The raw traces and ROIs are saved as 'folder/preperation.npy', and the decontaminated traces as 'folder/separated.npy'.</p>
+<p>With the data_format option (see 'FISSA settings' below) this behaviour can be changed.</p>
+
 </div>
-<div class="inner_cell">
+</div>
+</div>
+<div class="cell border-box-sizing text_cell rendered"><div class="prompt input_prompt">
+</div><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
 <h2 id="Exporting-to-MATLAB">Exporting to MATLAB<a class="anchor-link" href="#Exporting-to-MATLAB">&#182;</a></h2><p>The results can easily be exported to MATLAB as follows:</p>
 
@@ -12742,20 +14523,19 @@ experiment.roi_polys[c][t][n][0] # n = 1, 2, 3.... the neuropil regions</code></
 </div>
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
-<div class="prompt input_prompt">In&nbsp;[&nbsp;]:</div>
+<div class="prompt input_prompt">In&nbsp;[9]:</div>
 <div class="inner_cell">
     <div class="input_area">
-<div class=" highlight hl-ipython2"><pre><span></span><span class="n">experiment</span><span class="o">.</span><span class="n">save_to_matlab</span><span class="p">()</span>
+<div class=" highlight hl-ipython3"><pre><span></span><span class="n">experiment</span><span class="o">.</span><span class="n">save_to_matlab</span><span class="p">()</span>
 </pre></div>
 
-</div>
+    </div>
 </div>
 </div>
 
 </div>
 <div class="cell border-box-sizing text_cell rendered"><div class="prompt input_prompt">
-</div>
-<div class="inner_cell">
+</div><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
 <p>Loading <code>output_folder/matlab.mat</code> will give you three structs, <code>ROIs</code>, <code>raw</code>, and <code>result</code>.
 (Using the output_folder defined above)</p>
@@ -12772,16 +14552,14 @@ raw.cell0.trial0(2,:) % raw signal from first neuropil subregion</code></pre>
 </div>
 </div>
 <div class="cell border-box-sizing text_cell rendered"><div class="prompt input_prompt">
-</div>
-<div class="inner_cell">
+</div><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
 <h2 id="Sidenotes">Sidenotes<a class="anchor-link" href="#Sidenotes">&#182;</a></h2>
 </div>
 </div>
 </div>
 <div class="cell border-box-sizing text_cell rendered"><div class="prompt input_prompt">
-</div>
-<div class="inner_cell">
+</div><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
 <h4 id="Finding-the-tiff-files">Finding the tiff files<a class="anchor-link" href="#Finding-the-tiff-files">&#182;</a></h4><p>If you'd want to access a specific tifffile for a specific trial you can get its location as</p>
 
@@ -12790,14 +14568,14 @@ raw.cell0.trial0(2,:) % raw signal from first neuropil subregion</code></pre>
 </div>
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
-<div class="prompt input_prompt">In&nbsp;[9]:</div>
+<div class="prompt input_prompt">In&nbsp;[10]:</div>
 <div class="inner_cell">
     <div class="input_area">
-<div class=" highlight hl-ipython2"><pre><span></span><span class="n">trial</span> <span class="o">=</span> <span class="mi">1</span>
+<div class=" highlight hl-ipython3"><pre><span></span><span class="n">trial</span> <span class="o">=</span> <span class="mi">1</span>
 <span class="n">experiment</span><span class="o">.</span><span class="n">images</span><span class="p">[</span><span class="n">trial</span><span class="p">]</span>
 </pre></div>
 
-</div>
+    </div>
 </div>
 </div>
 
@@ -12807,7 +14585,7 @@ raw.cell0.trial0(2,:) % raw signal from first neuropil subregion</code></pre>
 
 <div class="output_area">
 
-<div class="prompt output_prompt">Out[9]:</div>
+    <div class="prompt output_prompt">Out[10]:</div>
 
 
 
@@ -12823,16 +14601,14 @@ raw.cell0.trial0(2,:) % raw signal from first neuropil subregion</code></pre>
 
 </div>
 <div class="cell border-box-sizing text_cell rendered"><div class="prompt input_prompt">
-</div>
-<div class="inner_cell">
+</div><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
 <h4 id="Mean-image-data">Mean image data<a class="anchor-link" href="#Mean-image-data">&#182;</a></h4>
 </div>
 </div>
 </div>
 <div class="cell border-box-sizing text_cell rendered"><div class="prompt input_prompt">
-</div>
-<div class="inner_cell">
+</div><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
 <p>If you want to get the mean data of a trial you can find this in experiment.means:</p>
 
@@ -12841,14 +14617,14 @@ raw.cell0.trial0(2,:) % raw signal from first neuropil subregion</code></pre>
 </div>
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
-<div class="prompt input_prompt">In&nbsp;[10]:</div>
+<div class="prompt input_prompt">In&nbsp;[11]:</div>
 <div class="inner_cell">
     <div class="input_area">
-<div class=" highlight hl-ipython2"><pre><span></span><span class="n">t</span><span class="o">=</span><span class="mi">0</span>
+<div class=" highlight hl-ipython3"><pre><span></span><span class="n">t</span><span class="o">=</span><span class="mi">0</span>
 <span class="n">hv</span><span class="o">.</span><span class="n">Image</span><span class="p">(</span><span class="n">experiment</span><span class="o">.</span><span class="n">means</span><span class="p">[</span><span class="n">t</span><span class="p">])</span>
 </pre></div>
 
-</div>
+    </div>
 </div>
 </div>
 
@@ -12858,12 +14634,12 @@ raw.cell0.trial0(2,:) % raw signal from first neuropil subregion</code></pre>
 
 <div class="output_area">
 
-<div class="prompt output_prompt">Out[10]:</div>
+    <div class="prompt output_prompt">Out[11]:</div>
 
 
 
 <div class="output_html rendered_html output_subarea output_execute_result">
-<img src='data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAQgAAAD6CAYAAABd29lZAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDIuMS4wLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvpW3flQAAIABJREFUeJzsvW2orddZ9/sfc6651to7u0mb1jRxp7a0u/acFERNQiucc6hv5EghIie25UAtpLJFKoeDHNuC2C9aiC8IxX6QYLERqbGonBTBYCtYvzUEFY9P5Vif02qavmjTNMnO3uttznE+3ON/j9+47jH3Xunz1N3OzAsWa8573vcY4x4v18v/usY1Us45a0tb2tKWOjS73g3Y0pa29O1LWwaxpS1taS1tGcSWtrSltbRlEFva0pbW0pZBbGlLW1pLWwaxpS1taS1tGcSWtrSltbRlEFva0pbW0pZBbGlLW1pLO9e7Af+9aS8lncX3VP74PYdrKtciJfy/2u9+PpY7u0Y9ec33eC2WEevuvWO8l5Ig438K1yKtwm/xnXpt4zM53Oe+jO8Yy4rtWde+q5V7teeuVg6fW+F7Cp/X9QPnWO89+Xnd7zrF9dPcu+7Zsy9/ub72ta9ds7yNYxBnJf2v5fNKdWHs9mZy+f0Y3/3MvqQ5ri/Ln8r1Wfm/DM96Qu1omCB7eMb3+Jml2sV0IOk4t+1Opd3LcpMnnn9fpOH7IrR3hu9+H9IqvPdS0pHaRXCs0JZQz6z8cRKdSLqMd/T7sgwTGUNGuctSzkmuZcQF53b1GDD7t1fnPFyfhc+rUr/LOFa70NwPph21DHidQGGbXIfny6HaucRyVuH6stOe+Cz71uPIZ3Zf85o1LWxp4xjETNK8jPYaniBpOoBXyoUdSXtpmERz3LtUuwBVrsWJ5Q714B7juxetJ9eB2sGdS1qVB80Y9iTtSsp4mcjQvGhnuMb2LzQwEtNJrhPfdKSWGXhSzvFOvfcnU9zle5TPUTtwO9mfR72ywwC5bVwsXBRm1pP+xD1mBGRE7CdfIxPp9Um83vvONkj1/d2XWbUf/N39aebE3/19Fa57XkUGFZkk++6F4AobxyCkugCXGiRySusHzBOczIBSXngudjrJAx7VUE7G3uKLGsWsNI6TdqGqARyrlVAnmkrnfU01CNZ7XP6oFcV3pnYww3Ok4/Kb+9sTe65h0ZNm+L8I13Y0lZTxe29ScyHExevfFa7PVPvO7aDWEctiObEfyQQjk6HWI7UMvEds686a6yzztMLP40jhdaIpQ15HW5ByS1va0lraOA1iokKmQV1dFZbbtVvz9FpU2UnWOhZq1bao0mYNZoRwL214ai0u1xqBf9vrlLunKq17EmoZvtvkOiwVHWmqQRgv6anErnuhKh39zhHLWKjVEiIo7PenlmEJ7neK48H3UngmjlvUgmjKUFP0vb4WwciofbGuaJak8DvNqnXYROw3jnkshxpcxDdodgif2e5ogryQRb9xDEKqE8/mBSfGiaaTnmQV9FjrVT0O2LgIQ1mHa9pGpN0TkczACywykVh3ZEQkM4dRFQ6YwxE+sx/4Dp7c68wpqTIYtnWuwcRxOYda7y0xZkEcg3WMbUkD04jjGME51+86OD7+3fWxLblzj8lj1FvofqeIT5ExsK4T3GNhEE2byABo2kYmIFynCX2sKVOMJthpTYyNYxC0XVPRHmYaJpg0SNMT1cm30gDgHWNUjsvocyHvqL9YXNdSLYNYqKLH0rBQdtR2uG1XP7evKok4GSy5WWfEBSgljIeQCVxRZVr0CBjbiJOImoAntie0F8aupmBn0uAxegne+zjXeyIC77r9DpJ0nAamNrYnr3+mJ625oOZob8+ejozYGmbv3hzu7f3mtlCLlaYM0H3p33c19VpwPF2vFzfr44L356sx9h1N+3MdbRyDkMJEL4t/lHq5dGCZNVb96U5capigjdRI086i5OtNRi9UqUqhk3BPT3WdlQXia6Q4oe1l4DvvqnWhHagsVPTBIg0u4YjWc6HY87EKsym6PQkKL0t7bizPHmXpcpIuw027UrsQzIzIFFepde32zAmpjgkXRE9b8T2U0D2t0Mwh4cd5eYCeoJmqUFmpBWWjtuFrPfCTbei5zXvPRTMp3sN55znKe6hhXIs2jkGsVCfWPLXXTUtJu+WeWTFBrGE4HkBqNYKUqyTdKSpvtIlX8D7saRh8MpCeJOMEcRzCTg5tB7OaQd2W6gByoXrC+p4rat/RjOBQNU7Dk5X9ZHeo3/NyKZd18h0s2Q5V8Y690t5jMIwoXePnSNbg6G2IqnNUuaX+goxMgx4l0hhnokGYUGuLC9lmI+vzPbEN/J2my44Gxn6k1hTptZXtvaJW48mdexXa8qJ2c0apcNxZyBKu5db37AURsQJKVy/YOAEYUBPNB9ugDlyRWvVdqpN+R1Vqz1JQJ4v09+92QzaYQ/lvgNQLn0wnl2ddP/EPaVjk/Oxy2Vd+5xgnsQRDWEjaTzXoKacaDGYyM6P/f6e8u+s9ya3ENU7E94kMuLcQYuyKx5aMIqWWyUTmscKf+yBK8KNwLZoudiuTuUoDk6D5GN/L5gsBzDgPV2rnYdKU6bxoNYioXnHBS238g1S1hWX43gsKMvU6fKlByxg5eGoHMsY+SBXA428ztYsz5Sm+cBIWmM2SVCqLEZAnKtpD8OQQg9gtnzOeMfi2Ll4gvttuuX8/1WduLN9fXuq+nKVnk/RMrmaHn7c2w+Ayv5+AJ5kIzjFeI4KQJE54M4aVaj/YlIzeIS7CZZ4yNM6x6BHxtWgK9MwHCxbSMX5zH1/B+1Az8pixDw34Xk1LW0fbOIgtbWlLa2njNAipNR/MAWNkH++Nar45f7RPGTMQ3aPycwFJi/Y5pXD0YVPboU98J3x3XW6vNOAWlDR0ve2EdhEV93vsqar0UtVcGAE61wBs2uSIqvxc0g1JuilJLytlvTJJ3zWXzpSbvrGUvrQM+xdy3/aOvvvGQ6W2nyiN2Z+sJ2IQjYs2aFek43DN2kSMrCXgG7UtE8cvlun3Waf+0xzyPQYcqUHE+ApfX4fNXI02kkFEmoCJajEH/vcgcACje2+hCtZx4UZEOg6E/f7rgmeoxtLHHl1ovM/qI70Wkpodrd48FV2ni/COCRX11HO/a9z4ZdPghiTdmqTvnkk3l8pu25Fevi/tF7/nN74uHR9IX1/WNs5TdYdK0nNqGfro24c3pOfdiYj+ngaQlH25zJVZ7pY6FwCXc/hvVy/n0H4aQFiarb0ALf/ma8QGzJx6wid6qjjvdlPdN+R3OOk834vVIfXGt0cbxyCiDzqposNSscfVMoaI3kfuzuvS0OmeNNGNaU9BTu2k2dN0oDyRGJ9gIpAZ7V1+T5Iuqa9lUKIy6nOh1ushtd4Kk5lcfEdqVgsNi1AatIZbkvTKmXRzacyZmbRcSkeXhu8HK+n5srjoRp2h4fu5ZYwEVEegFR4Zv6vfxzt3R7AT70QtaaW6MS9K8xGT0HTcVpJOUh1r0wl+j0FP3J8h/B5Byp4mNMbJpAJipqEPXW4UGJzfHDNqjus8JZE2jkFIU0Q65yq9pSnqS7eVmQN3GPbApJlqoJDK/QsNLtCxbrWTy1IjAqIeBKutlOyxbpexg9+t0XCSRL93BMfcH2wLF5NjNvwu/E838NlUNYGbknSmuASfLRV+bVnLk6RvrKR/X0nP5nYhOFBIGvpwlgfNx++zKu3zwl2mvtq8Dhh2PTGoyyYFd+HSm2Oi6s6FRuKYuc3kZ3O1mlFPisc5Q8bFaFeOCb1hUZOlGXs18HYdXVeQ8tFHH9Ub3vAGXbhwQQ888MDa+/70T/9UKSU9/vjjpyqXfmkj/rTvbcN5EZ/gmegqk6aS1Z3NyWY1L+cqWfY0LJ6zqlKAeyAoRTwxX6JhEfDP2oddrfPwu1TVXGMqlzW4OQ9CnTEs2NKO7lLaudZMxkWWBlPihsIMvD1+r7gGr2TpqZX05HL4+/xS+ucT6f9dDn//tpKeKouff1w4uxoYz155dzI3R6N6G7y/G93PuNZbwNYWvWjcbydqtTSTNTz347EG8+IoT7UuzikTJXo0K+JCJobRW8wHqhGx81S1qShAstp612nEp6HrpkEsl0u95z3v0Sc/+Undfvvtuvvuu3XvvffqjjvuaO577rnn9KEPfUhvetObTlUugSypD/hQilvNj9yf6iEljXA9qnJkGE44E5OpKLQvbvhyfaQd1QXkBUzXoyXjOjeWy7XWQGa1Thq6X3ZU3ytGLe6otc+v5MG9m1fS86hDklar+mw0qazhGMugliANuMGJ2sXi+91X1oBoEvl3AnULtRqbGSH7k+r4gWrymlW4h9oL5wvB0+hu5Dyj+7qHOdnEc/8e5Go25VAOy41My+/I/jutiXHdNIjHHntMFy5c0Gtf+1rt7u7qHe94hx555JHJfb/yK7+i973vfdrfj9DYlra0pW81XTcG8eSTT+pVr3rV+P3222/Xk08+2dzzt3/7t3riiSf01re+9aplPfjgg7rrrrt01113jcFH/pOKOqYq0XfVgnRzfLe67XvNrRPKNLeOwBYDb1a4RqnPuhiWbVX6RFWy5/KZ6u2Bqj18rLrHYhaeoRRxwhnXM9r6mrrVTvBn9dvtP9Egzf3n+v2+B5Key4MJ8Vz5+1qWns6DRvG8BnPCGoNVfkpiS+8FfrcpEc0x7uFwf94Q/s7inl1V08RzwH3CsfV7HarVHmi6zjRoLUfh2YgBmAhW2rxkH9AM8d9R+W9T8YoGQNom2RHKchs8prEddKG+EHPj2xakXK1W+sVf/EV99KMfvea9Fy9e1MWLFyVJN6c0UeOkaq/NNdiQvmdXQ+cTnPOiiIyApoCxC+5LsHdDGmzURapAG9XcqLKv8N2q9CW8X8YzVhmtT8UoP2nAQFapTQFHjwXNqlh3jG3Yw3OL1JoUZoIHAfUy05BK9GOqZsWy9P0CXp64WctM0m5Pt/Us+oEmov+n0l7GNBznNs0bMRgy9J75KKnZv0KchGZpz/sTx4QCxvdEtd/t4/ylC9Mg55HquPh5ZouiCRJNFrfltHTdGMT58+f1xBNPjN+/+MUv6vz58+P35557Tv/4j/+ot7zlLZKkr3zlK7r33nv1iU98Qnfdddfacm2TS4WLpnbPgTR0lBfPFbWYRGQGQnkKv3HRmTnweUt+3xuTqXjhc2H4Gu1zSeMGtKUGF6qf4eQf3y+1+Ic1k1jPvHON72ptw54ZS3La1cfCJjZ8dn/up9YjQs1KuBa9RHHRWbuLWAnfe9wgh77quRZNPUDaC5I7NY0vRY0xxj70fo9uTmpLTP1mBhLd7VL7zhYQxKT4jr3Fvy7I7jR03RjE3Xffrc997nP6/Oc/r/Pnz+vhhx/Wxz72sfH3m266qUnL/Za3vEW/9Vu/dVXmILUTOueKDrvjPUncaTEikhO5F7cgte5KuhujiyoCRlI72B6wuFGMk2+lqb/9INdgHy7WHrNwOxZqmQ6lKMltclAO4zeIskvTiMpeedFlmMtKWOUak3DkBQ3Jby3D31d58JRwATGHhz0RkfEQMIyL0GYZ38mSfYzRKPVw3HpeLV5nf0UwMLpeCXzadOIij/VG4LI3v+jOdR4Tvut3REapnZ0dffjDH9Y999yj5XKp+++/X2984xv1gQ98QHfddZfuvffeb6pcd7I0TMYosZwbInoo+N02cOTmTM4SpZm1Ega1SO3k7EmRCL3aBKHGEKXmDmaQ35fMiBqCNF2kVk85+JFR7qTq+uS27l7EIDU29xtjMGj3OjZlKTV5Jk5UF7yDgfje/s7Fsy6WJTIJtnedNhiJ7Z2lwSwlI2BZXLCkyKj5nWaDy+BOTv/W9EG5zziby+G4xLkZcbNeu65GKecon76z6eUp6a3oDS/IMStSbjUKL/zRRlZ/8KLkiYNn4MuMYV9TW7C318Bqu+sxAOXFkjUs1pgJ2m0x6MZJ6nuYH4JBXSQytJna/BAxKEulfSO+oFZzIdZh7GWdJkbb2oBnA56m6UJnW+hW9O9uU7xGbYl2v9vAsOlj/An3rVQ1Hc8HLrojTdt7FH7nM3GO2S0e5xU/c1s8NYjIIKImG/drrCQ9e+edp4or+rYFKb9Z4qQxAi7VybKbWg67zK36zYFl5GAcOAN81BB2U+1QB+4swzOU7F7UrNuMyEBbzLXg5wmg2vMSF+o6m9kqKNt3kKVzkNoug9mtvKEqahHuW09UelEIgkoVzDWAKFWPSZSebG+MaYgaXEzxZ6IpE8HaMUYgtUArTUdmAOM7k0GtNMWjjOfE8Y9913ufdXiMPRvxnsgUOT88dyngThsD4TZuaUtb2lKXNk6DkCqHjBuSpOpKWoXv1DTsyosod5Qk3n8hTetx+riIdVATiRmDRoAyV5CMdr3r6bkjKV0NMFI6zSTNAjJPMIufpYqnzFQlsJPKMKXfKrcb4XyEHLWDhdScDBa9Fu6jsf2pHbsepkBPkK+fhGvSYJ5xHCMOMM4VA6K5zUjuuTBXxX5i4hprBvQ60LR03T1zKxLnGN2wUpuEOGqdca5yDbgN0TN2GtpIBsHF48EyGGh7MiLPJrr+6KJkKLXVtXN4bidNTRDaoAySorspAm075WEOOIFCqYY4u9yVhn0RrJuqv82PE9xDQNDEyXi5PLNfTA9p+L9Qze0wk/SNPARCSdKlPJ18ufSDmYqxhp20Psyb7+l2SS3TjhiAzQKOrWMCouva/6/k6fEGNtfoWYrjNJOa/BqzPJ1H0QSNbnTWJ1WMgu3fVRVgCp8j5kLzhGPva44t4TOnoY1kEJ6MszQNHJmrPXhGRQpagtj2NTYh1ViKaCNSksRFXIpuPsfFExmR27ivlkGQaaXSfmoYBO5cHqW4sYORqaRhgZ7kKhXNaJxs1kj9YWo9KudUt3e7bTEIy7kbJE2yc1sbcY5K/8YAMgO3McKTCy5urGIbYoBSJGoREfWPLt0DVcY5jjVcoGMl0KQsBOaqqeH8PWpD3IXp73v4Pc4hX/c7mFFSU40asp+J2sVpaOMYRJKaw3sNBMYJ1JgGqVXJrFZHiUNmkDT1y7PcrCrR/N1cnAs6DqYBJrooo8uSbeJWX078k9yqpN4SLlXGwWQq7qcYJbnKQ9p6l3lF0mGp3O5UM5WxjNwu4JnUpIyPZp6JJgX7ID7nurJaDWhPLVAZF7aBTPcLGXb0HBzg+3FWN0N69Ci5LU56S3PFMREc6/j+fj+aJTRd+L9nokmamBMubxXuOy1tHIMgucOj3cfYA3doNB/i5EyqSPc8VdWVk4QT2NKCKmZvIUezxM/vdX53PQ4ckjScH+HfUPAs1dT+R2on/LhocmuaOM292ztKdognfo9ovpnZKlUNIcYMWGL3pBi1uD24du2KZICX2+dxO6Ophkb8wHVLajKC94KraMp4jB0ybooeFAUGctQxt/iMtbyIZRAnMY7FMTHTi9iWKXpO/D7Ro3Za2jgGsVJViQVcYB0oyUUs1XMGeiCl/1v9zZouYE5gSywTTQB1fvfJWmdVB2Yvtan7PdiNNMn1s2mVpxOC0tcTkWAi1XzfN1eVgid5aA/L8YYn0yjRy8se56rJsQ3SFPx13+2pRgC6Xv9OzYmxE4eajoXHmUIgupUpYf3MsVr8KJV5dBwYMMd6pZYp8s/vyliVrL6giBqpy/MzvUVOJmizhBpE1FRfCG0cg5AqgOTFH4G4rJqvgIvN3yPK7udo9/vesU61EYsjllG+93IveCDp1fDztvMtBckgoimxU5gIpXK8L9qzvG466lyPDPSQi8TtKgWfVWUq1tJshrk8S33GV9jTwHqiCh3VZDOnmGODZp4jE6NHgWQpzuMPyHg8P6hpWBtk8F1c/IwNYTkck14Kfr5LfKZnKjD+hdSLkyCzOi1t4yC2tKUtraWN1CCWkEwT+1PVVy+1poRU1TFydHsooo96hmsLtfZi9GGzfNrWjIuw9IuSdJHUHIrDg3Xm0rD5SW30X5SW0RyKAJvRcJpT15ocNlVGz0eqORfooYn+/1G7gkYWk/py74OlNTUpe11oi7sP+A4cx5NSbgSFo+bE9lojWuG+pDaztDUGtiW6LCOw6DIJnvN5tz+afPzd90TTI2pfEZzkLtJr0cYxCHoxpBpqyk7joLizEu73wl+GEaMPXmonY9wQFVVzqTIEt8WYA/EQxzgwtJoeCQ84cQCbJrRZo8oa7ffIMHwPTRuXRbcuJ6eZCsvwe5ii65fuz3GxF9Tfiy4CvlLt6whSkiG738go6dWIbr7RU6NWYLBcmz4ESCPD62EbJpqVfCae8xHnjtvCfshaH3DFtvW8FTSReiD8OtpIBkHwywuXE4vosScDB2rEBspkXuaKKPueeWrLmamNNfDeAXsP6PZkJqt9VQaxkyqoNroo89SNRRCKk5KTMYJS1DDG+AWsbgbnSINXYKV6MrjK/QTqmIRHKL83gcf2F5fhLFVw01gGF3bMQSn1JSf70lm5uPHuUBXrcEauETvQ1JNBfEjl/tEtXS7m3G9L9IRF7wjfx5+5aCMG0fM+eH5HrXcdzsJ5vQUpC8XBjtx5T3Xh9sJOj6XxsFipMgIuRiLzKuXRXPDZDF5QHug4aVaq7rN9VVDSZdtvH8E5ThCX62teYOt2ProcMs7olp0Xs8YLb3wOTMLnWTBwKGoM1g5GqZ2rJpLBYGZuqIbGZrWHBmdNpTDfi1ogJTBDwenqLdU0oebjO6rVTOjq5LPU4sgQPB5sU88DQWCWDIP3ReGVw3Os0997J2tFs+m0tHEMoofUUwpYinNhxMXjCRxjGiJFNdN1SdJOKDRp6j71pFnAhpdaW9uLg1hHbE+cJNacKFV6HpfoOWC8Ak2A6J6lDT8T3JBp2k80aySNOTooMaO2M550FVyw/uy20qzjRCajbLQxVY9EfI/IcE2eH1Eb447V+M5mKDRBe25GjqOZa8/TQu3XYxQ1Bmof8X2MWfXicK5FG8cgOJgcwHhgybrBXaqYDxnqa2oHl6q0O/v53KrtEQjiwHM7OYN96MunhNjXVCrQ/FmkNs+mtRWq/pGhzFLLECgp2eaI3zAYyyYIt3Jbu3J794obluHDlpLc7xAZGP9TKrqcGFFqM4EM2NGjtM+pWWXcT7iph+ewrogvRc3QmsNuuOZ7172j7/O7xhwTPYq4mDUtMoz/lkW+cQxCagfDHeZr3t+/LoIxqSwosGB3tjvrMFdpSZv8WGoiHDlB3B5pOugR1KO0cRxBVN1HX3mIl3B5tM/HSZja+vbCPZSuZrSWltLwrpScfnU/c5QHDYGMZqViqgTwU6r96TI52U8CI5L60pXkMug5iJ6ZXbXMNjKEsX48E/d9eF7RvCFZy9vFHDrOU3CQwKaZSsS12C7iY9R+XNbVyJvBpL6WvY6uxaC2tKUtvYhp4zQIqrfmwNQYIqBk7eJM+X6iiiOMEiO3KnHSgGTTsxE5etzgI/xOCUaXZs/eldRkRVqnSXBzmTNsj3smUmsaSDgXopR7lFtb3+7BpWqcg4HDdd6FAw37VeZo534qIGt5aJFa0NPvzXpclyna837vCBwbk3D/2hMSpTBd026/x3yMVszt93lqvRRxThE4nmuqYRozIfU8HTSHCXK6DJtJJmq/LIPleodoxHFOQxvHIAycSdX+6rmbCJ4xOYlzKTpPosukCkzVjyoeJ/WOymJJ7TVOVpcZTRj/JmmyXdrvEP3nnEyjq85uuVAvmZoXpVVXZqr2ovWEsinQ8927Hqmty3smxsmZhzrOBObpsy5dDwOnbCb2PDERXLQrU6obvOJ5Fqa4uMb3yFOT4yhUzp2Z62IKuBBjLIpUmApewELH5fXyXLq+0dzV+ngKt73n9j4tbRyDWKly7UWqnH6dP3iJP6l2Ns97sJ06ageaTlaXRcpSk7I+LtRFGjaH0RY30d14NdR5qemGKQN2nizccsy2HKpqTmOyVkhOqZ7e5GvcpzDRdNQyLKm4i1MbgyG1C243DX9mVrT7Xa7fL+IBPOczLgK3lwuOIKUZLT0dZg4EgaPdb8ZOjKnnslyGgesxI8ZxLFPbL2aKEXwmU4w5S2O8BQHrLYNQ66Gw+UD1btwsVL6vwvcD1YHlQHDx9nzapmhVkOt7cMfNWUXDGP3zRT2/Ae5CL5bozmL561RR046mGa98D+/rneFAlT2Che5bIub+i4vFdIx7PPmidB7jDkLbyPS8qF23mcuR2neK7Y8mHmMeTARJk2r/R62RLtb4nrl4l0YvS16/eF3WlTzVRHsxGTFOgos/Blbl8NsLpY1jEKRlHo6RdwyCiduszaGZhzAlaR4kv6WP1GojNDtiZy41dXWt1GYeMvLvcnc11O30+V4Uoys0t262WaoqOQ/RifjInmqZjh5karXj3PaL28p+iwskakTRNtea+xxxSm2DngOpHQ/W3WAkwGbodTH1gtOonZzgmVFg0Oepdsyjx4Gu6JSqtrhSG3UpDQzaWJafWbnhas/aJEWche9KWrf4zUCiGXI1rZS0cQyi0RZS2ynSNDLxUC14NGIYGHCH51LVjmZHlA6liGbBRbdb9InPSz1Mhmvcgqo/TaJF0UJ4lmd8ZwNoxjMONTxzgmux/Z6sxA/4XiSaYjHCb6UijcEEFeoaE83gmWgumJm5LT7LwpvYmD9iNGM0ZWD8b+aQsXBTeLm4L4PvOcZbFO3sONXfzcR5QlcvpJUMj+Pq94jfXRY/0w1uhnC1cl4IbRyDkNq8DY57oIq+VIsu8/DelKqJwcm8VLubz2gzPRAHahdIVLXd2VGKNAlfQuRL76wHDraDqwxG+VEyFZdJCTjiNKr/s2piWy4aEpmApTPt3xhU5HvGxQ+pH8snA2ZZBnKXUpMfk33KPiKDpMawqxaw9Hs2z0N7k5D4Nrf9xziHGKbew7tGCQ9sgwuXJigZXI9iuQRwYyxFT9vo8Km1tI2D2NKWtrSWNk6DiDaw1bbRNw7JLLXSUKoSheppDx03l/ZzO+G7f8/hGbqoMv5IK1Ub3BKFsR30uXMAuQPUsRDSoI4vUxuC7Layr3j+xrLgML009tGdGk0ZRq4aBOZLLjNUblVt4TB2BCS0tTF6LaRWys5wr5+jxXASfl+qYA7AYdb8AAAgAElEQVQo0GYpAUjHU4weg1Q31kk1Szq1gYjHOI6GY0+Mx6YtAXBjSVGKrzPlTBGI5ZhJrWfnWrRxDEIKkzNPkWqqg+686OuPGYjJJHi2hjv+SIMKGxdPRNSNM0gVwIxBXEk1ZZvrju1lHIHjGa7m4zeq7jJc/4hlhP9ny29MTuN3IFYQ/fQ8a1T4vTljJLXPebHMoH43/8szzM0ZcQqnn0sagGnXnVTNqYinEHtaglmxXDMZH2YsDWNzFu/mhRyB1WhCNczLuEWe/mayMGBbPP7kpTRLehuyIu5D0/datJEMwm5Ddgw7hIvfnxllFidSzNDkZ+OhK/QczDU9rdnPErcQnrFUj7YpF6VzEMakN7HN8dRwArbcj0IvC08NVx5s7L3gzWG7zSBoc8d4h6T28JoeneSplJMqU1mqgpGc5IwJ4CJy3WMiHojpHbXM123kblyOI8t0eT6XZIzFyNP9J34uMm1iAyeq8RbR1cu64/zo4QoRePUzEQNyOaeljWQQVyMGREnlJG31GQR3G1LNJzEblNSqjL24Az7D+0kNQq72/I0IoJ51uyBWeu4+Hg5kWmqaQYruvrMFUPTijKeSWfX2931Vl+pYd5qafJKaQ3ty+M3vQFU7Ivy9eAvfZzMyvq8T8vBdL5f/oztS04jSfU2ZHyNt3a5dfHcdTo5MgNtkNzcpRszGWAlrGpzHMdCPRVqL6jGV09DGMYgeJ5faTmP4rf3PHOzxQBiUQyZiG5ueDUumZhKhXkv9qB00bU+tBCQxsjL69i0RrSZbFSc+QjfgqmASC9WzPpYa0HsynjNp2MbuWX1QzDW/s70ENDnM3DLuoQaxozaNvlS3q3Pc4njRler2KtzH4wj8HMltp1llxu93SGrnkPfKzFXNupPclkMzR6rZxKjhOECP1HNFJlVG4wC+nnKxwD1sg9vfC5YiYz+tiXFdvRiPPvqo3vCGN+jChQt64IEHJr//9m//tu644w593/d9n370R39U//qv/3qqchlBKVU3mSceua7jIg7L3yUNUuVZXHsW95spXNIQJm0Gc1mDenqMPyZaJY5BcNL2uBdSVPsPJD2Xh8V5kKvE9vscqh4P53IY5EQV/DAPf0fl86UsPVv+ntFwxubl8ucyd9Nw3N45SS9JAxO5ofw5Xd6+Kmi30KB1LFINdU9oWwSR3bZ9POP72H4yHmtnBnzNfCP+IbVjvyzv7758rvSBIxjpOj1b/jyPWK7jHty+Od59ofoevN5j/AzFNu5koNfl9lyUu+GeCAzP8Gcyk4i40bXoujGI5XKp97znPfqLv/gLffazn9Uf/dEf6bOf/Wxzzw/8wA/o8ccf1z/8wz/ovvvu03vf+97r1NotbenFSdfNxHjsscd04cIFvfa1r5UkveMd79AjjzyiO+64Y7znh3/4h8fPb37zm/WHf/iHpyo72uvxNyLO/swj7K0+Uk2jO+2k89nSn+r2SlD/Vb0ltFUTsAFLHLqh/Hnc0FXuPw6/E+TbKeAiQ4rdJj4jtSnydlWjAVlg0z706XFqt3/bxGBbHIDFiMFoQjh4agRti/lzGbiAo18JiFITcd8zMCpqKj7uoAc4+16bQzGYjQmJs0owFTCfHdXAqdFFmqRZbtvrfon5Mf1MdM1KU3OKOIO1VOI47O/YJy+UrhuDePLJJ/WqV71q/H777bfrM5/5zNr7P/KRj+gnfuInTlV2kzEotVGBJxpMA4NHNiPoG4/o85VyT8xjQNrRwER8mvM5terZjoYFSPNhV8PiY75MUy9s2LTKLThHW1eqKq5daHbDxU1LVEu9KAyaHaQCbEpNdq0zqS4UT04vZGaidn+OjBd4g+1tLk6GC9teJyN1mVxICt9n4dplciFV7IneLZs/HNus1sY3KLiDdyA4S9zD3x0/4TgLR8sS/1gC82k2d6GwXrQpmVxkeGQWUmVwcaGvcZpM6DsCpPzDP/xDPf744/r0pz/d/f3BBx/Ugw8+KKnNkXhSmANByUMN3533IWoL/HwFz0jSc6jTB8QscO8Z1YnrABdPPAKLY8xBACXjIiHFMGpeN5MYmUmZbF5gz2kaxyG15Yz4ALSFXN7DWsNeapmK2+N6qLF4Ak4WaQAjXVc8MIiMaalhgcU4gxiQZUnPWIDojYrPx9gU731xXV3PVa7xHFLVVMfzVFWZHLVYt28djZoPtLjonvd/zlf+ts7bFsH7b3sGcf78eT3xxBPj9y9+8Ys6f/785L5PfepT+uAHP6hPf/rT2tvry/CLFy/q4sWLkqTvCrttzP0ZCBWjJCMHtquTZgjpJeV/nLAcfA+smYxNkBvULkz6rP2dpkoMYJqrleirPAQGEYlf5hog5rr5jjF239cWwpmauJ8Rmns0b3J7SpknrjdSSa1XyO/hukaGmeqZFlLLOPzfWZHY53RzOrZDKJc7dvmf90UwzwAzTU4vcu+6PVLREHNtX1bLeG0qjPk6NTUFlrluDovnyfoekpk83djRHOm5Rs0c6D07rcvzujGIu+++W5/73Of0+c9/XufPn9fDDz+sj33sY809f/d3f6ef+7mf06OPPqpbbrnl1GWPkjJXb8KYZUhhMYX/J6o7IyNjsKTkJPVnn0hN4iYwb+za13Sium1cNDxURqo4wMT2TvUenkzFSWCUO4aXE9tIqMPfnaqO6vwJzDX3ZXTXMYFunORmiAwFtwfC/WKmSom3kzSe09HrB3prYt3xvmiy0C3r66ZlrsznOZsYKnEiKDMLqfkSYjLQlkZTLQw8hzEjfqDwzArf4xwykRH4d3q9fM9p6boxiJ2dHX34wx/WPffco+Vyqfvvv19vfOMb9YEPfEB33XWX7r33Xv3SL/2SLl26pJ/+6Z+WJH3P93yPPvGJT1y13KxqR9slyYy+5MLCtTiRezvpegyDadivqJX0PfOBA+pITO7ynOFZ01xVijXbh9Uu9psMKpayzLwONExebgmO7ysVzCLVZxa5nUye9JROUapnFQ2ntNeux5jqn2Hqe5LOBa2ImonrpknnxcKFEs2vuDCklhFw4bFvqA2cdO63yXM51fb73aSalzO2h9GvMVWcVIUI+5ftJeAbdwZzXkXTi25mXzstpZyZFO07n25OSf9L+WzpRvDQXotL4Tv3ClzSeu2BdKQQfotyzpTfzpXvZyXdrMHE4FF7POBmpcp0nArODINmBRfXrNRxLtVF5oVs+//pPGAuNEFsq9PEIJ7gtvWiQdctuDHzUm77L3oFRmAw1b7ZVfUCnJS2R6BTmqalc/0OKurZ3wRnCcRKg2rfRH6qzSoWvSd8Z0bGckwMNjJAzLEixrGu5Gk6P2oRUosbuC0xqUxsSwQpDboT4D2WtLrzTj3++OO6Fl3XQKktbWlL3970HeHF+GbJqmLPjqNqznRtPQlksiTbxX9Ln+dUwct1z1g9HCVAUemjq45axVwDCEmpQo/EngbT4rtn0ktm9Z6nV/Wel6huiPINx2p3gE7cu3mws6Otz9Bq9qnpOLcqbtz45DKIkViDY9g3MRPvaJyrmlgnpY0cLyfUjWAxQb+Yj1JZOsQYMLyeRHMxmmdxG7k3bzXentAJjOQtzRi9C9F8jO3w/Wxn3EtzFH437sNnT0MbxyBikIgp+si5MKI3Yp15ERkA3Z4vURsrEePdbYfz2p4GVZbmgyfaGBtRVH2CiWzfy5J060y6DQU/W5iDzZszqQYbScP+ilQKm+RgKJSlMa+EaZFaM8pqeHTdNTEb4f9O+Gw6UQVZ3SSbHMYIaEJkDQCt4yvItOjmdLJb0zJ4WObhGnNLSn0vgPGOXXz3O7gt0YSb5cHtHlX2eefZsa1qhVkPO2L72DZiENHsiJ6zq9FGMggGwlgqrgNxpGnSlejGjAzD2ANxCTMH5pJkHavwJ9XBtmvRUoqT6CRLRwhO8u5KbryxVPdi/+pqwB3MrM4WfOJS8Nczm3cPtHS7R2mVp/khmN/Tdm58R9rnbm8EYRXKmasGep1LrcdFqguBOSSihPT4MQIyLnSVa83OzzTdFOY6XB53qcZFTjcv09ITkPaBQi7/KE/xBT/H+ez5TS2D2o01KDIIP7sO/LwabRyDkKbc0n53aegkSsFdVQBTGsDBE7WSM2oH9owwx+Gu2gS4J6Us7u40ABX98h5Mb+zhXN2By0zS5NyKmYbNVsfLKoH/PUtfQyfclAcmwUm0LGUxPoSbkuhOjIs9Mri4o5DUczW6rhhdub9GrDEIjG7DuSqTPpuG9yEYK5VAOZRLKexYhd3UehgoQLKGcT1RG0rNxe4t4mN+zIQYifLMbnjG82GJZ3iiOtvh5nuR94DhM7iW0AfsN3bvi5pBRKI9ONfUpJD6HbEXPvs5M4yeFyOWF/EFTj4j94ywjEj2cR7UXkptSpUruTIJR4c+k1vM4ZmyeCgVPdEikxrbnao2Y6Zkxsl3ikzB5UWzgxiK1GomSW0Kft/PLfiOboyuuvF/rhKZKvksBTdyatu8pzZHhNQm+rF5E92uZKYeVwodYw5c3PSWmTnwOINegmIKByezIXmMmKIwejF6TPrbPlDqW0VUX9lZ7iQGI5moCZzgPoJkpOfKM2YUJEpgMgOrmAQ2k2qQkNRiD3EhxeAZ05Gq246Tj8CmJ6/LtFkwL+aKiftC4slWpHXhwrb5s1ppRZXY/R8lY8yTGIFPt9+mwFIDqEkm4ghZj6/dp2NuTrV7UuzG3ccz+6ltx1Gupio1MJqQ7Fe/TzQVaHb4GTLBXryF5+QoLFRD+Gkm0YRT+E736TdDG8cgpPY4OS54aejsPdXoxWhHNkj+GiL2wECp6E/nXgznTTijmkkpmhNSZRosh8h8BFstVSl9xrwMKJOMzAuOzNQAJBnEQVB5abNLU0zFi5NmiMIzZh5z1X6IE9gLwGVYM9hRBRCNAUQvDIOezmgAaG3KHKh9H4eWs24HlDlGY7cwUTIe9wXxmwO10bonuW2f+5vYQTRlzVhiJCg9ElntVgGXybFmJKufIdN+IbEN2ziILW1pS2tp4zSImapkcux+VHkPVOPoIyYRQSJfo415TtVm5m7Npap24czH1mbOaLq/Qmq5PTMPzaFlxGcU2hy3Eq80AHONLa425b8lkfslHiBslV2aSneFeyM+QnKbaO4YrLuaq20lNVmt7TocKU/vTwrp6EsFlOzL8Iz/MwVhUk3Wu6/qeYnaFCU8Uwb4AGBqQdHsYOJkv6NNDnpz4s7NFZ4nUbOkJ4/vGr1Fp6GNYxCeJNIAFB1LTbp0q/ocBKlVm6P54WeJFPuMA5omxBz2NDASP3ODaqAPPQRR7TRz2AvXWG8THJRbtdrtPQ42b3TrxoQll3Nbdvws1MEQY6rEBvx4j9XhHkjp57zblGryvjTmUoh5LdymGPYdXctOr8dnDPqqtMn9YIDXpgDTA0jt4vSYRabn74ukcTPWOnOVJpfUZ1wxnsfvuwz3ENQmSOtnPM8isz4NbRyDIDIvFRszqckGHQ/U5eEkx6oMhgt3GZ7z4uBgnFFdRNYgbizf99J0U89CrSt0pYoFJNwb4wbifoJos0fG40VMUDCi3X73o84zkVGyHexP18tnLH17WbhW4Br0iBg/GfsyVZCPGg7fiQze7bysNj+E58Acv48Rn5gfBnClykCWeN5epdhe19vL22AibhED+byYuZDjodHLzrP8HAF1uzwJgL+oA6U4QRhE4ozPy9zmR3AGYneYJ3dvAL3Ao9bhcgwOSsPCd1JXqTVpPCnHACmsXE8QLkpKp4ic816r1PanE5h1ElqTpd66yD5PIgZuRXeZ4xDcNmfIipGLcTJ7kY8TNmvM1i21C1cqZkOaei3oCaHK7nvo4XHdS2k8ud3MLKrrczzHU7rH9wjamV2no9aUp/PH5XJcaXbw/7r4EjKH3hxkOTQn2Ed+5rRejY1kEM+X0duVRunERelFJ1XtgaaB1KrxUQp44dCO9mLxojynesCKyv37eFbqd/5J1iT0Orooo8RgbgVJ43brAzzDCRtVZZeT0TYmcCFG0gQhoY1SycGodtJGZtvb6+JTq3jPSq3GtafB5DiApPc7SNVsopbhe5mmv4kMVV/dJuOZ52nshYla50xVw6AWy5iRa2EuUov9xFwb/u1qXiLfF3/jHHkhnomNYxBRDT3Iw8KdY3R45FzPJx/tup6Ly77xcXu02vBrpz+nxDejWkDSH6uNReB7+B24MJ2YxkyEA091uxcMRvLkI2ZArcPvtlS7jTwef0dA7DhX3IDvwUtmPNS2klomyIAxaXBVzlVMknLT87kNPGLwF4FBMgFKZ5PHPgKQlMA2ZRpwOWBJPfMrMoUYr9B7pufm5Aay+FuPeUUzIzLlFxIXsXEMgoPt8NKsmnDUJgfVbyLHfj5OtJ4EIIDo/A8Ox3U03hiAg/tXkDT870CgKA3ol3dE5y7K8MTxRHJUXgzMMTNgNB4/9ybDfmr7Kic1WZCkEFRVPEez0FkEOM0ouXBXuY2LmGkq3RnbMVe769UMjybNKNlR9xLP7GrK/M0QolnF16FG6nK5QB1IpVD21aS+tY6o6TGWx3XHaEoKEJuNUftb54m6Fm3jILa0pS2tpY3TIGj/UZugzcrrPXMiuhZpp0tVgkQ8YR+eCnNyg5M+cfpQVYOIZ0RYKho4dZ17aXCTSgNotsgVdJUGCXMIyRnRe2tAJkpzt99uW/bXSoO2wFwGJ/nq0nKmdmek8RC6Ricuz4C7RFOAeTHHWJI0uGY5jkdBc6Ib0/dIU68MPShjuzv3Eos5ym2sSlY1r2ZQfRowU9P+7eESlP4R04kh6T2KYLTnON8pvu862jgGEcmqavQ3u4Oiu2+uqWobYxzshmSnOzMzd/idkXRjmQH7qcYsON2dNE3e6lgCP3djkl6KGfK1Vd1d6HoM0HGxMB1bZHhmkJygcSLQpnccghlKnNQx8S1NgaXUnCzuReJwb7mdYAL+712YB2UxEreI2MFSVR3nGHNRxrbbPOuBlRGA5aJ0u40dLaVuHgmhvnnq595gWy0w1pklV1vUxCKIsbntkdGcljaSQaxzAUnVrRXjDPhslHC28SIivUjVVenJywm1h9m4ytN2HYdnjD/sJem7yk23zaUbZ9I3yoh/QwMzYHKVlcoZnZiw7IeeS9NSJPrGI/hFIgDsMuaq27St+USUnaAZ8QEuwui6myfESaj0X2onfs8DIbVgLZmgvTT87rasWzxx3EnNIkRjyBTYvz3Jz7I5L6Q67w7Dvb3nXY+1mRg1GYP6rgVimzaSQUSiSmWvBdF7TmgvuDiYkSsbxbYJYRemySdQ+Zol/EqVcXhS+dRoA4l7asOyn18N27mlsq07I/Iv1w1b1IqEMmLAjqWJD3gR2hYDjpiRKU7QrJbx7EpjqnxSjPybmGzhGYOWjMmYlXcdjwhIw5/B2rOaRn72pDE1Nmsd1DI8BjRTklrPRs8suKbrMbfMynNy1JbU96ZIU9d7jM/htViGAXm/Q3z+WrSRDIIaQI/r0iPhzuOc7rk1/RypJxkZQcjFRTciNQaWL9VJ6+xPWg7l/Hup4Ok8JLjxvop1ORSJ8Hs7M9tPzIV1M0inF1DTm5ws0wuBDIHndzovRXT/KVVTxvX0NEFrK2QWUmHQaThS0dpVRPujySF853yI72WGGjUTumkT3J7LPI2IHfM+4BlK+ln47P87mmoQO517r4ahMGDQdV8t9yppIxnEPHwmp/ZAjIObggaR21yIfoanIDGnAVVmJr9VB3jzRKPaSbfbAtd8dujzeVgMxi282KiGum6TAUeTzSGS8RCqtXHxWxKTQTKgKalKZbfNbjgujIg3pFBOE6WoqTbjvtuDSXc5DSYV981Ed7TdmOwHuxJdLjUDvmvUEqJkJnn8xoWdpoyH7yW1wVtXIx4abMAxPsd3zOozuHjfaWnr5tzSlra0ljZOg2BAUM80iCqz1bVROqRqmjRqML5YdYzI8CS7VJCMKmh+zLrMwC7nxDTgaG3FGart3nPjeBQePRu7qdUqKM3WbdNmEA4la/QARellld5h7VTjbbZQG7HmNWIXaXAbxj0RjbsutVu53feu2nlFD3K7TX2mabQoNRMnio34QgSkSS63CcfHmPg0+YjpSK220TMLaBpKrRbExcpsUzEIKporEZRdpwn1aCMZhCl6KKTiBgK6bHODCG/0Ajg8mHsD7A0xeeJxZ+N4nLuGCeSFw8nSuL7SMNETJttKQwzFGF9RfjOo5zMdXL5UvSG0Ob2nw23bicBLIbffYO3VsBmr9e6vS3loK3NcxJOvuUA8VmQgrsf3SC2o6OdjtiuXQYYbX29HQ/tY725uc4v2PEBjezG5ZqhgxDbK93Up+aLJ0WMSdKev8yjFOAeSBV5kdDHPRA9o7dFGMggmcfHCMK7gPRMmdzCvZVV72kTE35IoovMzVS3iBk1dm4d5ujAkoNO5DEjCwir+de5xiDEZfnEyJ0pbqd3S7om6kyrY6fBohoEzlqJU0eyt8Ds34B1vUMskXY+l5HhYUVhYPe+DXXO+N2ImxjUyrscEMZKaICaPozUuv4PjNHyPpOaIvhHDKs+4DnuWfM5GT0Nw9dErRjyEzCpuA7DGQM2EGsPogi/fmY9jhWeuFWxl2jgGIUE9LIvrLBaP4xW4cKMqaCZDMI7Iu6VmnAD0mliiMbdEb8L0PCaUys8WN+ZZ3JPVSlWbIdR4mg1deSoxooYwDzdE969wL33rfg8/s1TJ6xjKG7M8qXoibEY9q+mCikzF2goBUarX1Px6wU1STVjLMfJi4yKcCwy5aConeCfv2iWjZITjbqoRp+wbgtq9+WOiaRzBUWtRUSOjidRocJ16XgjwuHEMIqlKg3m5EDf5UAL3Oo+IuFQXrAcjpmfnZ06aGH/h+rkoV7kNfd4JOIVdpT6I1wuZuxgt6bkg6IaLobUrTbeVH+e+yst3jLZsJC/SlWpUYdJQj5mBU7OdS9NnTS7jam2JDM6LfJGQy0FTdZvlsgk0+yhAxvcRckukFsvwxryeacDxjwKETM3aT/R6kHH2TBc/FyM9yTgmWpTWj2Gv/I0imhg75XMMPrE6KlWTgMk04r55S4fY0RwYBwxxknBhzlV945R0TJTiHJqcoGYWnjg2AZgzwO9EyUkp4f0Q0TY/7sySGKYcXZ+ELuLjdGGyvJj+7rncAnxxv4brp5Z0Obd7KyIgzMVkbdF9Q9vb7+Hv/PMzvMeLzdqRry3DPU4Q5GdjDo4eLpI1ZRhkaH6n+GzUCnph1dGVy7pe1BiE7W+pqlvsDPvfOVmISM/VRiD6HnYwtQFO4iYvYanDHeyTrajNeNKNiyW10k6dz0sNQObl3P6+F0acjNLZlmKKdWozvo/RjT7OrgeksV0Rk2BkJBeLvye1sRtOBuPGxPT00nSROGkwcQtrLm6vmXGU4hyjSMaRlqH91DoNBJL576vun7mch30k8RxQUsRLaCJEz1hkAL5PmsZ+EIwWfmvOCdXpNYjrGgfx6KOP6g1veIMuXLigBx54YPL74eGh3v72t+vChQt605vepC984Qv/+Y3c0pZexHTdNIjlcqn3vOc9+uQnP6nbb79dd999t+69917dcccd4z0f+chH9LKXvUz/8i//oocffljve9/79Md//MdXLXcm6Qa7CPMgWR3NJ1UObZzCcf+jByBV1dq79QyOrVPhXW6kheo275emKnUsuay+Pgt2Hl1+vdDfGDNA16Tbt5danGWWhm3irtdSnv3A3ZILDadRH6i6Yl0+z9CkFGw0LACRDOF23zFS02NA3z7NCWsLPf8+zYeTAsYyxyeBQkeCUv1mm9zsHPp33VjTDUtzbJGGtPk8Ks8mIDWKiEn43aN3i/XGA5SidmdTJeJkUeNZ54qNdE0N4nd+53f09NNPn7K409Njjz2mCxcu6LWvfa12d3f1jne8Q4888khzzyOPPKJ3vetdkqT77rtPf/VXf6Wcr64c2axwHoWZam5Io9COK9jTcHzejWm4djbVRLN7KrkSU6teSq165snPCZZKfWdYTxrqOZdqajpOfKuyhyjTNqgXghejJ5snvE0dLnADdgv0gbeGe0K7f7zwUihngTrsHqZEGc+8zMPfYfl/kkt4dekoZ++2ne4+OMZ9V8q783wJk7dxO6jJzMxt9kJzTsycK0g6wz1e2PEdZ/jb0zBuN5Q/v7Pxonmq4+AxMEjpth3m4RmP+Y1p+OxT1s+Va5wfHh+60C2YRvMJY8/35p/f0WV6Ls/D32npmhrEV7/6Vd199936wR/8Qd1///265557lBgx8k3Sk08+qVe96lXj99tvv12f+cxn1t6zs7Ojm266SU899ZRe8YpXrC03qWIQ7nACj85NwBRuS7XZj7OqT1uqi5/SylKHoCRtWg+E68nFTRY59xL1WpLSZj9Wm4aOE0Wqu0Y58McaJsZBKJvUCwRaqUYkXsEzlsiegPF8EGoCZpbR7icW4z0r9qIcBYAy2tnMVxlBVLr7iEf42hz3RGnIiE6XH2M/5oU7pwTAMQ/9HvOPmoyDnVVfW/H3laSjVOs9Ko2OG/DoRTJYHnEpfqamwjNHTrtBi3RNBvFrv/Zr+tVf/VX95V/+pX7/939fv/ALv6C3ve1teve7363Xve5130SV//3pwQcf1IMPPihpmNjePs3OZJALJ4394uMuwfK3m6egXpzEccJZavuz/eeStD+rAKhV55WGCUjzR2rVYE+aqFJGty09HzRhTEeYeJ5EvGeuNiGt66CK7qQ4ZISMKzjqXMvlfbiALpd7DLRG0NB93VNveY2ncPcmv8sYy09TtX6MgkT5dDMzQnUcg9R+tzk3Bq+l6S5hf6Zo5ZzyDt5LSfoGwFoeYOQ2cqwjSBmJ70+hEA9OWkenwiBSSrr11lt16623amdnR08//bTuu+8+/fiP/7h+4zd+45RVtXT+/Hk98cQT4/cvfvGLOn/+fPee22+/XScnJ3rmmWf08pe/fDyM04IAACAASURBVFLWxYsXdfHixeGZlEabea8svnlqFxTJ3gUe5uLvnrAnam24cTdnajUA0qh6lpE7xHNmRkmSspqjAg8KZuJcEZ4gxBeSKhNcqaiQeMeFsD9CVVXlRBvVcqEtKOM4TxdddK8ltd4RLjhfi4cQWQXvJZ5hfEKM6bCGQI1npirFR9cmVuW4eEpf2bzionWbGL24lJpDglmfP3PYV2oPAV5oGPc9tQwtMge+40EpYwEucqBhNy+Zudvn+cpYHb8jiS7NiFWdhq7JID70oQ/pD/7gD/SKV7xCP/uzP6vf/M3f1GKx0Gq10utf//pvmkHcfffd+tznPqfPf/7zOn/+vB5++GF97GMfa+6599579dBDD+mHfuiH9Cd/8if6kR/5kWuaN0vVrdHOqTDL7calXVXVf5bVBAztapCEe6lOklVgBF5ctkulKRDEhSZJz2kY8JhDgiDkS1ONnOTGn+jz7p0uvspVSi9Km80obS5YAjlIqudK5TmfvZ7mMztp6D9qLJERe5+D28Jt35RscdLuqwKox3nY/k4m5zq4KI/8Hf2Qwj3U/KxhEhj0fTMw4BgTEjUKz4UbUO+e2r0bObfh2mbsrucy+pHu3v2E4wELeMp55P5gmD01F9dFs2NdBGePrskgvv71r+vP/uzP9OpXv7q5PpvN9Od//ucvoKpQ8c6OPvzhD+uee+7RcrnU/fffrze+8Y36wAc+oLvuukv33nuv3v3ud+ud73ynLly4oJtvvlkPP/zwNcvNqgfneDKcSGOS14XamH4l6QwW11KVOXjx7+VBMjmOP2kYWCbuiAtXanMePJ/rxBtVU1UwVaqqbbPxSv2DWimRT1QBL2nQis5oSE8nVdOBainLkKqnh7suo5RzGxM+87+fizZyPADGdXuS2/ShZKcGN0uDRrVQXSw0C9wGjy0TucRUa9Fs8XONR6Xzjk171AK2Dr1uGFEZZ2tyxKukYayyquBJqqCpPV87Guac25JSxZXGvJgKmElov8ewYew6PaV8LbfAdxi9MiX978AgzCDOgEFYJZQGRPmMwCByHQhuIb6kdjCtQp6WQYzaQodBLMAgLuUh0pAp5SKD2BGYV6n3TGozaGdVW/ZSHhbWaArkvj0e64oMwglbxojBNLTVblqeYxlV66itXItB7Ks1oy6X8XAduxred44yTlTT77mcqzEIm0cEOCOYS40lMghnGr+p9P0ZjMmixyDAxOO27iMN8+wbGPsjtekFD8o98cAgYhvEJ4Tf4nh86c479fjjj+tatHGRlCSqs1RxF1DbVLSDMwYTE7YFl2s7abAND1Nbrm1wqU6e2KHRPcodnnupTZVvtZtnU0ZUfVd1v4Z/X0lNKny33wv5KUnPZIQpp7pAoxQmw6Ak9u+MrJzlNtJvhudW4RrB0JlaDYAuQtOR6mFHlq5RkvE8TkcmOr2eymcKA2syxHP8ruviC+zloqlirxg3oO2lloGsNMw5L+6FBk10iTnErf5uwyxJZ8FUEuahyu+zXOeZ+4DMlXEOjvDl+74Q2mgG4YEiNiCVnXbQMpbAIfbyMNhJVfW3iWJJSWkbEX0vJmsYVhcdfMNF6LgIf382ty5UE7/nUIZdalLLNJaq4OeZ0raYTNbvwmdN1ob2UnsPXaeuJ6q4bpcpLq5o08cF6D70JDfDsWYhYYs86uXmNL8D8SUzHKZ7czu4EKjdcDwSnluoagx+V2tCByruanZMYcpxu/oh5pT7hQvZwKpUmdUCmBjdmCYy8aUqNrPO3Xs12kgGETklVazoPjtSi/rvl4E8i4llCedyLxUVPcY5eDuxVDeKjYObqgTzJHdAjuseMQjB5VmMTB5LR4ZB7cOT4uk8tJHvmdHWWa5SfTSBcrtoc+mL6E2QqiZi7YbMJYKUZs4EyCL+sQ4Mje3PQg4JTRmlgTi6DhdYpGYEUXOJ8Sz8zl2W1Dx2cc9+MemOsPiP1Zo3Bju5h+ZQlVmtNCx6n/8hVS3F54PsZGRLgybCPR/r3JcOMnuhtHEMIgk2fW5dmFKfi3ICc4F7UUYNxL+fwQKapVZtPNK0c/cK3jG6NdWqydJ0E1UMwjGzayQnzBS/w2Gepl6jy84Si7tDueBWuCcIwgZrifkVzNy46KllMGGviZoeiWHKfibGpnDnZtSG5qoCwOX0TtqKm6HoHbHmEE2gGRbyYWG41iB652zEbFMuz8JhZFowQZepHSO7pZn8xwyMWpHjJ1zuMf6/UNo4BiG1YOK82HAj90+thDDgRPuR4a3S1FY/U8o4l+qpV7upZURXVoPJYI+K8z7MgB8Yj6BUtAYRU795QjgTUQ+Nj0RXGPej2L3Ho+v87qYd1SAvboFeRNh8TRt4C3GUngkVtTozJzKZaEfHyFWOkevyQoruSWpJZoJNDINabcHt7eXrlIYxjZ4nl8+oyKzap/6d/eSxdj0HeTrOMVrUAobMjubQjqog6jHEa9FGMghOrEW4QNtSGiQ6AaZzBdwjuGPXGVF1aw97ZQRzlm7AaO5IOlxWT4hdqzyez5qJ2+IAorgxzG4zqUh/eBtyKXelam8TxSdxcR3m9p6sdsG5vrhlOeIYsY7IqHoxDnGiRgYcnzPWQ6CSWpY0XfxSleSrNc9QS2I5vVgJ75Nhe8fI1NyegdILGOOY9cj3MRjMxIA9t3HsmzJnzFRoPvkd/1to4xiEpYLpsNjvPCJPajvOIdD+/UyqZgBpPBFL1XT5Uhm1ozxoEX7MJ15FFZKH7BoX8GCeSYPUYLal6G04yUP9npxH5dqZVKMv9zW030yAzESl7b2ktcZVXK+RdXYFbXy+h8uNi39077r9arUhEif1vtqDb6wmU/MjMBm1BH5eJzFXqhqZn7d2wD0eE/NCA6P0ocZRqtMrY4ZqhrdOmzEj47yM/ez2nITfiH15vCgMIvUwn3X0QgDNLW1pSy8y2jgNQgoei9SqzlY7R6Q4tfH6IyaQW5DyTIIXIA1S+2vL4bRtaQgFXqgFQQlU7qd6xgGPUjvJrcnhqD7vmGRmJ2lwz17Cd2fKPlQ9OyP7HQHWUvpaPY7uSbsSpVYrGNVtI+e53kP7nc/Hk71M9DrwM6Un4ymE63bZSUP/RA3E91C6GvSV6tjTXSm1cRtRW/BzBPh6GEn05sw1jE1jnqkFw2ky0YNF7YvYB8ePmcD5jNtFPMYm0jdjdmwcg+CgzaXxVOjYKe5sRyISpBwTunr0yvN70LeOc42wlOq+Dy6WHSEVXDFBaN9aNY35JRmBOcttMJVyO2FtIytLz5RrLy1M0UzmxtTuCnQsg+933bOsLtI9B6M03mGiCnqDpgvFE5U2MoE/UxyfGAeCoRjLiS7NHmAXdzrys3eDxrgHel38PQZYEQdwOZNNazDzXA6xjXX9eDVm1XPhz8N3tpWMKZqEp6GNYxBSQL9TC/plTXfe7aY2MMiLlKAfufZxlp5ZDVoDo+GuqJWKWTUKbp6G3xkYZducW4vNHCz9DaIay/DejTFnItpIEKunJTlQKKfhHfZTG/gUbd2xH9w+9ScsYwZUnouMhozTZfXqZT1xQlMCL9Xm7JA0kdLug2hHUxjEBRelbMQI2J74jGmuaWDaUm3/RXf16HbWtO96zIP94Dqlmp8jYh3UKvz9NLSRDIJkNS2q094p6BiCXfTYbmpV0cM8aBUOhJlpcGHO1AKXytOFYLLPm/EKNAHGMtI0nv4410l9Ng33mzF4P0IPALMpY+8I3ZZRw4kHxbichGvLPGUSNAXmeJ8I8rkvF5pGQWa1E9bX4+ncMbaCTCQGX0k1cxcPUopJeKMXQ6quQalqaOwHezTGQKlSP6M8o6lmpiFcp/R3/AK1DM/d3mIXrtGN3PMGRe9N1um1iI1kEF48i85vjn58SbnnpWnAF05CjzHDlLMcj7YsPBQevB0Nm3bI7a32SlWyXco1H8Q8tynW7Gpc4jnbqp7kziDF5tJvLtXt3XSf0r/eS/E/L9qEJ7Fdq6tcGVgM6pL68f3RldiLg+gFE3EyNvkrco1fGRdp8NBYIvv/eBHPeEHSTPEuTLoHqRX1NJ5jlS3XpQ2HqdVUrOKTMdrciX0T+yXj3SRNTlRzWW7PsTTBSEiMFr2WV6dHG8cgyJVtW1JC7ahEM4ZnuN37JNfdg1I1I6yirzSot1cyzAXHRaDuaB9asoxqfZq6ZA/UhvWm0l5v8jnDGaZh4ewWBjAyHrWRlLaPmUTGk4YnasWFLKm7lyEmK+FCt+nD4C/axHzeUY1ekFTrlyiL6d5YF4N/pMocRnNR7QlpUetYqOIHMUkt6zHjjuAn7+8tur2AQTgHqcv0dX5ParObWYvwbzZ1aVrQDd5rRy/O5LS0dXNuaUtbWksbp0GQqJqPXovUbtW1tLagtPbwjVwl3PO5BbQsiQh+pjxoEZTaboOfsWSkfU4z6BkNpg1VSAdFWSraa8INPQY2iW/QJejvJr/XQtW0skpsCbejQYJ34qkmuy6p9vcQc9rV1qKOVDWEVWrHYIbnpMEUsweodwq432/EC6BJOauU3zt6EqxFxSMOCDa7Xwh+Nu+tqctypYrZSFWTYS5Umhyuk++90hChO4N266jJCG5G6oGT1IBe1CAlF4o7ZYxhUM1D6e8nGRttsvRUbmMNjMpTbfYGneZEq9zGTjCs+kzxHMRDbTkZ96VJeruD8g57UN1ptpxVdWnaXnWaugiqkYwD0BzjYcNMu0YAM57QJLWMyKZCRN4J1nlSMyVbUstM44HDR7k1h7KmNv3oqQLj4ZZ84wQr3D9iFl6EOeT5AD7F8He3QaomCdu7p+FckYRx47NeuNF0Ih4yL+9AD0XObcZxM/BZKKcHbLLdL1qQshlcDR1xNrWDS47rPH/u8Et50BhO1B6ms8otUmwpOXoG4FWQhoXGMOqzSeNGLTOAMf4h13KdT5IjSLDT380EDyF6ubU5SpbxeDsNZUebdKZ2MtB9ugCjoETKpV29JDkx2IegWiTmPDClVBf6yIDydOKP96NuM54rmobeN5uscG3cHJeCxye3zM3v1MsfwQN7mKyo115p6hEyUMm2EnRNeIYbx6h9RbdnDxzlDtdr0UYyCBNRakYmOs2YVLmyO/yKpoNraUqQzwPnS4e51SbIHPy7O5uBUUtoL+vURdK4ecttS9PF7XLMrHbSIIHHdPupZlyOe0VM3EPAYKde+juTmTPfOwJk3ghHk81xKawnnkkZgUFrP/Ri2GvAhc9yYlZrSWNiH+9/cdLi58vvz0njhjWXY1ct1fwknDWa6ua8ywQcUTFNLqkKpJlaDZj3SBU45zxPmo4LGVNPGJyWNpJBMGAncntndnKQDV1RUrUbo/dhldvB9ClO7myHUY/4Qm7NBar4nFjUDpooTrwDNyXNNKDcnKxWm33trAbG4Xp2s3QFEtnPSTX+47JaF5sXMbUr9y1VdKv6fC9KQj5LIpPbL+09Du2jizhGTjoEOUZc0oQwU+HieR6fdyXNcjEFyrVzAQ8xJkSGEPNXHhZGcCPatiovvYd3WsJc8fOeL3vhuym+z04aMJnYFuEeMmnOC97bc0/3aOMYhNS637xQxpgADVKTbqHIDKR2Yp1gkph6kn5PdWI9r+oWJJ2oujmhkY5tSdLksBZHe0pVFebAxXMrV5ruGm3S4ZV79lKVamdVwC+YE9E8MDNoTBF89v3EE3Y0zXLkMkYGkdpt+ctcNI/y/ShPA6G8mJhmzgFuJi90ahRup0q7slrz8TDX9PV+hmX4eZpaVvudkvCGVPGnMSYnD0zY5o/HdQRqUc/Y3jBByGw5Z6kh5HCNwVYRpzgNbRyDoJSx5HUcgDQwiMv4bgYRMx0xXZwlFQfFkjRuIx9t7VzDtl2epeC6vACe0Izks6bCcw+cVcj1uVy373Jpj80HMwhKoplaiW2K4cEEwKR2D0VkcGfTNAr0MhYA72Xeg6M82P4EZxmsZCK45sXke5z2nxLTvzEugozeoKtU99Jc1mBW0ASYpYHZRw8K928cq2qlPjKBWtIqSfu5rTurMmQCsz0cYXwmt6ZtxHZ6Zmr8HiOLr0bbOIgtbWlLa2njNAhyS0tVJxCVKsZg6emMv0bqKSEJUkbfsVVE33NQrjnFnGMtYmSlf5OmGY8Y3z9ms8r1nAvXy3MRDI6xbWdUM3FLgybB3Zym6DK1jSvBVRjemUf8SVMpP6rOfCbUMVebRNXRq37HGIad8CyJe2oMdGa128BpypxN1fyS6sYm1+n2Opcp629wrNAWA75+n8tqcQKX32iGms6pVQCc7fFy23guCNsSI0r9rDQFbv1bxITW0cYxiKSqfmcNHcqNMlYHCfLFhX9Ow0KIrqzRfZqrJyTGF5DmqmGzZgQ889LtIzZg9Y97Ig5zdaMSS/AzkXyIDF1/3Cvg2App6ilYBcZAVXonTRdL8MiObWQIOvex2FsxVxtqHV18DM+O/6XKeFiur9EMIcBrRm/b/nKu95zDOJGRnuTyDtIkO1QEw2O+yZXaBc2+PIv6XIYZ69j3xcP1nGp7zejp8WF7zQyioIwM5EULUs5UcQHTjqqNyYGWKljnxeT4hbOqE8mJP0ZpU2xSBqxEiguJg+ZJEvddjO1TnTgGIDmRepgA3Xk+s8P3xTK5sKLkjIudQJu1lXV2qZkXfydzcFvMEBrpic/EXMaKA1DnA4SaPJpq2+9dunvh95E5FpB2L0kvBwh8rOHEMGnwcESNJsYWLNVu7ov4hFSjH80wDnJwV6sCvPSWec+PNMy3E7WRlNH9mzX17kSKwPzVaOMYRJQyx1lNwpi5Bu4dU8J7QlrKOFpSqoNwhElqLs6JTbDzSANTYr1e6FbjF0ENXeK+dZtvoieBTCCG1HLxW61nXazb7lVG2x0WRuNoQIepU/ugm9gAG6Xw6EUK4KfURgiSgTEHhSmp5o/0swyZd/p33+v/kUmTUZ/V8M67qkLlbBrG2RrbM7kGS3FMyDQiozcj6HleXMaV3DKvI1Xm6r57rtzHxMdxjOPJWna1Mz5kPNQY7ehl4+rRRjKIKI2WuWaktsss2rWjCyhNA2FWGjg+F4ZNDp6NMEutVDzRcIiNVHGCHfjCPYGIL/BPUpPNWppqHE5JdxY+9+dTTUVnotRgpCCxAp4QbpWf+MwCn1X6pMeYei7gMQlwnv5uzwPNQC4U716cqwajGVsgM0xqMYczqcZYmCIm4mPzGJx0WRWjojpPDImZpHsHCJnItOgR4unh/r9QDRKThrlKpkCmzjZRoESX5lI1OE3h2dPQxjGIpDai0SrkmPexLCiq+z7L0t8jHecWx+A23HFggBG4HC5k7wngJDK3j+Q8DHwHl09TRxoYgTddkdntpBZopPvsJFdsJr4vM2QZc2DQTXSNkiFmVVcdb4tgXdwCvtK0Xxi1abxnKY0nrHufBReGgUpuxPNvUtU4Ruwg1X0rdsceSfpari5Lm5fsJ2uYDJjyu7Ncvns8j4WBbyT2XdwazjFk38W+jgFRp4nQXUcbxyCkFjzKqQX9VuEe+88NUjk810xBqlF+lCBxUptzj759TTm1J2fc8clksCtJQl2O4IwxApYyu6kknQETiaqtNQEX4dR4DiRzf/S8BPH6JbWTmiHSDs7iQrDUpJ/e1xgC7chI32Ofv+swcYMX94GM2o6qgBjPk7DGlto9E8d5eJ/jVbsYD1QXu8tjfMXl3HoblmoXpU9PlxArUrQg7sxktKg1kBhrc6SWCbO//VxkyOxbm0IxIvO0tI2D2NKWtrSWNk6DsLvIZPswql2WMj6Bm1FrloQZ989xj12VxCmiS81lMbx1llq0e6IC2y4NgB7NlQjoXckAzCD15knN9mgf80ci2GmQjtIpgmbR327knXEdbtsC2sxhxqGzmuaadD/xnM2Zby7vZfckJRpdtwZ3KW1H1d/l5qFu1+OQe8aDjDs7oVFaY6Q5E6V6VrhY6GpRjdHFbMB3DPFXi/FIbTQpq4wmWq9OuvZPS9eFQXz961/X29/+dn3hC1/Qa17zGn384x/Xy172suaev//7v9fP//zP69lnn9V8Ptcv//Iv6+1vf/upymfSk8k2YhWgEN8vBwDS6D1zSETALyY/9SKOIduxg5kcN7ow90u5PNXL8QJkLG6DQjvoGt3LrReDLrVzaYpBLFLLiLiXI7rs6G1gngwnXpmlljGeSW1ZCyxMv0tcgEzQMk9T96vfJa7JI1XTxJujiEldxu9k0GYaN6RWZfdcIFOOHoAolKSayHY0v9J02753EkvtHo2x/ZqaDxZEMQGu22YXZ+O+Lp8JUsdQgHWUcs6x77/l9N73vlc333yz3v/+9+uBBx7Q008/rV//9V9v7vnnf/5npZT0+te/Xl/60pd055136p/+6Z/00pe+9Kpln09J/1fpiT21SLdUXUDuUANmXoCWOLRV7S6NoFkzidVGYVrqZHw/m9q2xI73xDuDCT1Tm7zm+QKaXcFzdsPRAxEnBqM6/Q5cGF5EbtNR7rvHuFBcV1zoXCz7nfuN1DOikZhO3KvSy5Vp25sb89z/0fXJTWFZbUDTIrWCZD/VA4iEdlKSH2oYkxN8l2r/7pdyiPtcLsCwM4JlVSxDGhiEPV3WsJ7NbQSsNQqmKzBjjZpJ1Bo4N48l3XDnnXr88cd1LbouGsQjjzyiv/7rv5Ykvetd79Jb3vKWCYP43u/93vHzd3/3d+uWW27Rf/zHf1yTQWTViccAH3coOas05cZG/JPaMGmGN48gmtoJSpU3AkPOQyG1ad6kOtGOVDNPecGOGanxDBkPD7Jh5ifGJ9g9yckyhiUHkJJ9MUYnmlFGyZvUpFWLkst1+zR0aehHH9BD1y0pSk1qZQTaZrjPp5hFUG1HNZr1bPl9hXeep9Yzc5ylZ9X2P7UkqYKSjKI9q5bB+zCm0R1ZPFPO0XGgyrCkGvlKbSBqKgQyaXZw8XsTHDW2w3DttEFS0nViEF/96ld12223SZJuvfVWffWrX73q/Y899piOjo70ute9rvv7gw8+qAcffFDSsM16TIySqzTmZNyTmq20e6rMhGp/L2KxPDLxNyfVCee6eTrXLDzvZ6QpbmGvhMq7XMl1Mlqt587NGIdghJ1MMUYDOmCMRO+Dn5mrBko56GnMXJ3rhHX99CZIQ/87WY9pdPkGzCXazhiicd/EiPrn6Ts5PVtkTl6U59J0n0iSdJBa5vq8qtszaxpO75Bn1xNPiPewRw8E+3dfVZvy+xyl1rPhORMZJLEtqRUGNs/omo47jV8IfcsYxI/92I/pK1/5yuT6Bz/4weZ7Skkppcl9pi9/+ct65zvfqYceekizWd/pcvHiRV28eFGSdFtKjYq6Eybxbpjk5LzS0CG7aqPR/BwjKW13Nj72hMNTUhtTwDbYFDgJk9yDO1dVRQ+Cmkktxv+9kMmseq5IHl/vsjwBrkjNEfW+v5kguVVvvRDo04+5Kc5oWJij+ZBrti2nyJulYdHFw3ZGHCD0kaQxLR+Zos/PIP6zUM3vcC6143opQyoDlFzlKmQu59K3SZOMUNxXERMGG29gwJLwjLECqv026/hOe2rHZHTduh80ZRbriNruaelbxiA+9alPrf3tla98pb785S/rtttu05e//GXdcsst3fueffZZvfWtb9UHP/hBvfnNbz5VvSl8vqJ2IXsBksNGu9kqsVVqmxcu29xfeI6qoXCNap1Nk2MwJ95Dz8QY1KR2sUTzRKqqKINwGD2YS530we9oYD6U0lThI3outZurpGHynkktw3HUHoHNS2Eh76gN9z1WTfXm737W9U0wCDBr/99P7cL1Rjw/YyzBjNKaySq34DHbv59q9C032ZEJ2rSh98FJdp0cyGZh9FxQW0hq+90p6LxIDSLHeAl6hcx04ti9kP0XpOsSB3HvvffqoYcekiQ99NBD+smf/MnJPUdHR/qpn/op/czP/Izuu+++/+wmbmlLW9J1wiDe//73621ve5s+8pGP6NWvfrU+/vGPS5Ief/xx/e7v/q5+7/d+Tx//+Mf1N3/zN3rqqaf00Y9+VJL00Y9+VN///d9/zfKJYlNbkEpkIqSFOTsl6WFuPQlGy0dVukgqmwimPVVJt4PnJJzOpSrdo5nT2yMRJUFMRW+QNeIY3JPgl6BEjii3PQV8xhpOk08z1/YbmHNfGdBbqu5AvKzWhTkP//k54T8lv6XiHPccFxMjmlXcqWpPQTRVmKV7nmpIuVTHZx9lHKqafK6LGhxzc5Acd2E6VNsWYgk23aLnaIG2LTGHejEUpp7UZ5m58/s6ui5uzm8l3Z6S/o/SQ3uptQOlokbnNtaARFdZ3JgUTYHnwSA8Oa2qWl23iukFuKuKkK/yFMiKSWSsco7ofTAxiOpzIO1mM0XU2+nZ3P6D3AaQsUwCeCvcc7OkG1MFOw/ywBCOcouZRDecmScPkbmCZ6KHwO9LkNJ7JEagN1V13HgA0/SxT8bs0/6PRWizifjTpTz8MdExBUZvLOx69jN27dKTxX7xu5Bp7Gk4Q5YeIB/JwDgYbvCK88X4VASAF9/Obs7/LLJ9KQBM7kBzYy/qiN7PpHHkzxaRdojF6VyFxiksRT3R5tLkQGD/xkXu/AP+TuYgVbdrA2ahLE8oagzRCxO/U8LSRnb5vier1ZK82EfNJ9U9Bi4jbjByWT3wjFGozvvoZ/d09WQ8fo7gInEll0MQb1U0BmpNZg7NwcG5Bi7lXBhJkhzKN1MIvioMxLEpZqwHqn13qJohW6p9SRDTYzjiTaruW9e7W/qcc4RMj7ESJI7/C9mLsXEMwotXqhuuuNEp+rT3pTHJqFS1h+gJuDENuQGkYSKs1JoLrqJB21MF03yKN333UjuxewEu44QqD3mXY1QjneSmRysNv3Ehx0hQb3wakfrCVNlfBsf8/Yr7Ldc2LNRmUdop704tKYakjyYSvDv0NhjcmwkMOE2ZnrW4mESGWobfQyrqfxEgUWU349+XdHOSXj7DVvOk8YhGFWShTgAAIABJREFUSfryqjAHj1GuiZGZ3YwgsOfBGCeBzxiCUbPzOzvuJGqEfsYCp/HuqJ3PNN+uRRvJIDix3DFkCotwv4N3TI4RGP3luWYn8kNR0vt7lMSsM3pLVuG/JzcjB2eqtr3vnalVn/eSdJOkmzyBVeJBgnYwD2VEJsEdqHu5SsK4RZnh2ezbhYYoxL3UMhEJ2AHaPeYBDe10vgVLRU9wMtAYZGXpm9C+GOgV4wHGACKYnElF8yvf95L0fbvS//C/Sel/Lg8+Ix3/39K//N3w9d+Pai4HaWCQThhDilI8Hl1A7c3tXAph0bn1nvTIc3+O7zYx2HcvWgYhtYBYDKahO0mqKhldVi6DMQKUTCkNPnwuZD/TSOXcDronCO1btm+Fe+g65KEycUvzDRq0mzOqDGymFky8rJbJmIn6xChpCrAxgS5NF4Yie/HRXJPb5kWfigsTJp40zVS1q3quhFP9N7kpUKfbG4E5a34087zHhGWM8QvlOaauI8YiDanovvd/ktL9c+ktZeQu36nFmb/V7f82fP0vXxkSA8VcGXSNSy2mFQXXLPffSZpqN02Zat3gy/DdQ0Hta92xCz3aOAaRVCVP0tSksPSlNJWmodiUIj0pzokuDQuUtrYR695msYgK0xfOMG6hnZYiRtxZ7qG/l4cWqV2kNi8y7o/AmuuPlMLvlIKLVBehVMO1udHL72fvyzzXYKBoWlHCM7O0U83FBSR8ZzQhA9IYR2AQlkFN3HMjDSahk/6qvMulf5Bu+txSOl+MuK8dK39G+q9fG74+tSoBVe6HXGNvGLRFmmm6q9UM3gzXJsiIXamaKhMTFPfMUXZvL8YLoesSB7GlLW3pO4M2ToOQWqnnPQm8xu+W2uTAhxrUaHYO09NTA6AkX0BqzzWo14yadGYinnlBIibAuhdqI/0Ifi1Lg5aqqvF+bveFRG+KNSKebhWBrHW0VI0J2MutO5jSqgFEUf9MNRLV7+pIy8bUQt9Fb4TrimCdT62OqeAYYs7MW85XydD7y2pB4Oey9DdPSRf+T+nWc4Of4vkD6b8cSP9fqfyrReug5DcQyH7glnuDzQTQGdchlEFtz2YJQ62jWdI7ZHmJaz0tdh1tHIOg+u2wWrqx/DmaFgxQmqvdS2F03gNhe5oJYPZCr69z61HtXKTWdOm5InfDM2Oi1FLXSXmpfbVmk/dWSO2p5KZZwVHi7sueSREZI5npCdri+8kYuY9CapOv8J2Y0s/7HhgnYSZB8JYeIYYfu1zHrkRPh9s/7u7MdbwOShvPoSO+spK+cijNS+fnPDDJb5TKn8lt23pJbHuM9yS3TLV3aFFWO0Y9E4vXuZfDbWk8a2rNlmvRxjEIg06SpFwR8dHVpdb/7InlZ5adxbTCn6QmmpGRko1mktqt2JbaRO+ldtclN4wRNCUQeFTub54pgKR3TVqK/AeYHu3uqGH5HWP2Z/O8qG3RS8B9Lu6jK7llJsSFWA7d0cwv6fM5GOPgfRTUeBg1SZzJTNQHzhDHcYJfScPJY4VJNkmCU/WspOKROc61fw26uh4vZAqhiC9ESX+Y23gWMy8mVLZnI2oQQelooi9XajUIg+Jx8+Fp92VsJIMY06dhYXEXJCV1BAOJfI8Rj6EOayALlL8K99lfTVfmKMmsdeA3lst2rdRKGm8F5zOWMp4AZ9MgPcdFWu7n1vezGvonagdkaD1gK2oYe6nVvrxYxsi+XAOh/Mx+qkzAZWa1DNL3kiLvZp+a6ZDxHOVhgfu5eAizd8o6YY3Kb0e5mlELMH6aKgyL31MIiVZ1mzP6cqWqHfg9e6q+r9lEYttW+O9rSesXv03ayKBetAyC5oRdhJyMdmtSClIN89Zdb0n2PXzGTGahNnouhs4eC8lrVO1dJrRxKnbXI025PSe9JUxUX+kWfEbDJB8TjqR2QjgwiaeH+ewJTvIYP0HvhQTtwe7U3KrE+GkkP0MtKUZfGosZ08iH36SW8foej9MYfJTaCb5UK9m5e9TlOgzc73qgykCeRnvo9j6XWtzFTIjtpiAR7mviZvLUQ8G2ENuIjKUXOen6ojv+hdDGMQgunqslyqCkjOqvE9SSk1t1lmpoNqP/xkOByzPHeZhc1FBsZ1sziYExMw0MirkhVxoW3iG+8328xZrlOamuy7DdTzLDol3KxbVCeXHzGyc780+ascWYEefYkIaYjZmky9A8ZuUeaiJ0aXohUeLSdndb3AdMUMNF6HGM29bZV1GL8e82M1zmDeB83STHGsZl3AKeSth2ec7Mg0Bs1IDcBzFOhm3373EOEMR0WaYXwiy2bs4tbWlLa2njNIiZqq19onYnolRNEHPUnQImNsfLqVU7e5uuaPO6XgYgHWi6ddcBWtzsZHPG5O+WgnbdCc8sQ5tsusSAsBieHdFt4dpeGiIbL+OeGOTlvImNNoJ2WHJSw7HJNppR7meCgrFMtUAsU+zFreH0vmQVs8m/paq5SYM5yKPsXD4XQTSJOPTcr0O34WW1+JET4GS0ZSEppzZE/lga0+6lXPfrcE5F7S+aFwyeIvXew9fivVejjWMQpJxbN51UvQI0P7hAe3slRtURE8TxEktMPqqM0jTyL6aaj+CSPSzjJqjS3r1UVUgzmBXabPODqihVU4ONq3DflVw/76X2iMIT4DbGWawGkww6SpWpMZ4jLv6ch/K4fZo5G6Rq45t8whSjNvfVLkppupgsCC4DiZ2rzSjl+qhKk9EaFJyrXdxcqHGBLjXdi9Ez8yIe0fM0kFG6vJhBiqYH75dqpi4y7tMClNIGMggu0h6y27NhffCuNAysJzU9ICeSzvp7qr+PB62qP+BclAYHOZgLtRrFYbFTvXPUE9H4B8OIJY2ZkuNGpih1IuOLtqzKPcZjfI7DKq/HcugRkGqOiaRW+7osNUl6TnLd/twrNzI0pgl8Sbl2Lg1/N5TvL50N9V7JA/ORBsZzWXARp6FOgtjWBKKt7TZZ66MW5DYx9oCuRWIRcYMb3zUKlOhZIw4VKfbZOs3HGvNJ557T0MYxiJWqi4pxC/Zzz1NrYozuQzADb/I6DveYc1uScOGN4BJUxrh5K2mawyDmIYjRdS43mgt2lfrciUn0ItpGkG+st2gle2tmjXMzHCZ4anIbn+CDkb1Ib5pVb4rb6yzjBCDtGaC5QXPN7r3RDCx/NyTpZeXibTPptrl0vgzGzd81/H/uKenLhWs/cSI9lbGTtGhez4P5EsA0kYnPNTBgbvpaqe4PkapnKS7+6BqNYCLngvsnak+r8D1qAXGOeR7QBMulvYwwPS1tHIPIqos9qboSufHKwSOmHfijrKJZA5Cquk6J5rTt3Mlo6SlVXCCq/U1otqaS/lit5tHFFrAAl6lGW5qMoDO7Ff/vaVhor5lLr4YL578eSl8ps2eVaryEJ3VM4LJTpPjLS+W3lFn7jRW2ea+GmICD0pYruUq1Md4htWHnZoq03xcFy7ixlHP7XLptT7rlfyxteZ2Uj6X0/0jP/ltt34xmFMqWqgbhPpPquPuZXdQdcY/oJaKwsNlCXIK4kBmi4yIsfByrIU01B5oyLIfMVKommX+/Fj5xNdo4BiG1UWR0wZFm8TMYyChxyv+U270Yq/z/t3d1MXIdVfqr7vn3EAMhYw+eaInjAS2RzEMSOUTizxNnRSLMSwCDxFpaUHgg4oEQMBKW8oCVPCB4CaNVVogYghAPSDESWqSYSFEkLGInQchIG1gnAds7Hvkvseeve6a79uHWd+ur0912T5KZcYY6Uttzu+vWPVW36tQ53zl1KgKS+qKsGj9kru1z2/HSLtKTE4rXvS5dDThISP0ANlXixOZ2b07wwfD7nXsA9+9hapxtYvN/evz5j8XlhUY0by5Tm0C6+jgA760A/xIafv0A0GgUIcmXQsF5FwY2V+0gjHWVc+Efzditan8VcVs7Q6B7HDA8CFSY5qkf8BeA+kVgNnT2hWaxhZzCiqaiCh7iRApYWs1KoxGVygjN0CY1LQhQKuirkaAOafh+FYW2pbEaFPx0y6rJoSCzCohepAJAg6rezPkY605AOEjmH7QOAAvQ6CQH4oYaXWl6TRmq7xYg04nszD30TOh9NriFgVXefD+I1lOWbG4HyLOpvZAsJgEAGyookkpuCndtAnr+rYZ/DWcYnfpHMdEuNETwuTTojPEiGqY830CSEm3RF23iIFfvi56DUUFhzpB0YxNt+V6kgrJeAxZPhjaeA2ZeBV6ZAV4JHXLexyPveI9qX0DrZOFYsUmB1URzKPqYTeHBS7yHuEa7ACU185qI2IymIbRBbYqbUSDYYCq9R+tooHXM23DtK1GOg8iUKVNHWncaBD0D/Nuj/a45Xclo9wPp6qsuTE2BxsNiFJiyW7e5KlICL/riuU3ELND94RnJ1lwXwUogrpzDohUtIpoLPABWbc0ZX9TB5/C3UoV3wGtLwA3/BWw9UdTk3gf4OaBnY1HmxpuAuTNAfQaYJS7RZtmZ98DpwOy5GZSh5BcDM68H00Y9SzTj2EYFfcmvekiqKPCUJcQdlJUGUJsHev+3uK554FwT+L8mcCGUmQHa7vlQ843vsXxPSLEW63rkd3XfulHMgontvDNs4yBSs5Qp6xRn4PjVOvV/1qkmqdUmNFJWy1jttROtOwGhpKqxbnmuIAJ49tQkqmyKxFsbn8fHqRurGdRv9SSoat9EgZ7rtnD61i0e0u/SE6b1+DUi72zPPFCmWC9BNFfYvnT3DSGdBHUPvA7gyALw8n/He4YcsDmMiJENwEzNBIO5NKgMKCbTXDPlbRFRuNZQbIpSL4yCewjtbSC6kReQCrxexN2P5GWmAfyjIde+EAiXfRpKTRcl0Dph1SuhZPMp8D3aLF6dXOelGeABPVVS3zPD8Bflup2r1XpH1LQk6a5WLkoUunyOClwuMt3QuhMQ2nGcFO1cR4pEW38+BQgHOe1hHRA80q+TLacrAa9tzEUVrYOTA1oTrWq6dB5HrwOlLvfyy4poQnNI7Xddic4TPAwr4qVw05ml4jmvN+OE40SbkUbrJNAt2eopqCHWoQBaOQk9krRv9BjoDlBqJnP6bHkONTj1JNEdSYHmEDU5oBCcdCFT4HqkG8k42S3gXSaSDW1jpnPllxuw+F0DMcCt4dMduBR+djwpaM5xrBhEFen4rqIVpORHMZ9uad0JCOvuY0f2yGDTDnTmd9UKdJDwBSP83+vTyd3jkGzf081eQHSpqVBoIHVp8h5drRaoorMe3wq6EiC1E4pqPUPPS/U2rNiar4KT6VK4rjWLQTyLtE+HpI3zKAZ2eTiQF/MgPHPOp5OW7WZbgCKAaUBMoiHECFLyNuNj+DrvteYA0H7wL0k/DLr4nI0uaibnQ1luAadAUxPEgqY6HhrSD9XAp7pRS/VeBFFT2qOBV6R2njebZFkXLiAG7ClIyU1ulpduaN0JCIc0cYp1zXHy2fwQJJW0DZH2OhD58jW6jgPIh3vKcyakXq4aHMXN8AwbzchgI/KnKxwHo94zZAQAB4i9JukeAlWza8KbhpHr7Na9LtVgbvSFchcg9ri0kXsKpPqWehvyvIoL53wYzURDuHXysd52aL3a+X0oslTfEF74aBW4rgKcbQAnQ2WnmyHRjPQ3Ba4KhBlEIcL0fdYU0DwTNiTaYhT6rux4VBPGagztguR0MauiNYqyW/MCWKcCgsQYdAY2Aa1BT0D6Ukp708UVAeYebgjqdbEDbWo4xkBovALNEvLY59KTtSB/K3ilIKryQ94hZYHoe1etyW68YpgzVzDmyyztftWQqDG4aIqQdNszQVfVcLjS2iAiu1rqe5tDoSEw4pF4im57Z+AR69GUe3w2F4OKVN6DGGzVi6jFsH830rQMZQgYLyH26yJSs8+eSl66SpGCn4oTUYNomGsr6HTltwKRbdTfnPndPhP4J9cgNPKQK46CkPybiDzL8HrJBQxAJoJVMbmKamxCv0xGJWYWWkLUSDRQR8snNrV8byc39zywLoYuq9mhGAgHiB4P2HDpZq05H00PfS59+myLxio0UTxIk7VWzD0coBaP0et+pMFJFRS8Ke4yG4SDRggqAKn8dpoAcwgJZkPFQ8GMmkEURkCMRAUKIX45CAk+m5vLdNUGWjWCXrkHpgzfkQp61QSANjtn21xTE1FMrYHYL9zDovEUy9EgchxEpkyZOtK60yB0Fabvv4EU8FLVrsQOwjUzIVuwK8EJQhxEH5Ac8toEkgxTGi7MzTmq7hMZ3yDqLHETzQqtqDqQagt2azLrhTyHJ1arRsQVTlesWS/Zo8QLohrMomgdNQT0XrQxVZXJq2IxamIokKarKZ9PE4+mhcUdlNgW1SA9wjsSbOMyYuh4xUewk+bDAIJGI/hHHeE4PdGU1A3Laztm2vFaNX/bMn3m93aaSqfvgKJv9WAoHdu2bDe07gSEQ7o1mgOvJt/Z8vq/+sBLtD3UQbWz4gtThOcsaNkl33ovwvN7XGpjVoDydCoghi5XfRooZeMk2gGvMNfWN24xF7bVSZlkO7MvXHKDiMKVvPCIPMZgaGJWIM3FCKQYEL0CahpwY1niRha8ge/QeqAopCE8EtAkHw1EN2c1tIu7U7mfpokIOC4E3gYEZOWY4LPb4SdOfteyNmy6Yu6zGwLt+FTShU3rV5wBaO+xULxmObQmJsaFCxewa9cujI+PY9euXbh48WLHspcuXcLY2BgeeOCBrurmBGTEpO6qLP3YLp1ADBzhZNaAHIT7qInoKjWDYrJcCoDaktTDsrzW6E2th3amrv79Dni3fIbk7bO+mo/xENo2IE4+jwiWJRmoEINpuKuS0YqV8CGwyBwR/dJPPJx2LtjvC774zJMneVYfYgwGd0nS+zMQPhUXJ3MDUQCSf+0b9evbvuT3FbT2CcuyPk78ORTvrhE+PJn7cvjMIWI8fJb2ma7y/FBAOqS8qgBWYaPeiSbSNum1EvuGdbG9rIe/a7CV3tMtrYmAePTRRzExMYG//e1vmJiYwKOPPtqx7P79+/Hxj3+867qrKHYqbqoAI64YgIMurM4uCoc+V3xsViI9qp6dzu3GJCYw5cYqvohF+RD55sDjyqYvvN2LRyhDfjkxOdBoGvSEtmjMxnD49KHwonBV08Altov98q7wGXZRvaZJYvldQkzQWkZNhpVeQVVGmWo8AD8K+No2aL0NFELN5klQocVkuH3huoqiHWwTf6MAm/MCSiNOLOfip+qixtVEmqxmwBUfjh+2kUODvJGs0GA7+Fxtj29zzxKisOTHCp52grCCKMSshrxcWhMBcejQIezduxcAsHfvXjz11FNty73wwguYnp7G3Xff/aaeo4Ox6VGeJ0E3Vd3Hl2ATxOjErSKGK1OYWDUfSFfOpo9brGt6n0HLaa9zpV/0BZ7BD33pXNk5gTmwiLhzx2cfws5RV7jzmEVao0F7EQ+x1Xu445R1UdMoV1wKOR9Nq4qLmsCgiyngdfJoHTQTKlLOajwMVuI1MZ8qCm1qKAiA61y8Rqh7yEVB2e9iMFUNYdu71EttgpoNP6otUFhpG6rSp2oC2jHk5TurlbKMjimaUqXwlf8Xpbw39wGpiaMahA3wa5j7rkZrgkFMT09jdHQUALB582ZMT0+3lGk2m3jwwQfx5JNP4vDhw13X3UBxVBpQdBTdTKVW4FvdiU0fbdBEjQ030c6lqsjt3rp6VIEkc5VH0bnq5yZRSJTh3CLeuWrZsGi9phYBxLgKe2o12wbEAZ24VH0quHp9CpBd52KdLPOG9AEb1YsiEhJI82YupsWSYKV+mWAIfG0QfhkbwviFJloPMaKwKbdy+5j4h/1g8RudZFqHnTB6j8Zv6HZvD5Rh01XfqgWoFspnKTBrycZEsB7FrFhOSd2m/F/voYBWnpaDRayYgLjrrrtw5syZlu8PHDiQXDvn4HRHS6DJyUncc889GBsbu+qzHn/8cTz++OMAAi4QvmfHJPEKaO1k9RHXkOaEIKnqqMAP7yuxjtAUhjErUMjVid/V0foCmlIOaBNay5U3PLjfFTxQ5QbiRrQyv6RP20LtR9Pb1ZAmreUxde+qpOn4al4mu0OZGJh9UAJtgrdodCpNCgXSehDU+3DPYKhXvVEUOuoNWfDpBKRHgikHybNOPJtpXIPkgCic9XQvaj1e7lGywhxyrYLCrviqqSqeQGKQn96jkZhaThcqbZ/VHgAk2bquRismIK606m/atAlTU1MYHR3F1NQURkZGWsocOXIEzz33HCYnJzEzM4N6vY7h4eG2eMX999+P+++/HwAw2kbYZMqU6c3RmpgYu3fvxsGDB7Fv3z4cPHgQn/3sZ1vK/OIXvyj/fuKJJ3Ds2LErgplKKl0JYJEogcvt0+LOAqI9qtFo9BSUOSMQV26KI64ABNU05gBIXW3Wbdmiuhp+tD0EnhhGTTWaZgSpgXSHIssilF0QDIb1akh3qY77dBVUO1v3GiCURdCkyN+AR3lyFtuvdbAeYgasp1/MNT6ngRgibnM06Dmpyp9qEAQmravQ9rdqCyWgChMPgmi+LrjivWsbrZubmpSOP+tVcOaa/LCtOqa8fKfuUfWGAO01E9Vsr0ZrAlLu27cPTz/9NMbHx3H48GHs27cPAHDs2DF89atffUt1O0Qgj5NPUWAbZqo2nH4GjCKingkOeKrKFBQl+Ed03sVrdRcqWEieHQphNixIOl98xTwHiABZr4uqfblnICD2ioYnYJdgIKpC9wiPFpEv+8EXcQTziB4N7SP12tDLw6AxTlh6FPhZ8EXwEq+5OY3u1NK1KvUQgGP/sh+BaCKUAC/iQNcJaCcjEE06BQqrKPZovCd83heA0CGkeUfVwzKIdDxpCj0gjkXrUbFEwaL36iLCehTotsKHuBY/Nvz7SuS89+366R1Lo87hP0JPK5hnJSbBLWIF+nKqSCMPrQ1aou8iROguVYFjJT3M3/ytBNVcGxDKpzsFOTC4Wg25aH9rAJSuEnST6qpWuhTl7fe5NPryXS5qSkARL3DRx3wQmusRSHMk8FmcGCXgGATXgtzHSVVOcFcICAZgcUIwHgVoTdhDgaCLADETxZf0/JJ2qys1CB0P1EKpBS76GCMBpBu32B+crJyMbINu79Z3xH6iWxhI8QMgLhbKLz0skDI61rhA6hb2GoCBW2/FsWPHcDVad5GUVtrxZelkJxAJIEmswt/5smzGIf7PybaIdJW18RR2UxU1AB2YPUjND1WBgRhpyXqYnYlllgSo08FmVXBLpVoanq0BYAj3N30x6fmseZ8CheolQriXbdZApiaQvBhd5cgLQ9GBYsJZYcsdtBQ03CynCYoVqASie1MnxoJMZs1+rgsJ3xWkXA1RMDL0elGuFYTUia2goje/aQg9J7KOIbu4UEDogtbObangKAUiBZby1w2tOwHBCEGg6BSGveo2ag2OUjWf11YqW/VU1VYtp6m8mh5YdHFV7UFMU6YrAM9cIA8+lNMUcxUgyemo2gLV7AHTpiqi4KmgWEmtFqXeBQ3K4XOJb6jbTY/kU2EBKWNNE53sGiylv0OeQ02A/TKEQlNSfqlBKG7hUQgO7TsNna8BaLiohcwhCls9w1U1T44FL/XwGIEruUfVWwVE7cDmxdCFi9f2N33XDq0eNhVm3LtjiWaM1tsNrTsBwaQgQLRjNQaeq7hV83XQt5PcVBGBNPW6DvxELXWt0WuDaB1UQLqSqQuVz7DHs/WL1rPkZc+B3KO5Krjyalo2q2kRr2EZjUFIyrVB0sgrV1IFUYGYUIXEAa4aD3EG/t6DeGLXe13EZvTUMUZ2sg4bPAQU70FxggrilvVFX7hEX/ed1XodF+X5FB2Mcp3IqvXxfuvm1DgN1XQ7rfDUDFQTsdoLkPZ1u7G6HA1iTUDKTJkyvTNo3WkQFcQU8QDKbdiaMMaSSlcgRuVRKlPVVXWWngzFJ2qKB7jW7dQe6arRa1QM2uYLZoXSldEjbrICimg+jYgEn+mjFkCvBCNDuZpp8tUagqsulFkKqhYxG6BVNe1HCjYSS+iXslTR3y04i7WbuRGO9/SjeIfXhethF71KJRaDVlPgamdPXhfqoYkx74oIUm3XnE+BQq7O6oWwJ10pX/xbAWOWVbcwsQ4bCUnvDBAjSm1f2ucpL9Rc7EFLbMtyad0JCI80nyMngr5MVfc42XXbNu1btb3Vh82JbQe6DWXmrkj9vYIY6cjyqgbStq1JPfwNgQ8eQFzy4tOcBnSbkmhyUGWfD88YFg9FX2gv1WfmhVQ+LerPidM011Uj+HTCDKFwkWpsStUVz1VvzjDiHguHeDqXRnUqGMrwbUuKSZWeFWkXzQE1MVRAM2+nNRH0b4sV0MVohbb1jiguQBPDekN0LwUFigoRW49G7ALtJ/giUo/TlWjdCYgm4kSZ83HvP0kFCBBegFmxl3yap4H+Yw5g7bR5c28n7UA3/Kjg0TMvOJhnhSei/YqQa/BU1RfCRIFMAPAuTnbuClW3LAUnJ8a8b01uetkX+y9scJmGIUPqoKtyUOqxsRfzch/7l7tKyd8gYno8oHhf8yi8CBr8pYKyTHgr9XKTl7X9eQ83l9U80GzGflkIbkxezyINS+9z8eAblmEuTu0n7SP+bQWLCl0uRCoklF8N8FLBzu8g5Swu1M7b0Q2tOwHRQExowqAcu7KoSeHRGq1IFV03COkE5MDTyENFzgGUUYUafUlalIk7jzjwnIt7AbgKM27AgpY62QnCKbA474ukNqyDO0WBQs3uR9zVSv7tGZpUizXSsyLqPr0auorbmAs+20YvAqnAHXYxmexg0Ogo3GeCEKSbtSSf1tvj0knIHJob5JYGoganQPJ7pU0zTrJZIWaV4qo7hKJO9tVlxJVdn6PeGqr+Fhx3ck0t1e6fsICpmmMUiCqsgDQn6Jtxb5LWnYDQDtG0bbpzEIidVUF65Drk95Yj6WXCDQd0XM9/mENnVa8e7HtdEZZ86v1gTINxug+NAAAKa0lEQVS68/RQWIT6dWBXUKSs05Xyoo9xDEAxSSo+MudoViEOunrgRRPLVF1Rll9VwnMG5fca0onhkGI+xF3KOhGDmhRzSOJORGMAYmo7qu5A6yY2QAS48KcbnjSKFYhRqH2yiCw1gTkXsQMKTc0JMoBi5baqP4kmlQoNei1asCL5XWNl+F2f3MOxncTJoJWMUltiQ+o16pbWnYCgissL5lBU8FBTt+uAI9Gms4CQFSK9Lt3izNUSiFoI5HegFQADIt6Q8CnPqbpUe1EhU0WM8iOfg2GUlWdp+KgmA4WgYiyFqsUecXUt2y/1UphRKF4XwI6aTOSGTzEHxU6AGJ6uexvsRGCK+9lw3Qj1amIarrja3zacmYCp9lUn0gCsYRePAWR+SgZvAWleCT5HtQONuWkXNAXzPclqFSTl2yGNrLVaAe+l6cE8FFdyn16J1p2AANJ4AO+QBLVwU42i31frPPr2ubrWHMocANqBWo/uAyh58REPYHnVIPhy+x2SjUd1ETTMXUE1n8f0DQtIV6kUK79O7KaPbV4MAsRGWzLpCxCTsjhEk+2NZrGSlzY8CsFU4jxBpYdPzR57lgYFXL8IGiZ3AUKae0QNgqaOkgJzvLZ9rosCpG301PQgerlIDDdn//b5cN6HvJMFlwojZvgqTbjw0cWA7VDN1Y65dguRempUy1BTwsZc6DhUgN4uit1QjoPIlClTR1qfGoRgBUAB/ukqTEkMtKr0tMtVclqVb84XWZT0CHhK9qrco5Ja8wOqeqgrawXFyqX2LjNoz4lGYVefDQ7YWBG1vpmuKAtBY6Da2ScgJdvZ74p6NgWGPtAPvHtTweD508V3/7MAnG3KpiXDSwKkyt+abakMZXYpSEkXLxA2avlUhQeQHCOggB0QAT7dzFRDEUuhNjdzkgJxTCwCmG3GZ2u4crIPwsW/mZIPKLSFRUgMCQptQmMRCFrqKu7M70ArPqCYmo265N+qNVlSV7RqVt1qEetOQHikp08T/NLQ33kfX3bDR7sbiINVJxhVOqqQFQSAUdR0bvWumnpolhBhh6kbENMCrS6tebTaqcrfEopdltd5YDA8oO4KIUGVmHsWGEC2wRUmRJ+LQrTHAUMVYEuwDTbuACqbiodvfqX4buElAPWIbTRRnAaupgzPH1V3pG2vjf/gdnUF43qNhF0y9/LvxMMS/tbJZgWwjoUKQk4Mn8bO1Hya2p94gwoLTbnfTmi50LdWCGgZmkVKunhROGiwFcuoUHbmN+1LjkONO1EBczVadwJC4yDoilTkuolicpQrj4u5I4Boz+nAbqA1UKbf2PC9bf6vAPG4d6T/kxfIs2lPaqCOLVPGWUh9Mx6YagIbiJH4NMt0D4pIxveEm0eqwGA19VhwUM2H5ar3z0DPMNCYB2ZfL75bbBaH3faG++Z8dEECKE8e19PI2Y8WIFSwk56NZO+IKU9gk/2hCXV5D1dlFbLUIgCUiX/1oJ+6T/trxgPnPHAhlKELE0gDrubQKvjUtbjk2++otf1AAaL36kKi5VWAWszBarlav8UobDzGlWjdCYjF66/H0x/4wNta59mzZ3HDDTe8rXW+nbSi/A0BuP6tVXGt9x9w7fBY6/D9lfhbbgBUE8Brr73WVdl1lzBmJei2227rKrnGWlHm763Ttc7jWvGXvRiZMmXqSFlAZMqUqSNVH3744YfXmol3At16661rzcIVKfP31ula53Et+MsYRKZMmTpSNjEyZcrUkbKAaEMXLlzArl27MD4+jl27duHixYsdy166dAljY2N44IEHrin+/vSnP+GjH/0obrnlFmzfvh2/+tWvVpyv3/3ud/jQhz6Ebdu2tT3kqFar4Qtf+AK2bduGHTt2dO1qWy3+fvjDH+LDH/4wtm/fjomJCfz9739fVf664ZH061//Gs65lfds+Ewt9NBDD/lHHnnEe+/9I4884r/97W93LPuNb3zDf/GLX/Rf//rXV4u9rvh7+eWX/V//+lfvvfenT5/2mzdv9hcvXlwxnpaWlvzWrVv9iRMnfK1W89u3b/d/+ctfkjI//vGP/de+9jXvvfe//OUv/ec///kV4+fN8PfMM8/42dlZ7733k5OTq8pftzx67/2lS5f8xz72Mb9jxw5/9OjRFeUpaxBt6NChQ9i7dy8AYO/evXjqqafalnvhhRcwPT2Nu+++ezXZ64q/D37wgxgfHwcAvP/978fIyAjOnj27Yjw9//zz2LZtG7Zu3Yq+vj7s2bMHhw4d6sj3fffdh9///vfwqwSBdcPfpz71KQwNFbHmd9xxB06dOrUqvC2HRwDYv38/vvOd72BgoNvEcW+esoBoQ9PT0xgdHQUAbN68GdPT0y1lms0mHnzwQfzgBz9Ybfa64k/p+eefR71ex80337xiPJ0+fRo33nhjeT02NobTp093LNPT04ONGzfi/PnzK8bTcvlT+slPfoJPf/rTq8FaSd3w+OKLL+LkyZO49957V4WndRdq3S3dddddOHPmTMv3Bw4cSK6dc3BtTgyfnJzEPffcg7GxsWuSP9LU1BS+/OUv4+DBg6hU8nrQDT355JM4duwYnn322bVmJaFms4lvfvObeOKJJ1btmf+0AuLw4cMdf9u0aROmpqYwOjqKqakpjIyMtJQ5cuQInnvuOUxOTmJmZgb1eh3Dw8Ndn0C+0vwBBYB677334sCBA7jjjjveFr460ZYtW3Dy5Mny+tSpU9iyZUvbMmNjY1haWsIbb7yB669/ixs93kb+gKLfDxw4gGeffRb9/f0tv68kXY3Hy5cv4/jx4/jkJz8JADhz5gx2796N3/zmN7jttttWhqkVRTjeofStb30rAQEfeuihK5b/6U9/uqogZTf81Wo1v3PnTv+jH/1oVXhaXFz0N910k3/llVdKgO348eNJmcceeywBKT/3uc+tCm/d8vfiiy/6rVu3luDualM3PCp94hOfWHGQMguINnTu3Dm/c+dOv23bNj8xMeHPnz/vvff+6NGj/itf+UpL+dUWEN3w9/Of/9z39PT4j3zkI+XnpZdeWlG+fvvb3/rx8XG/detW//3vf9977/3+/fv9oUOHvPfez8/P+/vuu8/ffPPN/vbbb/cnTpxYUX6Wy9/ExIQfGRkp++szn/nMqvLXDY9KqyEgciRlpkyZOlJGrTJlytSRsoDIlClTR8oCIlOmTB0pC4hMmTJ1pCwgMmXK1JGygMiUKVNHygIiU6ZMHSkLiEwrRkePHsX27duxsLCA2dlZ3HLLLTh+/Phas5VpGZQDpTKtKH3ve9/DwsIC5ufnMTY2hu9+97trzVKmZVAWEJlWlOr1Om6//XYMDAzgD3/4A6pVe7ZUpmuZsomRaUXp/PnzmJmZweXLl7GwsLDW7GRaJmUNItOK0u7du7Fnzx68+uqrmJqawmOPPbbWLGVaBv3T5oPItPL0s5/9DL29vfjSl76ERqOBO++8E8888wx27ty51qxl6pKyBpEpU6aOlDGITJkydaQsIDJlytSRsoDIlClTR8oCIlOmTB0pC4hMmTJ1pCwgMmXK1JGygMiUKVNHygIiU6ZMHen/AcyggKs4JiGlAAAAAElFTkSuQmCC' style='max-width:100%; margin: auto; display: block; '/>
+<div id='140059226360800' style='display: table; margin: 0 auto;'><img src='data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAQUAAAD2CAYAAADf55KSAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4xLjEsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy8QZhcZAAAgAElEQVR4nOy9W6hl13X3+Z9773Opo5JkyY5sSWXHOOW4W4aQRBJ2mu7GuXzoCwkVQtuxaXAMclAIhqYDHcckxE82KBfyYAQJIgYJjJEdE1omDwI7EOfNomiH7nyEjpK2E1mxYkuRpSpVndvesx/W/K/5m2PNfaoSPqf8bZ0Bh7P32mvNNa/j8h9jjplyzlmndEqndEqFZje6Aqd0Sqf0/UWnTOGUTumUGjplCqd0SqfU0ClTOKVTOqWGTpnCKZ3SKTW0uNEV+K9NOylpD99T+eP3HK6pXIuU8P+k3/18LHd2jffkNd/jtVhGfHevjfFecv+M/ylci7QKv8U29erGZ3K4z30Z2xjLivVZV7+Tyj3puZPK4XMrfE/h87p+4BzrtZOf1/2u67h+Pfeue3bv9a/XCy+80P1t45jCnqT/XD6vVBfDdm/2lt+P8N3P7Eqa4/qy/Klcn5X/y/CsJ9FCw6TYwTO+x88s1S6gfUlHua13KvVelps82fz7Vhq+b4X6zvDd7SGtQruXkg7VTvwjhbqE98zKHyfRsaQraKPbyzJMZAYZ5S5LOce5lhEXmevVY7rs39475+H6LHxelfe7jCO1i8v9YFqoZbrrhAjr5Hd4vhyonUssZxWuLzv1ic+ybz2OfGb7rW9dU8MNZAozSfMywmv4gKTpoF0tFxaSdtIwcea4d6l20alci5PJHeoBPcJ3L1RPqH21AzqXtCoPmhnsSNqWlNGYyMS8UGe4xvpvaWAepuNcJ7vpUC0D8ESco0299pMRbrMd5XPUAlxP9udhr+wwQK4bFwgXghn0pD9xjxc/mQ/7ydfIOHp9Eq/3vrMOUm2/+zKr9oO/uz/NkPi7v6/Cdc+ryJQiY2TfXQsz2DimINVFt9QgeVNaP0ie1GQAlObCc7GjSR7kqGJyAvYWXNQcZqVynKhbqpL+SK0kOtZUCu9qqinwvUflj9pPbDO1gBmeIx2V39zfnsxzDQudNMP/rXBtoalEjN97E5mTPy5Y/65wfabad64HtYtYFsuJ/UjGFxkLtRupZdo9Yl0Xa66zzOsVeB5HCqxjTZkw6RRoPKVTOqWGNk5TmKiHaVBFV4W1du3QPL0W1XGStYsttSpZVFezBhNBuJc2ObUTl2vJ7992OuXuqErlniRahu82pw7Kiw411RSMf/TUXb97S1UKus0Rm9hSqw1EYNftpzZhSe02xfFguxSeieMWtR2aKdQIfa+vRUAxall8VzQ5UvidJtM6rCH2G8c8lkNNLeIVNCmEz6x3NC+uteg3jilIdbLZdOBkONZ0opOsXh5pvRrHQRoXXijrYE3diJB78pEBeFFFxhHfHZkPyQxhVHMDhnCIz+wHtsETep2pJFWmwrrONZgvLudA670cxiCIS/AdY13SwCjiOEaAze/3Ozg+/t3vY11y5x6Tx6i3uN2miDeRGfBdx7jHAiCaLXHR02yNC1+4TvP4SFNGGM2rk8yHjWMKtEVT0RJmGiaVNEjNY9UJt9IAwh1hJI7KiHPxLtRfIH7XUi1T2FJFfaVhcSzUdrhtUT+3qypxOAEsofnOaOdTGhjf4MK/qsqoiOQbq4gThxLfk9mT2IthW1PAMmnw9NyMdh/lek9Ezv1ut0GSjtLAyMb65PXP9KQyF9Ec9e3ZypH5WpPs3ZvDvb3fXBdqq9KU6bkv/fu2pt4Gjqff6wXN93GR+/NJzHyhaX+SNo4pSGFylwU/SrdcOq3MFKv1dP0tNUzKRjqkaWdRwvUmoBenVKXNcbinp5bOyqLwNVKcxPYOsM3bat1d+yqLE32wlQb3bUTZuTjssViFGRRdlAR2l6U+t5RnD7N0JUlX4FJdqZ38ZkBkhKvUumF7poJUx4SLoKeV+B5K4p72Z4aQ8OO8PEAPzkxVkKzUAqtRq/C1HoDJOvRc3L3nogkU7+G88xzlPdQkerRxTGGlOpnmqb1uWkraLvfMinlhTcL+eqmV/ClXibko6my0cVfwGuxoGHAyjZ7E4qRwnMAih7qDQc2gSkt1ALk4PUl9z1W1bfTiP1CNo/AEZT/Zdel2Xinl8p1sgyXYgSp+sVPqewQmEaVo/BzJmhq9BFEtjuq01F+EkVHQE0Qa40A0CBBqZ3Hx2iTk+3xPrAN/p1my0MDMD9WaGb26sr5X1Wo2uXOvQl1ecy7JyP2POotXwrXc+oa9CKLtTynqRRoHnUEu0TSwTelgEqlVzaU60Req0nmWgqpYpLx/t8uwwRDKf4OcXuxkNLk86/cTz5CGhc3PLpd95TbHOIYlmMCWpN1UA5FyqgFaJjMw+ucXpe1+73FuJatxH7YnMt3e5I+xJR5bMoeUWsYSGcYKf+6DKKkPw7VoltgFTIYqDYyBpmFsl00TgpBxHq7UzsOkKaN5TWkKUXXiIpfa+ASpagXL8L0XqGPqdfJSgzYxcurUDl6MTZAqCMffZmoXZMpTvOA4LCqbHKm8LEYiHqtoCcEDQ0xhu3zOeMYA2jp/fmzbdrl/N9VnbinfX1/efSVLryTp5VxNCj9vrYUBX26fgA+ZCLAxniICiSROeDODlWo/2EyMXh0uvGWeMjHOsejJ8LWo5vdMAwsT0hF+cx9fRXuoAXnM2IcGbU/SxkincQqndEqn1NDGaQpSaxqY68UIO94bVXhz+Ghv0qcfXZnycwENi/Y2pW30MVOroc96Eb77Xa6vNOAQlCh0ky1CvYhmux07quq6VDUURmLONYCTNieimj6XdFOSbk3SbaWsNybpB+bSmXLTd5fSPy/DfoHct6Wjb73xLKntJ0pd9iffEzGFxp0atCjSUbhmrSFGuBK0jVqVieMXy3R71qn2NHV8j0FDagox/sHX12EtkTaSKUSaAIJqMQT+d8dz0KIrbksVcONijUhy7Hz75dcFtFBFpQ88urt4n1VDehskNTtFvUEpujm3QhsTXtRTvd3WuLnKav9NSXpTku6aSbeXl925kF6/K+0WH+V3/1U62pf+dVnrOE/VdSlJl9Qy8dH3Di9GzysTkfgdDUAn+3KZK4PcLu/cAkCcw3+7ZTmHdtMApNIk7QVN+Tdfo61vhtQTONHDxHm3neo+HbfhuPN8L5aG1Btf08YxhegjTqqorlTsa7XMIKLukYvzujR0tCdKdDka4c+pnSg7mg6OJw/jB0wEI6P9yu9J0mX1tQlKTkZfbqn1Vkitl8FkxhbbSA1qS8PCkwbt4I4kvXEm3V4qc2YmLZfS4eXh+/5KerUsKLo8Z6j4bm6ZIUHRESyFJ8VtdXu8I3YELNEmakMr1c1vUWqPGIOm47aSdJzqWJuO8XsMROJ+COH3CDT2NJ4xjiUVIDINfehyo5Dg/OaYUUNc5+GQNpApSFMkOecqpaUpWksXkxkCd+71AKGZavCOyv1bGtyV47vVTihLhwhqehCsklKCx3e7jAV+t+bCiRH90hHgcn+wLlxAjqlwW/ifLtu9VCX+rUk6U9x3r5QXvrCs5UnSd1fSt1fSK7md/A7ekYY+nOVBw3F7VqV+XqzL1FeJ14G7fk8MtLK5wN2t9MKYqJZzcZE4Zq4zedhcrQbUk9ZxzpBZMeqUY0IvVtRYaaKeBMCSbijQ+NRTT+kd73iHzp8/r4cffnjtfV/4wheUUtLFixevq1z6jY3U0163TeaFe4xnoltLmkpQdzAnmFW4nKsE2dGwYPZUuT33HFBaeDLerGHi889aht2i8/C7VFVYYyRXNLgk98M7Y0iupRpdm7RbrYGMCysNZsJNhQF4q/lOceNdzdKLK+m55fD39aX0d8fS/7sc/v5pJb1YFjz/uFi2NTCbndJ2MjRHhXpLub8blc+41lu01gq9UNxvx2q1MZM1OffjkQbT4TBPtSvOKRMldzQZ4uIlJtFbwPuqkanzVLWmKDSy2veu03zX0Q3TFJbLpT7ykY/oS1/6ks6dO6f7779fFy5c0D333NPcd+nSJX3qU5/Su971rusql2CU1AdtKK2twkcuT9WPEkW4HtU0MgknaYkJSBTqFzdV+X2kheqi8aKlm9AScJ3LyeVaOyCDWif13C8L1XbF6MGFWnv7ah5csXklvYp3SNJqVZ+N5pI1GWMT1AakAQc4VrtAfL/7ypoOzR3/TrBtS61mZubH/qSqva+a8GUV7qGWwvlCADS6BjnP6GruYUg239y/+7maRDmUw3Ijo3Ib2X8nmQ83TFN4+umndf78eb3tbW/T9va2PvCBD+jJJ5+c3Pc7v/M7+uhHP6rd3QhvndIpndL3gm4YU3juuef05je/efx+7tw5Pffcc809X/va1/Tss8/q53/+508s69FHH9V9992n++67bwwI8p9UVC1Vyb2tFmib47tVad9rrpxQprlyBKcYDLPCNUp3vosh0VaTj1UleC6fqbruq9q3R6p7GmbhGUoLJ2nxe0bbXVMX2DH+rFq7/scapLb//H63d1/SpTyYB5fK3wtZeikPmsOrGkwFawZW5ylxLaW38LvNhGhqcc+E+/Om8LeHe7ZVzQ7PAfcJx9btOlCrJdAsnWnQTg7Ds9GmNxFwtOnIPqCJ4b/D8t9m4FUNoLLNrUOU5Tp4TGM96O68lilxw8yH3ml1Cc701WqlX//1X9djjz12zbIeeughPfTQQ5Kk21OaqGhStb/mGmxC37OtocMJsHkhxMVPNd9YBPcB2CshDTbnVqpgGVXYqI6v8N1q8mW0L+MZq4PWm2K0nTRgGqvUpkejp4EmU3x3jD3YwXNbqTUXzPj2w1CaUUglCjFVk2FZ+n4L3pm4IcqM0S5K13UP/UDzz/9TqS9jDo5ymwKNmAqZeM80lNTsFyHuQZOz57WJY0Kh4nuiSu/6cf7S3Wig8lB1XPw8syrRvIjmiOtyEt0wpnDu3Dk9++yz4/dvfvObuuuuu8bvly5d0t/8zd/oPe95jyTp+eef14ULF/TFL35R991339pybWNLhVumNsZfGjrHC+aqWowhMgChPIXfuNDMEPi8JbzvjQlIvNi5GHyN9rakcZPXUoO7089wwo/tSy2eYQ0kvmfeuca2WquwR8USm3bykbBRDJ/dn7up9WRQgxKuRe9OXGjW4iL2wXaPm9DQVz03oKkHKnsRcgek8aKoGcbYhN7v0SVJrYhp0cw0omtcattsoUCMiW3sLfh1gW/r6IYxhfvvv1/PPPOMvv71r+vuu+/WE088oc9+9rPj77feemuTgvo973mP/uAP/uBEhiC1kzjniuq6sz0x3FExMpGTtxdXILWuRboGozspgj5SO8AepLgZixNupak/fD/XABwu0B6DcD221DIaSkuS6+RAGcZXEB2XppGNvfKiey+X2b/KNWbg0IsYEt7ahL+v8uDh4KJhDgx7ECKzIegXF55NLrbJEnyMoSjv4bj1vFG8zv6KgF50kxK8tFnEhR3fG8HH3vyi69V5QNjW79vMS4vFQo888ogeeOABLZdLPfjgg3rnO9+pj3/847rvvvt04cKFf1e57lhpmIBRMjm3QvQs8Ltt2si1mdAkSi1rHww0kdoJ2ZMWET61eUHNIErHBWaN20sGRE1Ami5Mq54c/MgcF6m6KblFuhe5R83M/cYYCdqxjh1ZSk2ehmPVRe4AHbbb37lg1sWaRMbA+q7T+iKxvrM0mJxc/CyLi5QUmTO/0yRwGdwh6d+aPij3GTdzORyXODcjDtarV6S0aUfRvz4l/Rx6wItwzB6UW83Bi320edUfsChh4oAZvDIz2NXUtuvF9lsl93sMInmBZA0LNGZAdl0MnHFi+h7mV2CgFYlMbKY2v0IMlFKp34gXqNVQiF0YS1mncdFWNmjZAKBpurhZF7oA/bvrFK9RK6Id7zowZPkIf8J9K1WNxvOBC+1Q0/oeht/5TJxjdmHHecXP3GJOTSEyhaixxv0RK0mv3Hvv2rifjYto5EQxci3VCbKdWk66zK1qzcFkBF8cLIN01AS2U+1QB9MswzOU4F7IfLeZj8GymKvAzxMEtcckLs51NrDVS9ZvP0tnIZ1dBrNAedNS1Bbct56c9H4QyJQqIGsQUKqejiglWd8YcxA1tZj+zkQzJQKuow8/tWApzUJmymKbyZRWmuJLxmfi+Me+67VnHb5ij0S8JzJCzg/PXQq1k2IUXK9TOqVTOqWRNk5TkConjJt+pOr2WYXv1CjsdovodJQY3u8gTd/j1GoRu6DGETPrjCBjrkAX7XS/p+c6pBQ1SEgpNJM0C4g6ASl+lio+MlOVtE7EwnR3q9xuNvPxZ9QCtqTmhKvobXAfjfVP7dj1MAJ6cHz9OFyTBtOL4xjt+nGuGNTMbSZuz4W5KpYTk71YA6C3gGaj390zpSJxjtFlKrWJeKN2Gecq14DrED1a62gjmQIXjAfIgJ7tw4gYm+imozuRYcxWxc7iuUWamhe0KRm4RNdQBMsW5WEOMsE+qYYXu9yVhn0IfDfVepsWx7iHoJ6JE/BKeWa3mBXS8H9LNTfCTNJ38xCcJEmX83TC5dIPZiTGDhZpfYg12+l6SS2jjja9VX6OrX320c3s/1fzNJW/TTF6hOI4zaQmP8UsT+dRNC+jy5vvkyrmwPpvqwothc8RQ6HpwbH3Ncd+8Jl1tJFMwRNwlqbBHHO1h6moSDtLCtuyxhqkGusQbT5KjLhwS9HN57hgIvNxHXfVMgUyqlTqT02C4JvLo7Q2FjAykjQsyuNcpZ+ZixOuGmE/SK0n5KzqVmnXLQZGOfeBpElWamsdztno3xjUZfA1RlpykcXNS6xDDBqKRG0hovXR/bqvyizHsYa7cnwJNCYz/rlq2jR/j1oPdzf6+w5+j3PI190GM0dqpFET9jNRi1hHG8cUktQcMGswL06aRu1PrbpllTlKFjKApKnfnOVmVcnl7+bWXMRxAA0S0Z0Y3YusE7fNcrIf51bd9PZqqTILJiBxP8VoxVUeUrS7zKuSDsrL7fo0IxnLyO2inUlNevRowploLrAP4nN+V1ar6eyoBRvjYjYY6X4hk46I/z6+H2V1M4NHT5Dr4sSvNEUcs8Cxju13+2hy0Czh/575JWliKri8VbjvJNo4pkByJ0c7jrEB7sRoGsQJmVQR6nmqaiknBietpQLVx97ijSaHn49H2JtG9dALMWGhoOBZqmnsD9VO8nGh5NbscEp313eU4BBD/B5ReDOwVaqaQPTpWzL3pBW1tR24Ye02ZNCV6+dxO6OpJkY8wO+W1GTC7gU80UzxGDtc2xQ9HwpM47BjSvEZa3MRmyDuYVyKY2JGF7EqU/R4uD3RE3YSbRxTWKmqu4Kdvw5Y5MKVah79HtDo/1Zts6aLlpPWkslE9V6d331C1J7qwOykNk29B7iRGrl+Nq3ydBJQynryERCkCu/75qrS7jgP9WE53lRkGiV3aexRrhob6yBNAVz33Y5qJJ7f69+pITG24UDTsfA4k/FHFzAlqZ85UosHpTKPjgLT5Viv1DJC/rmtjCXJ6guHqHm6PD/TW9hkfDY5qClEjfRatHFMQaogkBd8BNOy6n5/LjB/j+i4n6Md73vHd6qNHByxifK9l7vAg0dvhJ+33W5pR6YQzYRFYRyUvvG+aJ/yuumwcz0yzQMuDNerFLynykisjdnEcnmW7ox/sIeA74nqcVSBzZBijgqacI4QjJ4AkqU1U/2T2Xh+UKOw1seAuLjgGbvBcjgmvXTzbEt8pmcGMD6F1ItjIIM6iU7jFE7plE6poY3UFJaQQBN7UtWXLrVmglRVLXJuexaiD3mGa1tq7b/oY2b5tJUZt2ApFyXmVlJz0AsPi5lLwwYjtVF4USpGUyeCZEaxaSpda3LYDBk9FqnmLKBnJfrnRy0KmldMbMu9BpbK1JjsLaFt7T5gGziOx6XcCOxGDYn1teazwn1JbUZlawasS3QvRnDQZRIA5/OufzTn+LvviWZF1LIiwMjdmT3aOKZA74NUwzzZURwId1DC/V7syzBK9JFL7QSMm46i2i1VJuC6GEMgvuEYBIY105PgQaZdb7ODNmhUR6M9HpmE76HZ4rLoguWENCNhGW6HKbpp6aocF3hB673QImgr1b6OQCOZsPuNzJHeiOiSGz0saoUEy7VZE493Zxt7WIWJJiOfiedYxLnjurAfstYHQbFuPS8DzZ8ekE7aSKZAAMuLlZOJqK8nAAdntPXLBF7migT7nnlqy5mpjQVwrL5Rf7oomfFpV5UpLNL0ePdVnrqcCCRxInICRmCJmsQYX4AVzYAZaUDzV6onVqvcT7CNiWuE8nuTdqx/ce/NUgUojU1wMcecjFJfQrIvnb2Km9sOVLELZ64asQBNPRDEe1TuH13I5WLO/bpED1b0arA9/syFGjGFntfA8ztqt+twE87r1zTQGAc4cuEd1cXaC/k8ksYDTaW6+LkAiairlEdTwGcPeBF5cONEWam6unZVgUWXbb96BNg4KVyur3lRrdtR6HLILKMLdV5MFi+28TkwBp/XwGCeqBlYCxilc64aRwZTmbmiGiqb1R5smzWVtmwXtT1KWoZh0y1bXtOEeY9tVKuB0C3JZ6mtkQl4PFinnueA4CqZBO+LAiuH5/hOf++dEBVNopNo45hCD2Ent7e05mKIC8aTNsYcRIoqpN8lSYtQaNLU1emJsgWbXGptZy8IYhexPnFiWEOi9Oh5SiLiz3gCqvfRlUqbfCa4DNO0n2iySBpzXFAyRq1mPLEpuEv92XWlycaJTObYaF2qnoTYjshkTZ4fUeviTtDYZjMRmpc9lyDH0Qy15yGhlusxipoBtYzYHmNQvTiZHm0cU+AActDiIRzrBnSpYhpkqKapHVCqye7gV3Orkkcwh4PNrdkMwKGvnZJgV1PuT9NmK7V5J62VUK2PTGSWWiZAicg6RzyGAVI2L7gt2lqU67tTXKYM3bU05P6CyLT4n9LP5cTITpsAZLqO4qS9TQ0q437CRz18hu+KeFHUAK0hbIdrvnddG32f2xpzNPQo4lzWqMgk/q2LfOOYgtQOgDvJ17w/fl0kYVJZRGC17mB31kGuUpE29pHURBpyUrg+0nSgIzBHqWI/f1TLR192iGdwebS3x4mX2vfthHsoRc1cLRWloa2UkG66nznMgyZA5rJSMUMCgCnV/nSZnODHgflIfSlKchlE/KNHZVstg41MYHw/non7LDyvaLqQrM1tYw4d5SnAR3DSjCTiVKwX8S5qOS7rJPKGK6mvTZOuxYhO6ZRO6TVGG6cpUHU1p6VmEEEhaxFnyvdjVVxglAy5VXeTBgSaHonIueMmGuF3Siq6H3v2q6Qme9A6jYEbuJxZetyjkFq1X8K5B6Xcw9za7nblLVXjEAz+rfMK7GvYHzJHPXdTAUrLQ1upBS7dbr7H7zJF+9ztjuCvMQb3rz0YUdrSjez6e8zHqMHcfp+n1rsQ5xTB37mmmqQxEFLPQ0FTl0Cly7AJZKKWyzJYrndeRlxmHW0cUzD4JVV7qucaIgDGhB7OLei8gS6T6i3VOqpvnMgLlQWS2mucoC4zmif+TdJk67HbEP3bnECjW80utPBeMjIvRKulzNDshepJZDW/51v3e6T2Xd6jME7IPLzjTGCYPpvR72Ewk03AngclAoR2O0p1E1U8r8EUF9TYjjw1Jw7Dy7njcZ3Pn4svxopIhZGgARY0Lq+X99HvG01ZrY93cN17LuqTaOOYwkqVO2+lytHX+WuX+JNqB/M8A9udoxag6QR1WaQsNenZ4+LcSsMGLNrWJroGT0KLl5puSjLo5gnC7busy4GqhjQmLIWElOopRL7GfQETjUYtk5KKaze1MRJSu8i20/BnBkU73uW6fdG+57mUceK7vlxkBBrNXOmhMEMgkBvteDNzYkY99+IyDFyPATHOYpnafjEjjAAyGWHM4RnjIQg6v2aZAj0LNg2ouo0bcsr3Vfi+rzqY7Hwu2J7P2RQtBnJ3D+i4AapoEqP/vKjeN8G15wUSXU8sf52aaVpomhnK9/C+3hkFVMcj4Oe+JdLtv7hATEe4x5MvSuExLiDUjYzOC9nvNkM5VNumWP9ovjEmwUSgM6n2f9QO6Q6N7czFKzR6R/L6BeuyruapxtmLmYhxDFzwMdgph9+uhzaOKZCWeTjS3DECJm5ZNidmXr6UpHmQ8JYyUqt10KSInbnU1C21Upuhx4i9y93W8G6nivdCGN2WuXWJzVJVt3kwTMQ7dlTLdBQf044d5bZfXFf2W1wUUfOJtrbW3OfIT2oVRPyldjz47gbzANZCb4mpFzBGLeQYz4xCgv5JtWMePQV0G6dUtcKV2uhHaWDKxqb8zMoVV3s2JCniJmwrad2CN9OIJsZJ2ufGMYVGK0htR0jTCMEDtQDQiElgkB0aSzU6mhRRCpQimkUWXWTRZz0v72FCWOMQVOtp7mwVbYNnT8Y2GwQzPnGg4ZljXIv19wQlHsB2kWhmxUi7lYrUBeNTeNeYnAXPRFPADMx18VkN3ijG/AujiaIp0+J/M4SMxZpC4+I+CLZzjIcoWthRqr+bcfOkqV5oKZkcx9XtiN9dFj/TZW0mcFI516KNYwpSm/fAcQlUv5dqUWEeMJtSNR84gZdqd8kZJabnYF/toohqtDs7SosmSUqIRumdZcABdsCTASU/SkbiMinpRtxF9X9WTe7KhULiwrcUpj0bA318z7jgId1j+WS6LMtg7FJq8kWyT9lHZIrUDLbVgo5uZ/M8tDQJyV9z23+MQ4gh4j38apTkwCq4WGlekqn1KJZLEDbGOvS0ig5vmpR/Sqd0Sqc00sZpCtGmtUo2+q4hgaVW6klVclD17KHa5sZ+bhG++/ccnqE7KeOPtFK1qS05GHtBnzgHkDsrHasgDar2MrXhv64r+4rnSywLrtJL2R5dn9FMYQSpgVw2cpmhTqtqBQexIyCJrXXR2yC10nSGe/0crYHj8PtSBUNAgTY5CSI63mFE+lPdvCbV7OCU+hFfcZwLx56Yjc1WgtjGhqLkXmemmSKYyjGTWo9MjzaOKUhhQuYpwkxVz90dMu0AACAASURBVB0WffEx8y4ZA8+OcGcfalBP44KJSLhxA6mCkDGwKqmmM/O7Y33p53e8wUk+eKPhLsPvH7GJ8H+v/MaELm4Dbf/oR+fZmMLvzRkaqX3OC2QG1br5X55hrsqIOzg1W9IALvvdSdVUivgIsaQlGBTLNWPxgbvSMDZ7aJsXbwRHo3nUMCzjEHn6m8kCgHXx+JN/0uTobXqKOA7N2h5tJFOwi4+dwU7ggvdnRnvFyRMzGfnZeJAIEf+5pqcI+1niEMIzlt7R1uRCdE6+mCgm1jmeZk3Qlfs/6B3hadbK5Sj64IVhvc0UaEPHeISk9kCWHh3nqTSTKiNZqgKKnNj02XPh+N1j8hqI44Vahus6cpcrx5FlujyfuzHGSuTpfg8/Fxk1bf1j1XiI6Jblu+P86OEEETz1MxHTcTkn0UYyhZOIQUpSOeFZfabAXXxU4UnMmiS16mAvLoDP8H5Sg2yrPV8igqB7rhfER881xwNvTEtNMy3RNbdXQEEvyHi6ltVqf99VdX+O705Tc05ScxBNDr+5DVSjIzLfi4fwfTYRY3udxIZtvVL+j65DTSM7dzVleIx4db228d3vcIJggtQmu6RJMXI1xjJYo+A8jsF3LNLaUo+RrKONYwo9ji21HcXQV/uHOcDjIScoh4zDNjM9EpZAzcTBey3doxbQ1D21ko7ECMfoe7fkswpsNZt4B112q4IxbKmeZbHUgLqT2ZxJw5Zwz+T9Yoq5zUb3aU6YoWXcQ01hoTZlvFS3fnPc4njR7en6KtzH1Pt+juS602Qys3cbkto55L0pc1WT7Ti35dCEkWrWLWoyDpoj9dyGSZW5OKiup0Rs4R7WwfXvBTCRmb/mzAeqt+7oyEnpH3YyVKkeE8YBvKrW/uaC8wB6ofQ2+/i/bVX6yxeplVJW6T3I+xqkyai6pnYh2ubnoHsCUiqN8QKq/v0DtHuRhog619+HsWwn6SwXrzAhO7N1Lo25GqTpIjPjiC7E3YTFnFsVWHgmmjD+v1DfXOPYW7r7Hh4J14yJpqnluFC2EsBSVUbOY/lSKYzxAxPAGv1nHCniGb0YEc5FhjH7PdcKeLqW+XBDXZJPPfWU3vGOd+j8+fN6+OGHJ7//4R/+oe655x79yI/8iH76p39a//iP/3gDanlKp/TaohumKSyXS33kIx/Rl770JZ07d07333+/Lly4oHvuuWe858d+7Md08eJF7e3t6Y/+6I/00Y9+VJ/73OeuWXa0v+NvRIr9mcepWzUkl6br67jz2VKeqvRKUO1VvRy0PRNs/blqqPG4P0KtG/Oo3H8UfidQtygAIcN5XSc+I7Xp47ZVo/JYYFM/9OlRardSWwtgXRwURc0smgcOaBqB16KlXIEG5ShUSjuqwO57BitFFdmp/XugMTUOahfWwpiUN6sEOAHDWagGM43uzCTNcltf90vMF0ktL+JM0VQibmAQnLgM+zv2yfXQDWMKTz/9tM6fP6+3ve1tkqQPfOADevLJJxum8JM/+ZPj53e/+936zGc+c11lN5l1Uhudd6zBHDAAZBWavuuotl0t90TTgLTQwDh8yvBZtWqY1VuCjNsaFhzzR5o4KaVwNkFuATbariplMvOyXWZxYxDjCbwQDHztpwJOSk0WqjOpLg5PSC9eZmB2f47MFiaI7WcuyJWmm9bIPF0mF4/C91m4doWcRxVLokpt04Zjm9Xa7DZDF2gDAVbiGP7u+AbHQThqlXjGEhhOs4EKhfWiPsnYIpMjg5AqU4sLfY2zQ+rc+x9Gzz33nN785jeP38+dO6evfvWra+//9Kc/rZ/92Z/t/vboo4/q0UcfldTmDDwuDIHA4oGG786bELUCfr6KZyTpEt7pQ0+2cO8Z1cnqoBNPNoKDtD05mePCIMUQZl43YxgZSJlgXlSXNI2zkNpyjFIzbXsu7bB2sJNaRuL6+D3UTDzpJgszAIp+VzwEh8xoqWFRxTiAGCRliU5fffQixedj7Ij3mvhdXY9TrvEWUtVIx/M/VRkbtVXXbx2NGg60tehK93/OV/62zksWcZ3vS6aQ87RaKe5GKfSZz3xGFy9e1Fe+8pXu7w899JAeeughSdIPhDLM5RmcFKMVI6e1W5ImBunm8j9OUg64B9OMxebFTWoXYwTUIhAXg4oM5I335yFYhwj6Mlewzu9mG2OsvK9tCWdA4n5GSu7QdMntaVuerN6sJLXeHLfD7xqZZKpnNkgts/B/Zw9in9Ml6dgLoVzuhOV/3jdTq9EZeKY56YXt3ayHKppgrvXLapmtzYAxf6Wmav4y1w1Y8fxT30MyY6fLOa6YnhvTDIHg5EnuyRvGFM6dO6dnn312/P7Nb35Td9111+S+L3/5y/rkJz+pr3zlK9rZOUmBrzRKxFzdWWM2HoUFFP4fq+44jMzAEpET0599UjKJG628eWpX08npunGh8KAUqdr1E1saSD9PWOLAJ7UuMS42ng1Bv36SxjRuVNV5XL37MrrWmEQ2TmwzQYZhb2noW/eLGSkl26LES7Au7IeEe+O7433RHKEL1ddNy1wZziWbDypxHCgzC2nrEmImUJdGIy1MO4cxIx6g8MwK3+McMnHx+3ebENfrfbhhTOH+++/XM888o69//eu6++679cQTT+izn/1sc8/XvvY1/eqv/qqeeuop3XHHHddVbla1ix1HwEy25LbCtTh5ezvUekyCKcevqpXoPdOAg+iISO6enOFZ01xVWjVbcdUu8FsNDJay6GY96LjHIh0BIdzXYDZwAnmiUwpF6Z1VNJlSX4c9x7T2DBHfkXQ2aD/UQPxummteIFwc0bSKi0FqFz8XG/uGUv+4c7/NmSup1t9tk2qeylgfRqHGNGpSFRzsX9aXoG3ccRvdtzSrzBh68Ts9umFMYbFY6JFHHtEDDzyg5XKpBx98UO985zv18Y9/XPfdd58uXLig3/iN39Dly5f1vve9T5L0lre8RV/84hdPLJfBNcwpuC57kBcPY/N7FNO1S1MmwSQlNhdM9nVH2zlKKQ8gVVyaDEfh96UGLONsqgvLi9f2/EsF3ad5Ydubk+lQtTI5tf5vv6u3yHjc20pqTmVyfSIwKNWIxqWky7mi9wZJI1jpICfhne67XqCPFwfHnmCqNKjtTGrq+y3BPT4xGIjH0fH8UdfT4J6v7ZY/2v4x1R21Bb+bi7mn4RLw5HXW1cxntuaeSCn3jPv/hun2lPQ/l89mCvQK2AV5OXwnU7is9aYD6VAhHh7lnCm/nS3f9yTdrgFT4NmRPMlppap9OHdiZAq+RqZxVtdmCld0MlPwZIx164Vqr5O8Y9qyDlPo2bgOsd4r7zVTOC51j0xBmuZxjEyhB7JdD1MwzdWm5IuuULbZ1xw0dT1MwWD11Xz9TIHtiNmZYl2i98GMnUzhSNLq3nt18eJF9WgjIxpNVgN7dhnVbqYy600qkyfnNv57Ql1SBSDXPWOJMw5qUdejW42MYq4BSOREoSdhR4PZcNdMunlW73lpVe+5WXXTkW84UruzcuKKzYPdHG13RlOyT01HuVVf4+Yil0HMw0yZIdeU8N4pOFc1n45LHTlejuKMgC+Bu5ifUVk6wBgwtJ1EUzBK2rgl2xukGi9N6ATPA4KhK7UMqBeKTC8U6xn3rhyG343j8Nl1tHFMgapetC/5P5oPpHVaQlz0dFHerDaWIcaX267mtR0NEolagCfXGLtQJDYBQdbvtiS9aSbdiYJfKQzBWsqZVAOApGE/QyqFTXIYFMrSmJfBtJVabcjSNLrZmpiK8H8RPpuOVYFSV8mag21+agJZA8jq+AcyKroknfDVtAyekXm4xlyLUh+9t0mxje9ug+sSNbFZHlzkEeSbd54d66pWgPWwINaPdSOmELWH6PGKtJFMgcEpln7rgBhpmqgkuhwjk7DZQJPCDIG5FfmOVfiT6gDbDWhpxIlznKXDBElQUHhubrH09gL/l9VgMphB7RXT4nKwx7kPYJ2dSZ+2AcCo0lJqRRPD4CkXTi8aUaGcuWrw1dnUekqkOvmZgyFKQo8fIxHj4la51uyoTNONV36Hy+Puz7iw6ZJlCnaCyj4kx+Uf5qlp4Oc4nz2/qU1Qi7GmRKbgZ9cBmJE2jilIU65ov7g0dAyl3bYq3iANtvyxWgkZtQB7NJjzb1vtZqHjUhZ3TdpedP1oIqg8Gz0UC7i3JE3OZZhJeiVLR8sqab+dpRfQCbfmgTFw4ixLWYzf4MYfAoNxgUemFkFcUs8t6HfFKMfdNeKLgVl08c1VGfNeASeJnUgleA3lUto6lmA7tQAzhYZBxWO1Ycxc4N5uPW6iSohhKM9sh2c8H5Z4hid9sx6uvhd2D8c5g2sJfcB+Y/e+5phCJNp3c03NBanfETvhs58zk+gBjbG8iBdwwhlcY6RjBJuO8qDSUjpTelzNlTE4SvPl3GIIL5cFQ+nnyRUZ01jvVLUWMyIzS7YpMgKXF00KYiJSq4EktenmfT+3szvKMLrVxv+5Sl6q27MUXL6prfOO2hwLUrvb0qZLdJGSgXpcKWiMIXBBE9A2Q2Dq/l6SXgoEJ4AheYyYvi8CjT3G/H0ZvPS9Iqqm7CB3DAOETJT4x7hvnZvyUnnGzIFESUsGYPWR4GRSDdyRWiwhLp4Y0GI6VEXTOeEITnrCukyr/PNiipi4DyOe0ERaF6prGz6rlUpUd93/UQLGvIERvHT9reYvNQCTZByOVPX42qsx5qpUuwfE3pVdPLOb2noc5mqGUtOiech+dXuiGUCTws+Q8fXiITwnRwGh6v6kCUTzTOE7vRrXSxvHFKT2KDQucmno4B3VKMJoFzYI/BoilsDgpejamuHatobJd0bVPx9NBakyCpZDRD0CppaelDI2QziJyby8yMhADSKSKewHdZY2uDTFSLwgaWIoPGOGMVfthzhpPeldhjWAhSoIaJs+ek8YiHRGA8hqM2VfbXsc1s13O8jL7tLtwjjJbNwXxGP21UbNHue2fu5vYgHRTDUzYZuk1pOQ1Ybpu0yONSNK/QwZ9bUiGq/1+ymd0im9xmjjNIWZqgRyrHxUZ/dV49YjxhCBHl+jzXhW1QbmLsilqhbhjL/WWs5oup9Barm61dmZKkAV/c+mZmNQAB9XGsC1xraWmvT2ljjuF3ok/AxDk03R8xCvRTWVkXf+3YDbSW6xldRkc7abb6Q8vT8ppF4vL6AEX4Zn/J/p+ZJqwlpHIfb2FFCSc/u9D6mlthNNCiYPdhttTtALE3dErvA8iRokPXBsa/TyrKONYwqeGNIA9hxJTWpwq/HseKlViaNp4WeJ8DqHP80OYgg7GpiHn7lJNfiGyH5UKc0QdsI1vrcJ2Mmtyuz6HgUbNrpgY5KPK7ktO34W3sFIPqq7Bu14j1XdHtDo57yLkyrwrjTmIoh5IVynGF0Z3cAHuXqKxjbluiMxq/aDQVqr+dxqL7UL0mMWGZ2/M13bOlOU5pTUZ1Yx3sbtXYZ7CEwTaPUznmeRQa+jjWMKRNSlYjMmNVmQ46GvPHDjSJWpcLEuw3NeEByAM6oLx5rCLeX7TppunNlS67Zcqdr2CfdGv34M1Y02eGQ2XrgE9iJK7bYfdp6JzJH1YH/6vXzGUraXrWoFTkFPhvGQsS9TBeqoybBNZOqu5xW1+RU8B+b4fYy8xPwwCCtVprHE8/YGxfr6vb28BybiEDG4zguYizcebLzsPMvPERS3e5Ig9msueImTgoEdznS8zG1+AWfedSd5QvcGzYs6ahcuxwCfNCz2XcGPHuokIWgJq9WTgguRUigi3rzX6rL93QRXnaTUZOm2LsLOE4fBVNG15TgB182ZpGIEYZzA3DTm+jpLtdQuVqmYBGnqbaAHg+q476Fnxu9eSuOJ4mZgURWf4zmeHj22I2hhdnOO2lGezh+Xy3GlScH/6+I/yBB6c5Dl0FRgH/mZk7wRG8kUXi0jti2NUogL0QtNqloC1X6pVdEjt/dioV3sBeKFeFb10BCV+3fxrNTv/OOsSdhzdCdGycDcBJLGrcv7eIaTNKrBLiejbkx6QsyjCQxCHaWSk1DtRI0Mtre3xKcv8Z6VWs1qR4M5sQ+J7jZI1SSiNuF7mZK+idBUX5Ums5nnaWyEidrlTFWToLbKmI5rYShSi+XEXBX+7STvju+Lv3GOXMu7sHFMIaqY+3lYrHOMCFNk93zm0U7ruaPsux53FaoNfd5Six9YAzGuINWAm9SZmbQRuRidzIVbqT3YVKV7AVokTzhiANQu3Lal2t2X8eg2glpHueIAbAcvmdlQq0pqGR+DuKTBrThXMTfKTa/mNhiIAVkE97jwKYVNHvsIIlLS2kxpAOKADfVMq8gIYjxB75meS5KbtOJvPYYVTYjIiK8Vt7BxTIED7NDOrJp00+YEVWsivn4+Tq4epycI6K3SDoV1VNwYFIP7m6Pnw7sn6rdav7kjK7dRhieLJ4+j42KwTDyjIn7uTYbd1PZVTpoc394EOhWPzyx0FkFKM0cu1lVu4xZmmkpxxl7M1e4mNZOjuTJKcLx7iWd8vgb720wgmkxsDjVPl8tF6eAmhbJPku7WLqJGx1gbv7uXx8PP2CSMWt46D1KPTuMUTumUTqmhjdMUaM9Ra6ANyus9UyG6AWl3S1VSRHxgFx4Gc2wDjD4JmRl7bDvTNndkJFXpnTS4NKUB+NrKFTiVBklyAAkZUXdrOiZKbdffLlb210qDVsBcAMf5ZKk4U7vj0PgG3ZgT92TAUaKazzyRY6xHGtyoHMfDoCHR5eh7pKk3hZ6Psd6de4mtHOY2liSrmk4zqDgNIKlp//ZwBkr5iNHEcPAeRUDZc5xtiu0lbRxTiGQ1NPqD3SnRNTfXVG2NMQh2GbKjnZGYO+fOSLqljPpuqjEFzvoktZiAGcI2nrslSa/DrHhhVXft+T0G2bhAmJUoMjkzRU7KOBFooztOwEwkTuSY/JVq/lJqTrz2wnCotVxPLHz/9+7G/bIAiUNELGCpqmpzjLkQY91tevUAxwiiciG63saCllI3D4Pwvnnq565gXS0k1pkcJy1kYgvEzFz3yFxOoo1kCuvcNVJ1QcU4AD4bJZlttogkb6XqVvSE5STawQxc5Wm9jsIzxhN2kvQD5aY759ItM+m7ZZS/q4EBMCHJSgOjYOYi9kPP/WhpEX3XEcAiEcR1GXPVLc/WcCI6TuCL9j4XXnSzzRPiGFT6L7WTvec5kFrAlYzP3hV+d13WLZg47qRm4aEyZATs356EZ9mcF1Kddwfh3t7zfo+1lhi9GAPtTgKiN5IpRKK6ZG8DUXdOYi+yOICR+xp9tnlgd6PJJyn5miX5SpVZeCL5NGODgTtqQ6JfXQ1bo6WyRTojAi+3h8y6HKGMGERjqeFDS4S6xSAgZi6KkzKrZTbb0pgWnhQj8CbmWHjGwCNjJmalrWM6/DT8GXDd0zQCsyd1qZlZu6A24TGgCZLUeiR6Kv813YS5ZVCek6NWpL4XRJq6yWP8DK/FMgyquw3x+R5tJFOgpO9xV3oS3GGcxz0XpJ8j9SQgI/m4oOjyo2bA8qU6UZ0lScuhnG+XF7yUh6Qw3sewLqcgkXlvDWb9iaHw3Qyc6QW59CYky/TkJxPgeZPO6xBddUpqTrFeF6BjrYQMQipMOQ3HAVqLiih9NCeE75wPsV1molEDoUs1wUW5zNPI1DFvAp6hRJ+Fz/6/0FRTWHTuPQkTYRCf331SLtKNZArz8Jkc2Z0/DmgKmkJucwP6GZ7mw5wAVIeZAFYd8MyTiyolXWRbuOazLl/NwwIwDuEFRhXT7zYZNDTZ1CEZ36DKGhe8JS6ZIoOMkqr0dd3sMuNiiPhBCuU00YKaai3uux2Ya1fSYC5xn0p0HdvlyH6w28/lUgNgW6M2ECUwyeM3LuY0ZTZsl9QGVJ1EPNjWoGF8jm3M6jO1eN9JdOqSPKVTOqWGNk5TYJBOT+2P6rBVsVEKpGp2NCouvlgtjIjuJAtTkIAqKHzMNsxgK+eINGhorcSZme2Kc+V4jBs9Etup1R4otdZteWZgDCVo9NxEKWV13SHlVNFtklDrsIY1YhFpcPHFPQiNay2126Ld936182zu53bL90zTqE1qIE6WGvGCCCqTXG4TCo8x8SnnEaORWq2ip/LT7JNabYeLlVmZYmBSNEUisLpO4zFtJFMwRc+CVFw2QIVtShCZjei9Q3MZi28vhsmTjTsGx6PFNUwaLxZOkMZNlYbJnTDBVhpiHMb4h/KbgTmfWeDyperFoA3pPRSu2yICKYVcfwOuJ2EtVtndX5fzUFfmiIgnMnNReKzINPwe3yO1wKCfj1mhXAaZbGzeQkP9+N7t3Oba7Hluxvpics3wghGrKN/XpauL5kSPMdD1vc4TFOMQSBZykbnFPA09sJRlbBQltYlPvBiME3iPgsmdymtZ1T42Eam3xImo+kxVW7hJUzfkQZ4uBgmoci4DkrCYiv+bewpizIQbToZEqSq128M9ORepApYOTWYINmMdyiuavQxucwPA8Qa1jNHvsTQcD+AJi6nnNbAbzfdGDMQ4Rcb1mFRFUhNY5HG0ZuU2OI7C90hqTpIaManyjN9hj5DPkehpAn599GYR3yCDiiH41gyogVAzGN3l5TvzWazwzEkBUBvHFCSofmVB7WHBOJ6AizWqeWYsBNSImFs6xkGnt8OSi7kZepOk5+mg9H2luBz3cE9WKz1tYlCzaTZN5alkiJrAPNwQXbXCvfR9ux1+ZqmS5zCUN2ZDUvUg2ER6RdNFFBmJtRKCmlSdqeH1Ao6kmrSVY+QFxoU3F5hw0UiO0SbvhiVzZKThdqqRn+wbAtO9+WOi2RsBTmtLUfOi+dNoap33XAtI3DimkFS5/rxciBtpKGl7HUYkW6qL1AMQU5HzMydKjI/w+7kQV7kNO14E3MFuTZ8L6cXL3YGW6FwEdJnFsNaVplu0j3JfnWUbo20ayQtzJTUHtM5SZQBOW3Y2TZ81uYyT6hKZmhf2VkIuBE1VaZbLKtCko9AY2yPkZkgtNuHNbz21n+MfhQYZmbWc6K0gs+yZJX4uRlySWUy0Ja0fQ5e5UUTzYaH2RGH/blVTquo+E1DEfeeWArFzORgO4uHE4GKcq/quKdGYXMQ5JTkpzSA8WXjSsevmNlFCUhp4/0G0tY86MyOGCEc3JaGI+DjdjSwvpoa7lFuQLu6P8PupDV3J7V6GCOpyAVkrdN/QlnY7/J1/fob3eIFZC/K1ZbjHSXX8bMxh0cM5sqZMgkzMbYrPRunfC2mOble+6zWHKdielqoqxQ6wf5wThEjyXG0koO9hp1Lqc+I2efrKO9zBPqGJWosn2rhAUivV1Pm81ABGXsnt7zthlMkcnZUophOn1uL7GGXoo9h6YBjrFTEGRihygfh7Uhtb4QQqrkxMxS5NF4YT5xKHsIbi+poBR2nNMYpkXGgZ6k/t0mAeGf6u6n6VK3nYtxHPrSRF/IPqf/RoxUXv+6RpbAYBZeG35lxLnawpnMYpnNIpnVJDN5QpPPXUU3rHO96h8+fP6+GHH578fnBwoPe///06f/683vWud+kb3/jGNcucSbopDX+7KtuZ4aIzJ95N9W9bg7fgJhWXWlKzK89SgaaHs0JbgvRUri3U5XVpOCF6L0k3lz8f/Eqcw2CapWDPrWqfPiWlyrOWHDsod6ZBRXd7kio2sZ2Gv3ka9mDsuV6l7ruplZJC322XvpqVP/eb3zdLSH6iqsp6LFz/A7WZl90OH7DizNJ+3qaSx8Z1M7g3L/VYhPcZ2ffO0p7GmDRoG3Rvxv5P4RkCvSvVHbNzXPO84TizbhxD91UM0yboyPpGHCICrBFzOMnzIN1A82G5XOojH/mIvvSlL+ncuXO6//77deHCBd1zzz3jPZ/+9Kd122236e///u/1xBNP6Dd/8zf1uc997sRybTL4y0xFTS09tyreCNrfOfXPPvTW3Zh8lKoX8QHaap4YVpFvTlXlNQiXNZgCnhRML2byxKZdTPyAC4TqsEE315/Yylb4ncRt3FbzuTWabV+U3+mf92Kjyrul1vtzpphJNoG8AHrHsUut+cGzO6NKbPdt3MIcgcVerkJ/3lEVCFINB5cqI7Xa73sMNLqOB3noh5tT2B6uVu0/lpqzLdwPxGyiyWdGEvERk8vfwTMRlzJDXkfX1BQeeeQRvfTSS9e67d9MTz/9tM6fP6+3ve1t2t7e1gc+8AE9+eSTzT1PPvmkPvShD0mS3vve9+ov/uIvlDniHUoqGoIGaedU62fL321FM7BEvKVI6z3VvzOhTHeSJRgHZJKXUa0E2ymaSs59G3aJ5iw1MK2DXHZC5iEg6JIGH7j/PDmShgXmHIb+Y+LSuJ3aFBeu23i1/L2i4b1LQfIW7eCMajp726uWqjyvccw7oCqd91LdoGVtIgJn1ryo2fiP8SEzlBs9L/YYWDuwGzEGXyX8d1s4w6z5OCfESgOjiOU2iWU0tPF1km4vf6/rfL9d0q1p+LulaJSMl6FHxGPOaFAC26ZleMZ9s60pkLmOrqkpPP/887r//vv14z/+43rwwQf1wAMPKKVrFXtteu655/TmN795/H7u3Dl99atfXXvPYrHQrbfeqhdffFFveMMbmvseffRRPfroo5KGCe2tyPYYjNqCpuq+/dbj7rvyt52nXDpO3MhRKX2tBjo4aHdWQUwj6FZ1ediJ1GZAOiyFEZwU3u320GMxSjnU7TC3B5vMwz1ztUlZ/Q762q39kLnR73/YueaJyUVzpdxjTSECf+7rnsTiNZ4O3dv15zLG8tPULThGI6J8uoQZKTqOQWq/01Tze+LuW3/myuGc8s7Yy0n6LgBXHspDTY8M46SFzvYT1IyHAcVnTqRPfOITeuaZZ/ThD39Yjz32mN7+9rfrt37rt/QP//AP13r0ROpJ/MhsruceSXrooYd08eJFXbx4UXsaJO1Bru6w3mlCJtv13p/vhUupT3Vdwi7JVDlyJHNnS0Nuf7VN7vDlwTqzLAAAIABJREFUs9BWdopU5iQ7UrWvPZGtgaxc31S1hjNpYAL+s71uhscFYBPH0s5/wr3uuyjRk6pXw/fahedrHi2W4fFhX5HRuL/5F0/ztqTcxp9V/5laSbpINY28Iz23VLGhhDJcR5sh86RxJ63/6GVy2zhfbtIwvrekQTO9LQ2Y0u3h+xuSdEf5e335fpuG3/xnV6fPELGmcBKexD9iYW7jf5XgpZSS3vSmN+lNb3qTFouFXnrpJb33ve/Vf/pP/0m/93u/dz1FTOjcuXN69tlnx+/f/OY3ddddd3XvOXfunI6Pj/Xyyy/r9ttvP7Hcpeo2Y+ckmOV2c9C2qgtvltUE8fhYeqv80iAZqOZb2jjOQKoDEiW5tYBLGhZ1zMFAlfZ1qUYwejX1thX3Tr1e5bqYt0qdvfCuqqrdUg1c6tnUPJeyJ334zCIN/UfNhBqMVPcVuC60sSnBImPdVQ1CO8rDVnKaJH7HKJ3Luxyw5msp3EMNz5qktTrhPs8JM7OeHc//cw3qv5/fkZq9Ejm3odJm5n7PFZqX0BR2E462KwKO88j9wRB3aih+F93P6yIpTddkCp/61Kf0+OOP6w1veIN+5Vd+Rb//+7+vra0trVYrvf3tb/93M4X7779fzzzzjL7+9a/r7rvv1hNPPKHPfvazzT0XLlzQ448/rp/4iZ/QF77wBf3UT/3UNU2XrHoYjCfAsTQmOt1SG0OvJJ3BglqqMgQv+J08gI6Om08aBpO2bFysUpsz4NVcJxtBLSdmlaoEaDY3qX+YKINijjVoB55we0XCfLd8t1lAlTMGJjnvAXczRtTadaT0538/FxH7eKiJ3+2JbS2KqjZjJmZJmpf+20cZLNPlHeC5pGkasigl/dxoLqxpY1MfVS+GVHGFhvmUcfYO0mj/75T2LjGnrGk4ye9Cw5xzXVKqGBHxmgYDCfX3GDbMXCfTNZnCCy+8oD/7sz/TD/7gDzbXZ7OZ/vzP//xaj69/8WKhRx55RA888ICWy6UefPBBvfOd79THP/5x3Xfffbpw4YI+/OEP64Mf/KDOnz+v22+/XU888cS/+32ndEqndH2U8rXg/P/G6I0p6X+F5JUGbhm3NJtr72qQ1PY47KYq4ZnW6wBAHcE5k12HkcuaY8cdhdKgbt6cWvfR5Sx9J9cdd8YDTNuq+yNch5mkm1XVV8dDWGV/MUsv52mIMEOu/S6TN1qxDY51YETjFbWuxd6eD2opvZiOlVrzxu30JjBrH4dqATLmh3TkIQHK3fLdEa7WWKiR+L1RW4n1pxli74LT7ru/GV6f0qB5eRxtUlArjP1tUNEm3H6pl/v3VfcBQHDjZWyTr7vcGIIvSd+8915dvHhRPdq4MGeS1VROUqkEuZTem6uo6zAVdlIJEy7XbH68gslvVTsi8VxAO6qqoANiOGntDvX3V3Ktb3SdEc1nGZ6gUqvqLlVPXDqjdrKRuNeBNMYDpPaefZTh90T11fUyxQUVbfS46OLENtqe1C5w1ptgpcsx0GtagMm7Lq4HFwJNG45HwnOOt2BbzVj2NfR1s7ckVXem60/GQE9IFDbcYbqUxqPu/XvPXGPfGmvpnVrVo41kCtEONjAoTV1dhxo63VrBbhm8PUwmSwuXeznDU4FFb4RfqpuxxgFNVVJ5Yp9Jg3T3u0dMQXBPFqORR6qRScQgFWlI7no5t+3MasFVewpGXCC3CzWrRjOa/JultX36ZCgRaDRDpgSOeMY6QDPW314NaaoVeDFFN98WFqYXP70vS7ULMX7n7kUXRb+/NPRTVt1FaUCUeIYBS+5ZcUyHf1/mNnDKGIOD6BYZWcUMwqrdY7HO1egMU9dDG8cUkipo6IlOoG7dGX/uVC5qL8Soafj3M1g0Duk15z/UtHNtprhcA2oxWpJIcQyMMYNrJGRqvSuuR0xLZuCUKj13XXKR0QUZBF4DqMb8BAxFFq67DCatNVGjIzE1nJ+JsSPcERm1nrkq03c5vROj4oYjejWsIUTzZobFa/c3zcsojWNWJpdngTAyKniblqkdI7tDmTDHTIvaj+MbXC7dxddDG8cUpBbRnScpgZOOEWrlu5FkIsuWQgwG4oQ4U8o4m+rpTdupZT5XV4M5YE+I8ybMgAc4MxOlnzWFmBbNk8AZe3ooeiS6rexdkKorjseuue2mhWrgFbcTb0W4e00deAujBHvmUdTezJDIWBinILWYh9SOkd8Vj22PAWB2RZIh2UVMrcD17eWvlIYxjR4jl88U/Fm1T/07+8lj7ffs5+k4x1BwCxUyOJo6xrqO1WeCPdpIpsDJtBUu0FaUBsm9A65/Ng3qvQEaqbq5bEOuVLWEnTJqOUs3YQQXkg6WNaGo3aA8Ws4aiOvi06KZxce2ciPl4TrMqvH5M9wT+8FlSTWAiPdktYvM74vbfyMuEd8RmVMvBiFOzsh043PGbrbULlaWGxe8VCX2as0zvYAsC4wYy3CkKUA7Rojm9owP4gNH4Z51ROAwakxb+M11HPumzBkzEppGbuO/lTaOKZj7mw6KPc7j3aS2sxzF6N/PpKrik8aTnVTNkn8uI3WYB23Bj/nkpqge8iBY2/kewDPFD82sRAa9GHg0V52Qh+XameLLl4a2LuB9IANRqXsvcSu9Ml4w3EjjMmJ8AsuNCz4GaHHxxLgOTuRdtV4Xq8DU8AguRm2An9dJxpWq5uXnrQUw3dnEdNDAHH3wbpTeMzxjJmomt05rMfPivOzFgWS1Jqc1CzIVajK9tvcwHNK1gMhTOqVTeo3RxmkKUvA0pFYttko5IrxFOiaYBkdSg/jPVSIGrZ6nQTq/sBxOgZYGH7Lj6V0Hgo3O27BSuw/iOE/Tzfv8B0lNBiRpcKVexndniD5QPRsiu40AXCllrfpGV2KMhHMdR1XaiHeu99Ae5/PxhCoTvQX8TClpSRu1ALvXpKF/oqbheyhFDdxKdezpWpTaDUZRK/BzBOl6mEf0wsw1jE1jeqkFtGkO0fNELYtYBsePGbD5jOtFfMXmz/WaFBvHFDhQc2k8rTh2hDvYR78TaByTmnrEyvM70KuO8qDqx30WXCALIU1aMS9or1rtjPkWGR49yyVRjGo5nKS2eZWll8u11xVGaMZyS2p32znWwPf73bOsLkI9B3NkfgGpVTVv0nRxeHLS5iV4Z4rjE+M0MBRjOdH92APd4g5CfvbmoBiXQG+Jv/Oa655DOdzNaIFkE87lEKtY148nMaieu30evrOuZEbR3FtHG8cUpIBapxa4y6oZk6RhMmynNljHC5PAHbnzUZZeXg3aAaPSmDDFkyaZWaThdwYr2dbmNl0zBEt5A6HGJrxXYswhiDoSiOppQw7eyWlow25qg5Gi7Tr2g+un/iSlT1+qyVnifXxH3LdAGu1x1MX3cbJf6TzHe9wH0UamAIiLLErTaPOzPvEZ01zTYLGl2v6LruXRRaxp3/UYBvvB75Tq7smIXVB78Pd1tJFMgWQVLKrK3oFnH/82emk7tWrmQR60BwenzDS4G2dqwUfl6eQ32SfNeAKq92MZqVVnpWEBeyLvpeF+M4M9TYN2YoSdvRp0MUZNJh5+4nISri3zlDFQzZ+jPRGoc19uaRqNmNVOUl/vpSPje8k4YkCU1G6p9jMxEW30PkjVjSdVTYz9YE8EQ+VnaqMtoxlmRiFcp5R3fAG1Cc/d3gIXrtHl2/PiRK9L1snawkYyBS+YXqYjRyHeXO55XRrwguPQS4f47uy+o20Kz4IHbKEhgw65ulVaqUqwy7kmdJnneg6CVN2CSzxn29MT+0xqbVGp9WtLdas0XZ30f/fS2c9TG1NvN+gqV6YVA62kqaR1O0y2lSntvUCihOVkpInkSD8ukHiqlCWv/48X8YwXIU0Q7+WgK4/aT0+zcX4LR0sepFYjsfpOZmhTJvZN7JeMtkmanAzmslyfI2mCeZAYtXktb4xp45gCua9tRUqihUpUYXiGW6eP8xDYM8YYlEGy+r3SoLpezTAFHLeAd0d7zxJkVNnT1H26rzakNpX6euv3mcC85mnIErUSmI3aiEbbu1fxrCcKT4aKi1dSd++AF2Jvn4PNGgZk0cbl8zxGnjb2aMeXh1KaSkuXE1ViB6NJNYFMtNH9fUsVD2AMAReQVJl1BDB5f2+h7QRMwTk6Xaav83tSmwXM2oJ/sxlLs4Eu6149enEgJ9GpS/KUTumUGto4TYFEtXv0NqQaHSdVqWyBaC3hu7lKsldzC0pZ4hDATHnQFiidXQc/YwlIe5smzssazBaqhw5UsvSzt4ObZgxOxqPnD8N3k9u1pWo2Wd3lcfbLPE3i4TpJ00Qk9kxEpJt2srWlQ1VNYJXaMZjhOWkws+y56Z1O7faN9j80JmdfcrujB8DaUkI/0LSxFkAtKoKRPffiShWDkarGwtygNCf8TrZ7pSFSdgYt1tGLEaCM1AMYqem85oBGLg53xBhjoHpak78fZ2xmyUP+AcYCGE2nSuxNMM3JTLmNbWBI85mC+Me06pyAu9Ik9dt+acMO1HKaJHuq7kfbn07hFoExku16mlo8EJcpyQhCxlThUst8bAZExJyAmycyk2gltQw0Hop7mFtTJ2tqo48eJjAbbm+33b/C/SMG4YWXW1BxC3gTQ89dB6maG6zvjqRjMJuYg8OLNZpFxDfmpQ30LORcMSOXk9XOZ3XKpSn7mgMamwHV0Ph4zgM5q/PeuZMv50EzOBYSsxTAjQivpeGI6MMbINXkLR6UvaRxM5QX/RifkGu5zq/IUSNg6e9mfAcQsdwmHCXIeDSbhrKjjTlTOxno6twCc6DkyapnPZA4sc0gCIxFYs4AU0p1cY9MJ08n+3g/3m1mc1XTsPdmIxOujRvQUvDU5JahuU29/Atz9C9zUfbqK009OQYbWVcCpwnPcHMWtazoouwBnNw52qONZAomosuMEHTGYalyX3fyVU0H1FKTQJ0Hy5cOcqs1kCH4d3c2g5WW0FLWqYKkcYOU65amC9rlmEEt0iBpx9TyqSQN1XRvhokx+wxAipt6ImAbtYQIcnmzGc0xx43wPfEMxQjuWcuh98FoPxc7yzHzaUDCVDNqSzVx76vl90vSuCnM5ditShU+CWdjproB7gpBQ7yY5pRUhdBMrabLe6QKfnOeJ03HhcyoJwBOoo1kCgyiiVzdGZAc+EK3kVTtwOg1WOV2ABepRakdwjziBbk1Bai+czJRC2iiKdEGbvyZaUCnOUGtEvvangZm4fdsZ+kqJK+fk2p8hg+ZodZiVJ6qKqMtLYGi+44Sj8+SyNh2S32PQv3ozo0RjA7/jZGPNA/MSLhgXsXnbUmzXNT8cu1swDeM8ZAJMFeBVA7vSdItqNuqNHoHbVrCFPHzni874bsptmeRBowl1kW4h4yZ84L39lzJpo1jClLrKvPiGH32GqQjXTiRAUjtZDrGxDD1JPqO6mR6VdWFRzpWdUlC2xzrkqTJASSOupSqmsuB885DLs64G7NJFVfu2UlVeu2pAFgwFaLqbwbQmBn47PuJDyw0zQbkMkamkNot7stcNIzy/TBPg5O8gJiCzUFnJi9uag6up0q9slrT8CDXXJd+hmX4eZpRVumdru+mVPGkMWYmD4zXpo3HdQRb8Z6xvmGCkMFyzlITyOEaA6Ai7rCONo4pUJpYwtpPL5VEmPhuphAzAjGVmiUSB8ISM27JHm3nXEOmXZ6l3bp99Z7EjKizRsLEs86+4/e5XNfvSqmPTQMzBUqcmVrJbIqhuQSxpHbPQmRqe2kajXkFk573Mm/AYR5seQKsDCAyESDzAvI9TnFPyejfGLdA5m7gVKp7V65oMBmo3s/SwOCj54P7JY5UtU8fD0BtaJWk3dy+O6syYYKrPVxgfCa3ZmvEanomaPweI3wjncYpnNIpnVJDG6cpkCtaejqJplQxA0tJZ7o1wk5JSKAx+nat/vme/XLN6dccCxEjHP2bNM0MxHj6MetTHiQwgSOeTm2Ai3U7o/YAnKu53SVpiu5N26wS3HqhzQ43NvU2FBFcjBqW8QYmEnUUqdsYQ6ATniVxD4vByqx2SzXNlL1UTSupPXqNKeec25Pvb3CpUBeDtm7PFbV2v8tvNEBN59QqgMb2VLluVzU1xax59vY8SFPw1b9FjIe0cUwhqarWWUMncjOKVT0CdXGxn9Uw+aPbaXR15urBiP5/0lw1ZNWL/yi4qxzW7Hus2nEPwkGuLk9iA34m0oHaeAKaUVKNfZCmCP8qMAOqyYs0XSDBezrWkeHf3DdiL8NcbZhzdMcxNDr+lyqzYbm+RhODIK2Zu231K7necxbjROZ5nEsbpEkWpQhox/yLK7WLmH25h/e5DDPTse+LZ+qSan3N3OmpYX3NAKJwjEzjNQU0zlTtfNNC1Wbk4EoVcPMCcnzBnurkcbKMUaoUG5NBJJHi4uFAeWLEfQ5j/VQni0FETp6ejU/Xm8+k8H2xTC6mKCHjAidYZq1knc1phsXfyRBcFzOBRkriMzGU8cUBbPOhOE1eSbX19+7XnfD7yBAL0LqThgNeXe6RpEvWJtJUc4m+/6XaDXQRb5BqFKKZxH4OrmVVkJZeLu+xkYb5dqw2ojG6arOmXplIEVyPtHFMIUqTo6wmycpcA5eO6c89CS1NHLUo1Y4/xMQ0t+ZkJmB5qIER8b1e3FbRt4KKucR96za4RA8AF34MZ+WCt8rOd/HddoUy6u2gMBdH5TlEnFoGXboGyShtR+9PADClNlKPTIs5HExJNZ+in2W4Ok+CZn0iYyZz3tPQ5m1VQbKXhnG2ZvZyrgFMHBMyisjcvfh7HhOXcTW3DOtQlaG67y6V+5j8N45xPCHKbnHGb4wH76IevaxVpo1kClHqLHPNxGz3VrRTR3dNmganrDRwdi4GmxPM/T9LrfQ71nAwi1Tt/gV81Z40xAv4J6nJ4ixNNQuna9uDT/zVVNO0mSgdGLFH258nV1udJ96yhc8qfdJjRj137ZgIN09/t8eAJh4Xh3cFzlUDxIwVkAEmtRjCmVRjIEwR4/BRbgwYuqKKOVFVJybEDMq9Q3FMZFT05PBUa//fUg3ckoa5SkZARs46UYhE9+NSNWBM4dl1tHFMIamNLLR6OOZBLIuIqvxC1cbrhX8e5RaX4JbWcTBg87scLl7H4HPimKtHch4DtsHl04yRhsXvjU1kcIvUgoV0dR3nirXE9jKTlDEEBsJENyaZYFZ1q/G2CLjF7dQrTfuF0ZPGb5bSePK39zVwMRhs5GY3/yZVzWLEAlLdJ2LX6aGkF3J7lmdW20/WJBnE5LazXLY9njfCYDQS+y5us+YYsu9iX8cgpeuJlCVtHFOQWgAopxa4W4V77N820OTQWDMCqUbbUVLEiWwOPfreNeXInpBxJyUToq4kCe9yJGX04VuabKeSqAWMI6qtlvguwmnjHNzl/uih+/H6ZbUTmeHJDpji5Ld0pB/d1xh+7AhF32OfvN9h4iYq7rsYtRpVoTCel2DNLLV7FI7y0J6jVbsA91UXuMtj/MOV3HoJlmoX4hIa16ggFW2HOx4ZtWlNI8bCHKplvOxvPxeZMPvWZk6MjDyJTuMUTumUTqmhjdMU7Nox2d6LKpWliU+GZvSYJV7G/XPcY7cicYfo/nJZDC2dpRalnqi3tjMDKEdTJIJyVzNAL0i3eVKz1dhH1JEIWBpooxSKwFf0hxsxZ9yF67YFreUg42BUTXMvup94LuTMN5d22ZVIKUY3qwFaStVRrXe5eXi33+Nwd8ZrjDsmoTlaM6SpEqV3VrhY6KTowugONmg7hterxWykNqqTr4zmV++ddMOfRDeEKfzrv/6r3v/+9+sb3/iG3vrWt+rzn/+8brvttuaev/7rv9av/dqv6ZVXXtF8Ptdv//Zv6/3vf/91lc9EIZMtuSpgH75fCSCiUXfmYIigXUwA6oUbw6VjBzNBbHQ37pZyeTqV/flkJq6DQj3oxtzJrfeB7q+zaYopbKWW+XDvRHSv0UvAPBNOVjJLLTM8k9qytrAY3Za46JjUZJ6mrlK3Ja7DQ1WzwxuQiDFdwe9kymYUN6VWHfdcICOOyH0URFJN5jqaVmm6Bd47dKV2T8RYf01NAwufmATWdbM7snE1l88EmqPbvmlPzjn29/ecPvrRj+r222/Xxz72MT388MN66aWX9Lu/+7vNPX/3d3+nlJLe/va365//+Z9177336m//9m/1ute97sSy705J/0dp/Y5ahFqq7hp3okEvLzpLFtqedm1G4KuZuGqjIS1dMr7vpbYuseM92c5gEs/UJnx5tQBfV/GcXWb0HMTJwOhKt4GLwQvHdTrMfVcWF4ffFRc3F8hu534j7IwsJEYT94b0ckfalubmN/d/dFNy41VWG2S0lVrhsZvqoTpCPSmxDzSMyTG+S7V/d0s5xHGuFHDXmbOyKjYhDUzBHiprUq/kNhLVmgO3/puZRg0kagecm0eSbrr3Xl28eFE9uiGawpNPPqm//Mu/lCR96EMf0nve854JU/jhH/7h8fNdd92lO+64Q9/5zneuyRSy6mRj0I07kRxUmnJdI/VJbYgyQ4tHIEztpKQ6G8Ed53GQ2hRoUp1ch6oZmrxIx0zMeIbMhoezMEMS4wfsSuQEGUOCA9DIvhijBM0co4RNalKORQnld/uUbmnoRx86QzcrKUpHal8Ey2a4z6dxRZBsoRpVuld+X6HN89R6VI6y9Ira/qc2JFVgkdGse2qZug8YGl2HxaPkHBf7qkxKqhGolPpRIyEYSZOCC94bzaiZHYRrJwUuSTeIKfzLv/yL7rzzTknSnXfeqW9/+9sn3v/000/r8PBQP/RDP9T9/dFHH9Wjjz4qadiyPCYTyVXqcgLuSM221B1VBkKVvhc5WB6Z+IOT6iTzu3nK1Cw872ekKQ5hb4JKW67mOgGtsnNHZIwTMDJORhij8hzERaLXwM/MVYOXHIg0ZmzOdZL6/fQCSEP/O8GNaXTPBgwl2sIYonGfwojW52mbnLosMiQvxLNpui8jSdpPLUN9VdVFmTUNZXe4sd8TTy73sEfPAft3V1VrcnsOU+uR8JyJTJFYldQKAJtedCPHHbzXou8ZU/iZn/kZPf/885Prn/zkJ/9N5XzrW9/SBz/4QT3++OOazfrOkoceekgPPfSQJOnOlBr1cxEm7naY2OSw0tAh22qjwvwcIxptRzY+8IQDQVLr82cdrOYfh4ntAZ2rqpn7QYWktuL/XrxkUD23IY9Sd1meAFel5rh0399MkNyqrp789LnH3A5nNCzG0TTINSuV08fN0rDQ4gEyo10f+kjSmLKOjNDnQxDP2VLNj3A2teN6OUP6Alhc5SpYruTSt0mTzEncxxCT5ho/YBCR8Ixtf6r0NtnYph21YzK6Wd0PmjKIdUSt9iT6njGFL3/5y2t/e+Mb36hvfetbuvPOO/Wtb31Ld9xxR/e+V155RT/3cz+nT3ziE3r3u999Xe9N4fNVtYvXi46cNNrBVnetLtt0cNnm8sJzVPuEa1TZbHYcgSHxHnoUxkAjtQskmh5SVTMZGMMovlzeSR/5QgPDoTSmeh5Rb6ndwCQNE/ZMapmMo+cITl4Oi3ehNtT2SDUNmr/7Wb9vgimAQfv/bmoXqze7+RljA2aO1kBWuQWAWf/dVKNguZGNjM9mC70GTjTrhDo2+aLHgVpBUtvvTs/mRWogOMYz0JtjRhPH7lr7HUg3JE7hwoULevzxxyVJjz/+uH7hF35hcs/h4aF+8Rd/Ub/8y7+s973vff/RVTylU3rN0g3BFD72sY/pl37pl/TpT39ab3nLW/Snf/qnkqSLFy/qj//4j/Unf/In+vznP6+/+qu/0osvvqjHHntMkvTYY4/pR3/0R69ZPtFnagVSiRCk/14VyZYqUEkPgFHuUU0uEsnqv2lHVaIt1KLj4ylTqlI8mjC9PQmR48e06wZKIy7BPQBuBCVvRKeN8PMZazJNfslc629wzX1lUG6purPvilp34zz85+eE/5Twln5z3HNUzIdoMnEHqBH+aIYwO/U81XBuqY7PLso4UDXn/C5qasxtQXJchOlAbV2IDdgsix6fLdRtiTnUi3Ew9SQ9y8yd30k3xCX5vaRzKel/K72yk1q7Tioqcm5jAUh0a8XNP1HNfxVMwRPSaqhVcauPXnTbqsj2Kk/BqJh4xerkiLoH84FoPAfSLjFTRKudusz1389tUBfLJAi3wj23azjm3oDlfh6YwGFuMZDoMjPD5MEoV/FMRPbdXgKN3pMwgrWpqtq275nCjn0yZl32fyw8m0TEky7n4Y/JfikkemNhN7GfsRuWHij2i9tCRrGj4cxTem58/ADjVLiJKs4X400RxN36fnNJ/keR7UUBJHKnmet6IUfUfSaNo71XRNcBFqRz9xl3sLT05JpLk0Nr/RsXtvfv+zsZglRdpA0ghbI8iagZRO9J/E5JSpvX5fuerFYb8gIfNZxUY/pdRtzE47J6ABijQZ0H0c/u6OQENn6OACFxIpdDIG5VNANqR2YIzeG2uQYT5VyYR5IcXjdTCIgqTMOxI2am+6p9d6CaGVqqfUkg0mM44keqrla/d7v0OecIGR1jGUgc/2vtfdg4puAFK9VNTdxMFH3Ou9KYaFOqWkJE8G9Jw956aRj8lVpTwK9oUPJUATGfLk3futRO5l7QyTiJykPePRhVRCeG6dFKw29cvDEi05uLRoS9MFL2lwEuf7/qfsu1Dltqsw0tStupDcVw8NH8gVeGXgIDdDOB6aYpo7O2FhOvUJtwO6Si2hehEdVxM/tdSbcn6fUzbNtOGo8XlKRvrQpD8BjlmhyYWcAI5HoejHEM+IwhGDU4t9lxIVHz8zMWMo1XRu18pmnWo41kCpxM7gwygq1wvwNqTPbhj/7sXLP4+KEo0f09Sly+M3o5VuG/JzQj+GaqtrrvnalVjXeSdKukWz1pVeI1ghYwD2VExsCdnTu5Sry43Zeh0ezbLQ3RgDupZRwSsADUe8yLGerMZiJdAAAgAElEQVTpfAWWfp7UZJox8MlSNqF+Mfgq+uvHoB6Yk0lFwyvfd5L0I9vSf/e/SOl/Kg++LB39n9Lff234+u3DmgtBGpiik6yQorSOafqppbmeSyEkObdejx557s/x3eYD++41xRSkFtSKAS50/UhV3aJ7yWXQh08JlNLgY+fi9TON9M3tQHtS0F5l/Va4h24+HpQStwffpEGLOaPKtGZqAcErahmLGadPPpKmIBmTyNIsYRiwFxxNMbluXuipuBthvknTjE7bqucmOK19k9sB73R9I7hmDY8mnPd0sIwxvqA8x7RuxEykIU3bD/+PUnpwLr2njNyVe7V15v/SuX8avv6X54dkOjHXBN3YUotRRWE1y/02SVMtpilTrct6Gb57KKhlrTtiwLRxTCGpSpikqblgKUupKU3DoCktetKak1saFiVtZyPNvQ1ZEdmlr5oh1EI9LS2MlLPcA38vD22ldmHadMi4P4Jjfn+kFH6ntNtKdeFJNVSam6ncPntN5rkG6ESziZKcGZWdhi0uGuE7o/oYJEY/v4FUBhpxj4s0mHtOfKvSlsv/t3TrM0vp7mKgvXCk/FXpH14Yvr64KkFO7odcY2MYSEWaabpb1EzdTNbmxYhFqZohE/MS98xRdm/vw7XohsQpnNIpndL3L22cpiC10s17AHiN3y2dyWkPNKjI7BymYqekp8TegnSea1CdGb3oDD4804FEG5/v3lIbcUcAa1kqtFRVe3dzuw8jekGs+fCUpghGraOlqs9+J7euW0qlBtTE+2eqEaFuqyMeGzMKfRe9CH5XBNx8mnJMk8bwbmaocv5Ghr1fUQvkXsrSX70onf/fpTedHfwLr+5L/2Vf+v/Ky/+laBeU8Abz2A/cvm7AmCA44y6EMqjV2eRgmHM0OXoHAS9xraetkjaOKVC1dkgrXU7+HM0GBg3N1e5dMKruzrd9zKQpO6Gn17ngqFJupdYs6bkNt8MzY7LQ8q7j0qhdtSaR9zJI7WnZplnBReKuxp65EJkhGegx6uL7yQy5b0FqE5awTUx3530GjGMwYyAAS08OQ39drmNLoofC9R93TeY6XvuljmfREc+vpOcPpHnp/JwHxvjd8vKXc1u3XiLXHrM9zi0j7R3Ek9WOUc984nXunXBdGo+YWpOkRxvHFAwcSZJyRbJHt5Ra/7Ank59ZdhbQCn+SmqhCRiw2GkhqtzVbOhN1l9rdjNyUReCTYN5hub95poCK3o1oafEdMDra0VGTchtj1mPzuahVEd3nvhL30dXcMhDiPCyHrmPmW/T5E4xB8L4FajaMXiRuZMbpQ1SIyzjJraThBK3CGJtEual6RFLxpBzl2r8GTv0eL14KnogXRIl+kNt4EzMsJhW2RyJqCkG5aKIgV2o1BQPbcYPfSR6MjWQKY2oxLCbuLqREjoAeEesx8jC8w5rGFspfhfvsT6bbcZRY1i7wG8tlvVZqJYq3VfMZSxMP+l4apOS4MMv93Ea+p6F/ohZAJtYDp6ImsZNaLcsLZIywyzU4yc/sprrwXWZWyxR9Lynya/apGQ2ZzWEeFrWfiwcFeweqk7yo/HaYq4m0BWZPM4Qh6TsK4ciqLm5GQa5UtQC3s6fG+5rNH9Zthf++lrR+wdtcjUzpNcUUaCrYnccJaBckpR1VLG+D9fZe38NnzFi21EaxxbDVIyHhi6r9yiQwTjvu90hTrs6JbkkSVVO68F7WMLHHJB2pnQQOFuIpWD5bgRM7xjfQ6yBBS7DrM7fqLn4ayc9QG4pRkMZWxpTp4TepZba+x+M0BgSldoIv1Upw7sp0uQ7Bdlv3VZnGS6gPXdRnU4ujmPGw3hQewn1NXEueehZYF2IVkZn0Ihj9vug6vxZtHFPggjkpuQQlYlRtnaSVHNtqsVTDohmFNx5cW545ysOEoiZiu9kaSAxWmake507JfSVXKRU5vrcrszwnlnUZtuNJZlK0M7mgVigvbjDjBGc+RjOzGNPhHBXSEFMxk3QFGsas3EONg+5HLx5KVtrirov7gElduPA8jnELOPsqaiv+3SaEy7wJ3K6b6FfDuIzbqVMJmS7PmWEQTI2ajvsgxrGw7v49zgECkS7LdC0GceqSPKVTOqWGNk5TmKnazsdqd/hJ1bww51wUQLA5Gk2tStnb2EQb1u9lUNC+pttgHTTFDUU2VUz+bmlnN5vwzDLUyWZJDNKKodERlRau7aQhwvAK7omBV84j2GgdqIclJDUZm2OjieR+JrAXy1QLpjL9XNxmTa9JVjGJ/FuqGpo0mHo8hs3lcxFEc4dDz/0xdPFdUYsHOWlMRl22JOXUhqcfSWNKupTr/hjOqajlRdOBAU2kXjt8Ld4baeOYAinn1qUmVTSfpgUXZW9vwqgWYlI4nmGJCUd1UJpG4MW06hEgsmdk3GhU6ruTqnpoprJCnW1aUM2k2mnAcBXuu5rr553UHq93DBzGuIlVXJKBQ6kyMsZbxAWf81AetyIz54FUbXaTT0pi9OSu2oUoTReQmf8VoKlztZmX/D6qzGSuBvbmahc0F2dclEtN9z70TLiIL/Q8BGSOLi9mWqJZwfulmtGKzPokkFHaQKbAhdlDZHs2qQ+HlYbB9ESm5+JY0p6/p/r7eBio+oPMhWiAjwO4pVZzOCh2p3dkevIZz2AIr6QxQ3DcLBSlS2R20TZVucf4is8pWOX12AyRfKnmaEhqtawrUpPY5jjXrcS9ciMTYwq9m8u1s2n4u6l8f91seO/VPDAcaWA2VwR3bhreSSDaEj/a0a6TtTtqO64TYwPoBiS2EDeRsa1RiESPGHGlSLHP1mk41oyPO/eso41jCitVdxLjCuyHnqfWfBhdfWAA3kh1FO4xh7bE4GIbASKog3GDVNI0B0Dcxx+j3FxuNAXs1vS5CpMoQtSNQN343qJ97KyZKc5tcJDgYclt/IAP7/XCvHVWvSCur7NrE0Q0ok9TgqaYXXGjiVf+bkrSbeXinTPpzrl0dxmM239g+H/pRelbhVM/eyy9mLFDs2hYr4LhEoQ0kXHPNTBdbqxaqe7HkKpHKC746MaMgCDngvsnakmr8D1K+zjHPA9oXuVSX0Z6nkQbxxSy6gJPqm4/bm5yQIdpAd+R1S9Leqmq4pRcTlHOHYKWklK186NK34RFayrRj9RqGF2sAItumWrUo8nIN7NA8f+OhsX11rn0g3C9/MOB9HyZMatU4xk8kWPSk0WR1q8vL7+jzNTvrrBlejX47PdLXa7mKr3GeITUhnybEdIe3yrYxC2lnHNz6c4d6Y7/vtTlh6R8JKX/R3rln2r9ZjSRULZUNQX3mVTH3c9s490Rx4jeHQoImyTEGYjzmAk6bsECx7EU0lRDoJnCcshApWpu+fdr4Q2RNo4pSG00F91lpFn8DKYxSpbyP+V278MqV1CRgxNV9L3wPb63V5dexKUXkb9vpZbre2KYdiS9cVYXs7dOe1GfKb//Dx+Q0i+X5fCdld70/7d3dTF2VuX6WXvPf8fWA4cpQ4tHSqs5ktQLIEUTA7bUo6j1BhFNTC9I8EJiYhCCiU24oAFjojc4IRyJVDTG6IU1McdEIBISm0OLNaYmBz0FtO2ZlrZTaOdv75m917n41vOtZ73f3tMBOjN1XE+y2/n2Xt/63rW+td71/q13PeHxp/8uLidaUXW5QKkB6SrjAFxRA/4tNPzKAaDVKsKBz4eCMy4MZq7OgQHraubCP5qpWkX6OuIWcYYf9zhgeBCoMR1SP+AngOY5YCp09kS72I5NBkU1UJkN7T5qdLQSlEYFKspIydAmVRtoZFTDrUZkOqSh83UUUpXGUpDZ04Wq6oQaipUp9CKd9BrotNjzH1YdU3CQDDmovnRrZNGJDcRNK7qi9JoyFM2tkUsnrzP30KOg99mAEwY7efP9IKqnBdncCJBnU0ohrI0BANbUUCRZXB/uWg/0/EcD/36quDz+92JyTbSE2bk0EIzxHBoiPNNCki5szhdt4sBWr4me81BDoaoQunmIunkvUubYbABzx0IbzwCTrwGvTgKvhg456+NxbbxHpSygOkE4VmxiXFW/HIo+ZlN4mBDvoZ2iU9CQqnBtRFuLpuizgWZqByMTsAFOeo/W0UJ1zNtQaYscp5CRkZFg1UkKtOjzb4/Ou9F0xaIeD6SrrLobNT0YD0BR45LdBs3Vj1x3zhfPbSNmP+4Pz0i2ubpocATiCjks0s8coirAQ0pVd5z0RR18Dn8rxXMHvD4PXPWfwKajRU3uXwE/DfSsK8pcex0wfRJoTgJTtDN0WF5mPHAiEHtmEmUY97lAzJtBbVGPEFU0tlENt6RXPRt1FPaRecSdibUW0JgBev+3uG544Ewb+L82MBHKTAId91ioasb3WL4npLYT6ybkd01f3YxlDYKdvCps4yBSlZPp3NRuwPGrder/rFPVTSs1aMSqlrFSqmLVMQWFir26fbiGaISzp/9QHFMLutXZefSZupzaQbRWD4CK7W0UVm/dYk3ft7Vv9Lv05GM9OowWc7ZnBijTiZeGMFfosnTNDSEd+E0PvAngwCzwyn/Fe4YccHUYESNrgMmGCdByaaAXUEyg6XZK2xwiQ22g2Hik3hM10CG0t4Xo8p1FyuR6EXcVkpbJFvD3llz7gglc8GkYM92JQHWSqjdBYfMR8D3abFfd3NyliO9RZoVmPQRD4OfkupNb1Ho1VG0kdLcoFyIyWj5HmSwXlm5YdUxBO4sToZObRy3I1t9OpsGBTf1WBwGPo+ummynH57WNiaijOiA5iDXZqKYG59HoOjiaci+/rInEM41UH9cV5ywNgGHlOx9uOjlfPOfNdpxknFyT0mgd+Lq9WS38DcQ61AhWTjyPJCUaLf26s5ISyLQ+W55DSU09QHQdkok5RIkNKJgl3b1ksh7pZi1OcGu0LpOphrYxw7fSy01O/K6FGHTW8unOVjI8O57U8M1xrDaFOtLxXUfV0MiP2nAWwqpjCtY1x87rkQGmnebM77r668DgS0X4v9enE7rHIdkWpxuqgOj+UkbQQup+5D26Ks1S/GY9vmo4pZHTTiKK7Az7LkXXsDJrvgdOoPPhutEuBu4U0j4dkjbOoBjM5YE3XkT/8Mxpn05UtpttAYqgogFRd4YQIzlJ26SPoeO814r6QOcBPy/9MOjic9a5KIGcDWW5nZpMTNULa/jU8dCSfqgHOtXlWYruwnza0h4NhiI6ecxsomFdrIAYRKeGRm4ks7R0w6pjCg5pshHrRuOEs/kVCOWoLeHqOvj4wjXKjYPGh3vKcxSkXq4OHLnt8AwbVcgAINKnKxkHoN4zZCY9B4W9JjRmX0XohtCmIdw6o3VvST2oEn2h3AREv5Y2MoZfqq/U25Ln1Vw4x8JIIBo+rROO9Xaysqve3ociO/NV4YWP1oG1NeB0CzgWKjvRDslZpL/JZJUJTCIyDqa2s2K+5mmw4cjW5qDvyo5HVU+sZNApcE0XsDqq0YwLqQ7AKmUKBGO+GWwEVAORgPRFlPqji5wf5h5uuul1sQNt2jTGKGg8AVUO0tjn0hOiIH+rAUoNoUoPaYeUBaJvXKUju7mJIcZcqZg/stTjVRKiZOCimkHoFmIaTlWS4YpqA3vsqqjvbRqFJMDIQ9pHdAs5g4FYj6aj47O5ANSk8h7EAKheRGmF/buOamMoQ6PvPGK/ziFV6exp2aVbE6kBU+0+lBRa5toyN13hLRNkG/U3Z363zwT+CSUFjQDkyqKGRP5NSzrL8HreBZ1eBr8VH7laauxAv0xABTPwzCNKHho8o+UTHVm+txOaewxYF8OGVaVQmwYHhR5t13LphqhpH9UKfS597myLxhK0UTxIE5bWzD0clNa+otf9SAOGaihoUzvKVGAIGqmnRkSlt9ugn0ZIshoqHgoq0iQiAwJiRChQMO4LgTHw2dzApaszUF35e+UemDJ8R8rcdcUHOuxI7XBNiUNtZC3EfuGeEY13uJikkOMUMjIyEqw6SUFXW/rmW0iNViq2lbaAcM0MwNZglej9IU6hD0gOIm0DSSYmDdXlBhgV5WnRXiOiKu0gmg1ZreFAKhXYbb6sF/IcnqSskg9XMl2ZprxkWRLvhUoqcyJdNBCs7iJ1qRhMWtW2ouqDGsN01eTzqb5RbbB2BAXbopKiR3hHYqu4gBi2XfPRYEnVYABBchF7RhPhKDiRiNRlyms7ZjrRWjd/2zJ95vdOEkm374Cib/WwIx3btmw3rDqm4JBuM+Zga8h3trz+rz7q0koe6qBIWfOFmsFzBLTsvK/ei/D8HpfqjDWgPGUJiGHDdZ8GL9k4hk7GU5hr67u2NhS21UmZZGuwL9xng4gMlbTweDfGSGhyUiDNTQikNh1a81Xs5+atxOUr9gO+Q+s5ImOG0EijJOloIbok66Fd3PXJ/SttRKPhbKBtQAylHBN8did7iJPftawNWa6Z++ymOzs+FbqYaf1qNwA6exrU/nIxrDqmoJOuRwaKXYXUA9CDOFCAasakGoLEIdJGuRdfRr9uotGVks+c9yH+QepVvZEDv98B7w3f0YpN/3wlX6CrbnRhsJNKE87HgC0aL/tgVhgX6Z3z0bvCCUyGxAnEFZxGS0pGjBoF4qS1h9sAwrRcanxk39oVrtOk0RVT9610AutUpqiBVizTcrIZDtHQWLq3zbP5m2WKlAxZthfVSa02BrbDdymj0DL6HOMZTySzi0kIxIrYFCYmJrBz505s2bIFO3fuxLlz57qWPX/+PDZs2ID77rtvUXXXUewAXF8DRlyxCg26sAq7YrAybLbPVbP36LHpnKTcuktwUnLzEjnznHzKgRQMcVzByO31Y9FGpLcfUX2gm7EXRTv0YNQ6iijIYRQTcQiSvwHV7dfsl/eEz7CLojPVDUvvPGKS0jJ6MTAGNYwy2lP99fyo0da2Qeslw7V5Bhj2zX7pC59+9oG0ib/N+uIz7cWwjDiZnIsfHnHPMprgZcAVH44ftpFDg7QR+o5VIuVztT2+wz3ziFIhP2Q2fLYGVRE1xK3pVhJeDFaEKTz22GPYsWMH/vrXv2LHjh147LHHupbds2cPbr311nf0HB2AbY/yvAS6lJo+drxNqqKTtY4YKkwGYkV4AEkWnbaP25Ubep+xcnNl8IjMxsuHvu6aQ8zpiDiYaCnnTso+hB2ZrnC9MXuyRmX2Ih60qvdwJyfrorrAdtMNx75EoGsAkckMy2ThhNE6KB3VpBwlEfYDA4h4TRtOHUXswlCY9GtdvEaoe8hF5tjvYoBTA2ELudRLqYH5E/jRlZ8MSttQlz5V9c6OIS/faYg2pIyOKapJJcOV/+ekvDf3Aan6QkmB9alLs2Xu64QVUR/279+P3/3udwCA3bt347bbbsO3v/3tSrmXX34Zp06dwic/+UkcOnRoUXW3UBzzBRSdQ5dQufr7quuv7aNITCZSR4zKowhMEY9bp3WVqANJhiePonPVD02QMZSh1MLGuTpZEVWvKS0AMe7BnqbMtgFxECfuT58yq16fGrnWulgny7wlfcBG9aKISATSPJJzabEkgKhfJhUCXWuEXsZuML6gjerBPGQw5bZoH9VC9oO1x+jE0jrsJNF7VDXTrdMeKEOW67662qu0yWepcdXCxiywHlWHWU5h1Q/aGHhNpqw0Xcy2sCJM4dSpUxgdHQUAjI6O4o033qiUabfbuP/++/HMM8/gueeeW7C+J598Ek8++SSAwufMUF12RhJPgGrHqg+Xx7pb3VTFQjXe8L4y01LoeYYQq7GPqxC/a6L6AtpSDugQ1soVNjy43xU0UJwGou2gzLfo07ZQytHUbw2kiVt5xNp7ammquoaXCe5QJsdlH5R6vxhcNUqU6oIaw3oQRPdwz2CoV71IZDTqxZj16aSjJ4Hp+EizTjZrL7IRhGTIekoVpRtr4yAsA4dcK3OwK7tKpNaOAMTAO71HbRRaThcnbZ+VEgAkWa06YcmYwu23346TJ09Wvt+7d++i7h8bG8Mdd9yBa6+99qJl7733Xtx7770AgFHdlpaRkfG2sWRM4dlnn+362/r16zE+Po7R0VGMj49jZGSkUubAgQN48cUXMTY2hsnJSTSbTQwPDy9ofyCUi9IIRZDTlluRxQsBRP1So8LoSipzLiCu0GRBpbch/KHWZCB1i1kXY0UsNfRoe2g8onWfIjJVBKKFdOcfyyKUnRWbCuvVcOpS1Pbpaqd6s8b2I5RFkJhI34BHeQIU2691sB7aAFhPv6hifE4LqadDoed6Kn0qKdC4aD0Atr9VKiiNojDxGoiq6awr3ru20bqkKTHp+KPeTzhzTXrY1k4eCtap6oOT9nSSQFSC7YQVUR927dqFffv24aGHHsK+ffvwuc99rlLmJz/5Sfn3008/jUOHDi2KITikB7faSdVJxANSMb+OGLxCqMilYra6rnoR7RAaegqk+q0OQN4LBKOfK3YmakITVVPU0g0gOfpN3YmddOdyIlqbBqLPXPVxG17Nuks/P42N/A0xC7SGlavdRD0WRD9Su8M8CoY2K9etUI+GT9eR2ho4qdivTNev78F3+Zuw6d7pun2P2GzqSPM26I5KCB2a9p/qg9oLlDFycncan3YCc+EgdJJzAbMqEr1hgBww1AUrwhQeeugh3HXXXXjqqafwvve9Dz//+c8BAIcOHcITTzyBH/zgB++4blp8gbTjuvm3Ce0krgzKKJSL017Q72TrNdKX3muuOxmvPNKdid7FQczB3vKFfq+rnUbt9QLlSVjqf9eBUp4BGa6npR7bL+Vk9dU2MKCo3PIsNAHp2Yl8luZaBEJQFDpYwX2sj9GU9hyFXhejE22Smx4UAWU62epIc14yy7GuoqqPs4zq7qyn5VHmU5z2RWRkGbTlOxsDOymyKjmwbiD2U7NDGW2PSpYsU0OaU0PftS6KbSmzEJz3vhPD/IfF1c7hnvBGOeg90tN9GkgNNjo41X1nM/PoQAeQnAVAMa9UI5AaNWlcU+ZSrs6iWqgVmvSoeMv8CoSKpBoRmKSwR2eRVgetjYBzKFyTAy7+xtVbsyPrhh+qatqfxrlS3qfGXUolqoq1EScd3ZbaVm5I0yS9amwEYkKaWbmeFaOrZv3WeA8NDWY5ZTYMe1bmqIZENe6pZNBCKv3owsNzJNR1SfoSDxdS6cdubqqZe9iX5QIU7llz441dPXqrLqKxhsgAODkc0pVVA5ZU5OO1Ff35t1qf1a9NaJqrdlhZBuQ3pvDSSdIrYikZRgNp+rUa4gC0UgGligHTpjqiHaOGYnLYFUK9Ahoow+dS5dGBrcfJqTcAUsaKpsroNIBJfwdShqo2nSEU8QdKLyUFtUN4FMxC+07D1hsAWi7afaYRbQ565qi6fDkWlNEyZf5Crkz1MgFRCrB5JVQa5bX9Td+1Q9UzpgyMe2UsqF5pvd2w6pgCE2kAcWXTmHOuXLqq6v+6glnfr7UF2MGug6LPVVfIQVQHEtD5nArraoN8z9wHQDHAaTxTyUZzPTCGQlOWWfGQYmlpJzBxAWW5DtYw0soVUw2hQExCQnBQq+g8hzS3Yg/iyVNXuBAUJTYQIEZYsg4b0AMU70HP36ghbv+e84X78k1fFdmtq1Dp6yZb6+StI6XFMlDaoPQ9U53pFkdAF6eXMlZKAapSIuu3beuGFYlozMjIuHyx6iSFGmI6dADllma1hltYPZ7RceS+FGNVVKWbTS38uvGKJ1tbMU9Xh14jSnDPxKxZiWwobB9kBXBpZCL4TB9Xe4ZF0zPCVUsTkDYQ3GqhzHwQqWiDAapiZz+ihR+IHo5+KUvx+71iN7F2HG5vL707KN7h2nA97KI3qLStoCrmX+ysxLWhHqoPM66I5NR2TfvU2MdVWA2m9sQmpYt/q9GXZdWFaw2CKrlyfDCy0/alfZ7SQgnFHh7EtiwGq44peKT5DTn49QWqKMcJrlugqa+qLq1GLk7mTkZKohXqtUbDGmLEIcuriEddtSH18Dcghl/rORXwaU4Ah6pfutdFcXwmPGPYxTZyxyRFY+ZJVDrVQFrWi5QxKvPR57PMEAqXpsaO1F3x3NId6oq4Be5pcIgGQ42uVO8JQ6ct1MZUGoqlXRT1VX1Qpsw8llb87+TZUsZt3YYU/a0tRftS1QJ+p25KMhFlHLYejZwFOk/wOaTZqC1WHVNQq/W0T7dEAynTAMSPLpj3aZ4D+ng5aLXTZsy93aQA3VSjzEbPdOAAnhKa6NFQy7a6meo+elPU9uBdnODcbalbu8ksORlmfDXB5wVf7HewcRAaAgypg6nZB6WecjMPV2e5j/3L3ZqkbxAxdRxQvK8ZFHkaNSBLmWOZ9FXqpXfI6vK8hxu4Gh5ot2O/zAaXI6+nkIaE97l4mAvLMDel9pP2Ef+2zEQZLRcfZQxKrwZdKTPnd5By1s6zmI1QxKpjCi3EJCBzSOPjCVUXPLoEOPk0MEYnHQebRgCqxRtAGd2nUZDEnEzWGUgAkRNXlagqVmyc8+kEpyFNjYMzvvDbsw7NwTAQmAR3i5J+e+YjRV4NsqqJKE9vhA3q0oHNZ9soQiBlssMuJlQdDJIbGfpkYHwzYhAEAPi03h6XTjzmlFwjt7QQJTU1Bl8hbZp0kvUJMfsSV9chFHWyry4gdT+yHvWyUKy3Bm51HdoAppZ89B5VtcgEbSyCxnhYI+rFsOqYgnaCpjTTHXlA6pfX478hv1eOR5dJNhys2nq+wTS6i3HNoK8r55/3qddi3qdhtQCSg0uBmAxFn7PGrIjnwqpPlajhignCmxxVJsSB1gy0aNKYuivK8ismdBmU3xtIJ4NDasOhHaWsEzGmQ20ISVyISAZATPtGsRyobhQDhGkLfbqpiM9JJAlXpKgv30EbmHbRFkBGqTk1BhDjCtgmK/Zz4dHJb6UWKxFQcnDyXZ/cw7Gt93WKTDTCa2nrUW/PQlh1TIHiKy+YU1ANgJqmXAcZQR3NGnUs4+h16XZhropAlDYgvwNVIxYQ7QcJnfKcuiHCQcQAAAmbSURBVEulFGUsDOzRMzAHw8gqz4rwUQQGCubEWAcVeT3iKlq2X+otQ2hDmbXBeNGQydvyqQ3BRtExiEv3EtjBz3TuU+GaIc6azIUrq/a3jZ6k0VP7qhsoZVGl4BF2zNfY9JE+zcvA56gUoDExuuonNifzP9sEVF3ZSrdDmgXKrv68l2oFg6EWcnVarDqmAKT+eu+QBJpw44parS/WYfS9cxVtOJR76LUDtZ4yOYrS4qN+z/IqKfCF9jskm3uawlyY+4EiPI+YGxZDW61WrPA6mds+tnkuMA27qYiJUoCYyMQhqmNvtYsVu9TJUTCj0m4TxHX4VKWxZ0WQqfULc2FCFCCkdEeUFKjGKNS4xmvb57oQQNpGD0sPoneK6AvSEPu3z4fzLOSdzLqUATETVqmehY8uAGyHSqh2zHVafNTDotKEqgk2JsKGOXv5HqhKEhY5TiEjIyPB6pQURPcHCgOerrbkuEBVXKeerdzSinPTvsg2pMeRk4PX5R7lyJovT0U/XUFrKFYo1V+ZOVoTt9pVZo0D1tVEZG+nK8dskAwoUvaJoZHt7HdFPesDQe/vB967viDw7Iniu/+ZBU63I22WlsQYKn9rVqIyjNilhka6Y4FC7eGBK5C6dAejGt2AaKSjVAcUEsdapDo0c3QCcUzMAZhqx2drqLC+Xz0YmOnqgEIqmIPEeKCQGjRWgIZHXa2d+R2o6vtqI7PRj/xbpSMLdRurBLWQtLDqmIJHeioyDVgadjvj4wtu+ahHA3GA6qSiuFZmUEYwEooIzhwLdVMPVQ5axmHqBkRtQNX9NIOq3qn0zaM4r2GtBwbDA5quYAwUd7lHgEFda1yhHvS5yDh7HDBUAzYEuX/dNqC2vnj41a8W380eBtCMtoo2ilOqVU3heZnqOrTttfEZ3P6tBrVew1Xnzb38O/GMhL91glmmq2OhhpBTwqexLQ2fprGn/UAZhKaX78SoXOhbO/G1DFUehS5YZAgaAMUyyoid+U37kuNQ40KUqXTCqmMKGqdAt6FanNsoJkS5woQVy7qOdDBzh5wO7n6jk/d2+L8GxKPHkf5PWiDPpn6owTO2TBkHIfVNemC8DayhzcOnOyl7UEQU/ku4eaQODNZTTwMH0kxYlnr/BPQMA60ZYOrN4ru5dnEga2+4b9pHdyEQ8zjoKdnsR2vkU4MlPRLJXg1TnsZJ9ocmleU9XH2VsVJaAFAmv9XDa5o+7a9JD5zxwEQoQ3cjkAZBcfu5Qt2A87464UmngkxD79XFQ8sr07Q2BCvNav3W5mDjJSxWHVOYu/JK/Pb977+kdZ4+fRpXXXXVJa3zUmJJ6RsCcOW7q+Jy7z/g8qGx0eX7hehbbFCSln/99de7/r7q8iksBW666aZFZ5NeCWT63j0udxqXk77sfcjIyEiQmUJGRkaC+sMPP/zwShPxj4Abb7xxpUlYEJm+d4/Lncbloi/bFDIyMhJk9SEjIyNBZgoZGRkJMlPogImJCezcuRNbtmzBzp07ce7cua5lz58/jw0bNuC+++67rOj74x//iI985CO44YYbsHXrVvzsZz9bcrp+85vf4IMf/CA2b97c8eCeRqOBL3zhC9i8eTO2bdu2oK98Jej77ne/iw996EPYunUrduzYgb/97W/LSt9iaCR+8YtfwDm3NG5Kn1HBAw884B999FHvvfePPvqof/DBB7uW/drXvua/+MUv+q9+9avLRd6i6HvllVf8X/7yF++99ydOnPBXX321P3fu3JLRND8/7zdt2uSPHj3qG42G37p1q//zn/+clPn+97/vv/KVr3jvvf/pT3/q77rrriWj553Q9/zzz/upqSnvvfdjY2PLSt9iafTe+/Pnz/uPfexjftu2bf7gwYOXnI4sKXTA/v37sXv3bgDA7t278ctf/rJjuZdffhmnTp3CJz7xieUkb1H0feADH8CWLVsAANdccw1GRkZw+vTpJaPppZdewubNm7Fp0yb09fXh7rvvxv79+7vSfeedd+K5556DXyY792Lo+/jHP46hoWLzxy233ILjx48vC21vh0YA2LNnDx588EEMDCyUafGdIzOFDjh16hRGR0cBAKOjo3jjjTcqZdrtNu6//3585zvfWW7yFkWf4qWXXkKz2cT111+/ZDSdOHEiOSF848aNOHHiRNcyPT09WLduHc6ePbtkNL1d+hRPPfUUPvWpTy0HaSUWQ+Phw4dx7NgxfOYzn1kyOlbd3ofF4vbbb8fJkycr3+/du3dR94+NjeGOO+5IXuKlxLuljxgfH8eXv/xl7Nu3D7Xa0q0BnVZ859zbLrNUeDvP/vGPf4xDhw7hhRdeWGqyElyMxna7ja9//et4+umnl5SOf1qm8Oyzz3b9bf369RgfH8fo6CjGx8cxMjJSKXPgwAG8+OKLGBsbw+TkJJrNJoaHhxd1MvZy0AcURtBPf/rTeOSRR3DLLbdcErq6YePGjTh27Fh5ffz4cVxzzTUdy2zcuBHz8/N46623cMUVVywpXW+HPqDo97179+KFF15Af39/5felxMVovHDhAo4cOYLbbrsNAHDy5Ens2rULv/rVr3DTTTddOkIuuZViFeAb3/hGYsh74IEHFiz/wx/+cFkNjYuhr9Fo+O3bt/vvfe97y0LT3Nycv+666/yrr75aGsmOHDmSlHn88ccTQ+PnP//5ZaFtsfT94Q9/8Js2bSoNtMuNxdCouPXWW5fE0JiZQgecOXPGb9++3W/evNlv377dnz171nvv/cGDB/0999xTKb/cTGEx9D3zzDO+p6fHf/jDHy4/hw8fXlK6fv3rX/stW7b4TZs2+UceecR77/2ePXv8/v37vffez8zM+DvvvNNff/31/uabb/ZHjx5dUnreLn07duzwIyMjZX999rOfXVb6FkOjYqmYQg5zzsjISJC9DxkZGQkyU8jIyEiQmUJGRkaCzBQyMjISZKaQkZGRIDOFjIyMBJkpZGRkJMhMIWPJcPDgQWzduhWzs7OYmprCDTfcgCNHjqw0WRkXQQ5eylhSfOtb38Ls7CxmZmawceNGfPOb31xpkjIugswUMpYUzWYTN998MwYGBvD73/8e9bo9OC3jckNWHzKWFBMTE5icnMSFCxcwOzu70uRkLAJZUshYUuzatQt33303XnvtNYyPj+Pxxx9faZIyLoJ/2nwKGUuPH/3oR+jp6cGXvvQltFotfPSjH8Xzzz+P7du3rzRpGQsgSwoZGRkJsk0hIyMjQWYKGRkZCTJTyMjISJCZQkZGRoLMFDIyMhJkppCRkZEgM4WMjIwE/w+CQgnl6sUcpgAAAABJRU5ErkJggg==' style='max-width:100%; margin: auto; display: block; '/></div>
 </div>
 
 </div>
@@ -12873,8 +14649,7 @@ raw.cell0.trial0(2,:) % raw signal from first neuropil subregion</code></pre>
 
 </div>
 <div class="cell border-box-sizing text_cell rendered"><div class="prompt input_prompt">
-</div>
-<div class="inner_cell">
+</div><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
 <h4 id="FISSA-settings">FISSA settings<a class="anchor-link" href="#FISSA-settings">&#182;</a></h4><p>FISSA has several user-definable settings, which can be set during the experiment definition.</p>
 
@@ -12886,37 +14661,40 @@ raw.cell0.trial0(2,:) % raw signal from first neuropil subregion</code></pre>
 <div class="prompt input_prompt">In&nbsp;[&nbsp;]:</div>
 <div class="inner_cell">
     <div class="input_area">
-<div class=" highlight hl-ipython2"><pre><span></span><span class="c1"># By default FISSA uses all the available processing threads. </span>
+<div class=" highlight hl-ipython3"><pre><span></span><span class="c1"># By default FISSA uses all the available processing threads. </span>
 <span class="c1"># This can, especially for the data preparation step, quickly fill up your memory. </span>
 <span class="c1"># Generally one only has to change the number of cores for the preparation steps, </span>
 <span class="c1"># as here it will load as many tiff stacks into memory as there are available processes.</span>
 <span class="c1"># The number of cores for the data preparation and separation steps can be changed as:</span>
 <span class="n">ncores_preparation</span> <span class="o">=</span> <span class="mi">4</span> <span class="c1"># If None, uses all available cores </span>
-<span class="n">ncores_separation</span> <span class="o">=</span> <span class="bp">None</span> <span class="c1"># if None, uses all available cores</span>
+<span class="n">ncores_separation</span> <span class="o">=</span> <span class="kc">None</span> <span class="c1"># if None, uses all available cores</span>
 
 <span class="c1"># FISSA uses 4 subregions for the neuropil region, which can be set to something else</span>
 <span class="n">nRegions</span> <span class="o">=</span> <span class="mi">4</span>
 
 <span class="c1"># Normally the area of each subregion is set the same as the central ROI</span>
-<span class="n">expansion</span> <span class="o">=</span> <span class="mi">1</span>
+<span class="n">expansion</span> <span class="o">=</span> <span class="mi">1</span> 
 
 <span class="c1"># The degree of signal sparsity can be controlled with the alpha parameter.</span>
 <span class="n">alpha</span> <span class="o">=</span> <span class="mf">0.1</span>
 
+<span class="c1"># The data-format can be set to &#39;npy&#39; (default) or None.</span>
+<span class="c1"># If None, no data will be saved.</span>
+<span class="n">data_format</span> <span class="o">=</span> <span class="s1">&#39;npy&#39;</span>
 <span class="n">experiment</span> <span class="o">=</span> <span class="n">fissa</span><span class="o">.</span><span class="n">Experiment</span><span class="p">(</span><span class="n">images_location</span><span class="p">,</span> <span class="n">rois_location</span><span class="p">,</span> <span class="n">output_folder</span><span class="p">,</span>
                               <span class="n">nRegions</span><span class="o">=</span><span class="n">nRegions</span><span class="p">,</span> <span class="n">expansion</span><span class="o">=</span><span class="n">expansion</span><span class="p">,</span><span class="n">alpha</span><span class="o">=</span><span class="n">alpha</span><span class="p">,</span>
-                              <span class="n">ncores_preparation</span><span class="o">=</span><span class="n">ncores_preparation</span><span class="p">,</span>
-                              <span class="n">ncores_separation</span><span class="o">=</span><span class="n">ncores_separation</span><span class="p">)</span>
+                              <span class="n">ncores_preparation</span><span class="o">=</span><span class="n">ncores_preparation</span><span class="p">,</span> 
+                              <span class="n">ncores_separation</span><span class="o">=</span><span class="n">ncores_separation</span><span class="p">,</span>
+                              <span class="n">data_format</span><span class="o">=</span><span class="n">data_format</span><span class="p">)</span>
 </pre></div>
 
-</div>
+    </div>
 </div>
 </div>
 
 </div>
 <div class="cell border-box-sizing text_cell rendered"><div class="prompt input_prompt">
-</div>
-<div class="inner_cell">
+</div><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
 <p>Alternatively, they can also be changed post experiment definition as follows.</p>
 
@@ -12928,19 +14706,18 @@ raw.cell0.trial0(2,:) % raw signal from first neuropil subregion</code></pre>
 <div class="prompt input_prompt">In&nbsp;[&nbsp;]:</div>
 <div class="inner_cell">
     <div class="input_area">
-<div class=" highlight hl-ipython2"><pre><span></span><span class="n">experiment</span><span class="o">.</span><span class="n">ncores_preparation</span> <span class="o">=</span> <span class="mi">4</span>
+<div class=" highlight hl-ipython3"><pre><span></span><span class="n">experiment</span><span class="o">.</span><span class="n">ncores_preparation</span> <span class="o">=</span> <span class="mi">4</span>
 <span class="n">experiment</span><span class="o">.</span><span class="n">alpha</span> <span class="o">=</span> <span class="mf">0.1</span>
 <span class="n">experiment</span><span class="o">.</span><span class="n">expansion</span> <span class="o">=</span> <span class="mi">1</span>
 </pre></div>
 
-</div>
+    </div>
 </div>
 </div>
 
 </div>
 <div class="cell border-box-sizing text_cell rendered"><div class="prompt input_prompt">
-</div>
-<div class="inner_cell">
+</div><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
 <h3 id="Large-tiff-files">Large tiff files<a class="anchor-link" href="#Large-tiff-files">&#182;</a></h3><p>By default, FISSA loads entire tiff files at once. This can sometimes be problematic if the tiff files are too large to comfortably load into memory. To avoid this a low memory mode exists which instead loads tiff files frame by frame.</p>
 
@@ -12952,17 +14729,16 @@ raw.cell0.trial0(2,:) % raw signal from first neuropil subregion</code></pre>
 <div class="prompt input_prompt">In&nbsp;[&nbsp;]:</div>
 <div class="inner_cell">
     <div class="input_area">
-<div class=" highlight hl-ipython2"><pre><span></span><span class="n">experiment</span> <span class="o">=</span> <span class="n">fissa</span><span class="o">.</span><span class="n">Experiment</span><span class="p">(</span><span class="n">images_location</span><span class="p">,</span> <span class="n">rois_location</span><span class="p">,</span> <span class="n">output_folder</span><span class="p">,</span> <span class="n">lowmemory_mode</span><span class="o">=</span><span class="bp">True</span><span class="p">)</span>
+<div class=" highlight hl-ipython3"><pre><span></span><span class="n">experiment</span> <span class="o">=</span> <span class="n">fissa</span><span class="o">.</span><span class="n">Experiment</span><span class="p">(</span><span class="n">images_location</span><span class="p">,</span> <span class="n">rois_location</span><span class="p">,</span> <span class="n">output_folder</span><span class="p">,</span> <span class="n">lowmemory_mode</span><span class="o">=</span><span class="kc">True</span><span class="p">)</span>
 </pre></div>
 
-</div>
+    </div>
 </div>
 </div>
 
 </div>
 <div class="cell border-box-sizing text_cell rendered"><div class="prompt input_prompt">
-</div>
-<div class="inner_cell">
+</div><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
 <h3 id="Handling-custom-formats">Handling custom formats<a class="anchor-link" href="#Handling-custom-formats">&#182;</a></h3><p>By default FISSA can use tiffs or Numpy arrays for imaging data, and Numpy arrays or ImageJ ROIs for ROIs. It is also possible to give FISSA a custom script to use for other custom and/or proprietary formats that might be used by labs. In this case, one has to define a python script like fissa.datahandler (which is used internally to handle all the data). As an example, see the datahandler_custom.py script in the examples folder (where this notebook is located).</p>
 
@@ -12974,13 +14750,13 @@ raw.cell0.trial0(2,:) % raw signal from first neuropil subregion</code></pre>
 <div class="prompt input_prompt">In&nbsp;[&nbsp;]:</div>
 <div class="inner_cell">
     <div class="input_area">
-<div class=" highlight hl-ipython2"><pre><span></span><span class="kn">import</span> <span class="nn">datahandler_custom</span>
+<div class=" highlight hl-ipython3"><pre><span></span><span class="kn">import</span> <span class="nn">datahandler_custom</span>
 
 <span class="n">experiment</span> <span class="o">=</span> <span class="n">fissa</span><span class="o">.</span><span class="n">Experiment</span><span class="p">(</span><span class="n">images_location</span><span class="p">,</span> <span class="n">rois_location</span><span class="p">,</span> <span class="n">output_folder</span><span class="p">,</span>
                               <span class="n">datahandler_custom</span><span class="o">=</span><span class="n">datahandler_custom</span><span class="p">)</span>
 </pre></div>
 
-</div>
+    </div>
 </div>
 </div>
 
@@ -12989,7 +14765,7 @@ raw.cell0.trial0(2,:) % raw signal from first neuropil subregion</code></pre>
   </div>
 </body>
 
-
+ 
 
 
 </html>

--- a/examples/Basic usage.ipynb
+++ b/examples/Basic usage.ipynb
@@ -227,6 +227,16 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "## Data storage\n",
+    "By default the ROIs, the extracted raw traces, and the neuropil decontaminated traces are all stored in the folder defined by the 'folder' option at experiment definition ('output_folder' in the above). The raw traces and ROIs are saved as 'folder/preperation.npy', and the decontaminated traces as 'folder/separated.npy'.\n",
+    "\n",
+    "With the data_format option (see 'FISSA settings' below) this behaviour can be changed."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Exporting to MATLAB\n",
     "The results can easily be exported to MATLAB as follows:"
    ]
@@ -338,10 +348,14 @@
     "# The degree of signal sparsity can be controlled with the alpha parameter.\n",
     "alpha = 0.1\n",
     "\n",
+    "# The data-format can be set to 'npy' (default) or None.\n",
+    "# If None, no data will be saved.\n",
+    "data_format = 'npy'\n",
     "experiment = fissa.Experiment(images_location, rois_location, output_folder,\n",
     "                              nRegions=nRegions, expansion=expansion,alpha=alpha,\n",
     "                              ncores_preparation=ncores_preparation, \n",
-    "                              ncores_separation=ncores_separation)"
+    "                              ncores_separation=ncores_separation,\n",
+    "                              data_format=data_format)"
    ]
   },
   {
@@ -402,21 +416,21 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 2",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "python2"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.15"
+   "pygments_lexer": "ipython3",
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,

--- a/fissa/core.py
+++ b/fissa/core.py
@@ -289,7 +289,7 @@ class Experiment():
             redo = True
         else:
             # define filename where data will be present
-            fname = self.folder + '/preparation.'+self.data_format
+            fname = os.path.join(self.folder, 'preparation.' + self.data_format)
 
             # try to load data from filename
             if not redo:

--- a/fissa/core.py
+++ b/fissa/core.py
@@ -380,18 +380,18 @@ class Experiment():
         self.separation_prep(redo_prep)
         if redo_prep:
             redo_sep = True
-        
+
         if self.data_format is None:
             redo_sep = True
         else:
             # Define filename to store data in
-            fname = self.folder + '/separated.'+self.data_format
-            if not redo_sep:
-                try:
-                    info, mixmat, sep, result = np.load(fname)
-                    print('Reloading previously separated data...')
-                except BaseException:
-                    redo_sep = True
+            fname = os.path.join(self.folder, 'separated.' + self.data_format)
+        if not redo_sep:
+            try:
+                info, mixmat, sep, result = np.load(fname)
+                print('Reloading previously separated data...')
+            except BaseException:
+                redo_sep = True
 
         # separate data, if necessary
         if redo_sep:

--- a/fissa/core.py
+++ b/fissa/core.py
@@ -244,14 +244,16 @@ class Experiment():
         self.data_format = data_format
         
         # check if any data already exists
-        if data_format is not None:
-            if not os.path.exists(folder):
-                os.makedirs(folder)
-            if os.path.isfile(folder + '/preparation.'+data_format):
-                if os.path.isfile(folder + '/separated.'+data_format):
-                    self.separate()
-                else:
-                    self.separation_prep()
+        if data_format is None:
+            pass
+        elif not os.path.exists(folder):
+            os.makedirs(folder)
+        elif not os.path.isfile(os.path.join(folder, 'preparation.' + data_format)):
+            pass
+        elif os.path.isfile(os.path.join(folder,  'separated.' + data_format)):
+            self.separate()
+        else:
+            self.separation_prep()
 
     def separation_prep(self, redo=False):
         """Prepare and extract the data to be separated.

--- a/fissa/core.py
+++ b/fissa/core.py
@@ -553,6 +553,10 @@ class Experiment():
         - `raw.cell0.trial0(1,:)` raw measured celll signal
         - `raw.cell0.trial0(2,:)` raw signal from first neuropil region
         """
+        # check if folder exists
+        if not os.path.exists(self.folder):
+            os.makedirs(self.folder)
+
         # define filename
         fname = self.folder + '/matlab.mat'
 

--- a/fissa/core.py
+++ b/fissa/core.py
@@ -225,7 +225,7 @@ class Experiment():
             from . import datahandler_framebyframe as datahandler
         if datahandler_custom is not None:
             datahandler = datahandler_custom
-        if not data_format in ['npy', None]:
+        if data_format not in {'npy', None}:
             raise ValueError("Only 'npy' or None are supported.")
 
         # define class variables


### PR DESCRIPTION
When defining an experiment it is now possible to define the format in which data is saved with the data_format option. At the moment this can only be `'npy'` or `None`. If it is `'npy'`, the behavior will be as before. If it is set to `None`, no data will be saved. This is useful for users that don't need to store any of the data directly on the hard drive, and just want to define how and where to use the data in their own workflows. 

I have also laid the basic groundwork for other formats than npy, and am working on saving everything in hdf5 files. 

Note that there is currently a bug with our use of numpy.load, see #85.