### PR TITLE
BUG+RF: Int OverFlow on Windows resolved on Py3, utilising read_roi

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ shapely>=1.5.17
 tifffile>=0.10.0; python_version>='3.6'
 tifffile>=0.10.0,<=2019.7.26; python_version<'3.6'
 Pillow>=3.0.0
+read-roi>=1.5.0; python_version>='3.0'


### PR DESCRIPTION
Resolves the issue/error:
```
  File "C:\projects\fissa\fissa\readimagejrois.py", line 129, in _getfloat
    v = np.int32(_get32())
OverflowError: Python int too large to convert to C long
```
which was seen when trying to run the code on Windows with
AppVeyor, on a freshly compiled from source copy of FISSA instead
of using the pre-compiled version on conda-forge.

This is fixed by using the imagej roi reader from the package
read_roi. However, their implementation only works for Python 3
and not on Python 2.7. Therefore, we use theirs on Python 3 and
our old method on Python 2.7.