### PR TITLE
Update release documentation

### DIFF
--- a/HOWTO_RELEASE.md
+++ b/HOWTO_RELEASE.md
@@ -146,7 +146,7 @@ Follow the instructions in the [PyPI tutorial](https://packaging.python.org/tuto
 rm -rf dist
 python -m pip install --upgrade setuptools wheel
 python -m pip install --upgrade twine
-python setup.py sdist bdist_wheel
+python setup.py sdist bdist_wheel --universal
 ```
 
 ## 6. Test the submission


### PR DESCRIPTION
To generate python 2.7 wheel, you need to explicitly tell setup.py that the code is universal with the `--universal` flag for `bdist_wheel`. Otherwise you'll make a wheel which only claims to support python 3, when we actually also support python 2.7.