### PR TITLE
REL: Specify conditional maximum tifffile, imageio version requirements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -93,9 +93,12 @@ before_install:
   # ---------------------------------------------------------------------------
   # If we want to run the tests using the oldest set of dependencies we
   # support, modify any *requirements*.txt files every '>=' becomes '=='.
+  # Undo swapping any requirements which say version>=, since they are for
+  # our environment markers.
   - if [[ "$USE_OLDEST_DEPS" == "true" ]]; then
       for FILE in *requirements*.txt; do
           sed -e 's/>=/~=/g' $FILE > $FILE.tmp && mv $FILE.tmp $FILE;
+          sed -e 's/version\s*~=/version>=/g' $FILE > $FILE.tmp && mv $FILE.tmp $FILE;
       done;
     fi;
   # ---------------------------------------------------------------------------

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
 pytest
 pytest-cov
 pytest-flake8
-imageio
+imageio>=2.5.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,5 @@
 pytest
 pytest-cov
 pytest-flake8
-imageio>=2.5.0
+imageio>=2.5.0; python_version>='3'
+imageio>=2.5.0, <2.8.0; python_version<'3'

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,6 @@ future>=0.16.0
 scikit-learn>=0.17.0
 scikit-image>=0.12.3
 shapely>=1.5.17
-tifffile>=0.10.0
+tifffile>=0.10.0; python_version>='3.6'
+tifffile>=0.10.0,<=2019.7.26; python_version<'3.6'
 Pillow>=3.0.0


### PR DESCRIPTION
In its latest release, our dependency tifffile dropped support for Python 2.7 and 3.5, and our unit testing dependency imageio dropped support for Python 2.7.

This was causing problems (and breaking our unit tests on Travis) because pip fails when it tries to install the latest version of these dependencies on the old Python versions. When it goes to install them, it sees that the Python version isn't supported but for some reason doesn't go and find an older version of the package which supports that Python version.

To resolve this, we manually introduce maximum version numbers for these dependencies, which are conditional on the Python version being below a certain version, using [environment markers](https://www.python.org/dev/peps/pep-0508/#environment-markers).