### PR TITLE
REL: Add past to requirements if python>=3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 numpy>=1.12.0
 scipy>=0.19.0
 future>=0.16.0
+past>=0.11.1; python_version>='3'
 scikit-learn>=0.17.0
 scikit-image>=0.12.3
 shapely>=1.5.17


### PR DESCRIPTION
We removed this because it wasn't available on Python 2.7 and so
that was causing problems on Python 2.7. But we were actually
getting by because some of our dependencies happen require the
`past` package for their Python 3 implementations.

This uses the correct solution - requiring `past` conditional
on the Python version being >=3.