### PR TITLE
DOC: Amend folder listing in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -183,6 +183,19 @@ interactive python session with the ``exit()`` command, or CTRL+D.
 Folder Structure
 ----------------
 
+A clone of this repository will contain directories detailed below.
+
+docs/
+~~~~~
+
+Contains the source for the documentation, which is available online at
+`<https://fissa.readthedocs.io>`_.
+You can build a local copy of the documentation by running the command
+
+::
+
+    make -C docs html
+
 examples/
 ~~~~~~~~~
 

--- a/README.rst
+++ b/README.rst
@@ -183,12 +183,6 @@ interactive python session with the ``exit()`` command, or CTRL+D.
 Folder Structure
 ----------------
 
-continuous_integration/
-~~~~~~~~~~~~~~~~~~~~~~~
-
-Contains files necessary for deploying tests on continuous integration
-servers. Users should ignore this directory.
-
 examples/
 ~~~~~~~~~
 
@@ -214,6 +208,12 @@ fissa/tests/
 
 Contains tests for the toolbox, which are run to ensure it will work as
 expected.
+
+.ci/
+~~~~
+
+Contains files necessary for deploying tests on continuous integration
+servers. Users should ignore this directory.
 
 Citing FISSA
 ------------


### PR DESCRIPTION
- Fix reference to `continuous_integration` directory, which was moved to `.ci`.
- Describe docs directory, and how to build a local copy of the documentation.
- Add note that this is for if you clone the repo, so people don't expect to get this when they pip install it.