### PR TITLE
DOC: Change pypi badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -253,7 +253,7 @@ with this program. If not, see http://www.gnu.org/licenses/.
    :target: https://gitter.im/rochefort-lab/fissa
    :alt: Join the FISSA chat
 .. |PyPI badge| image:: https://badge.fury.io/py/fissa.svg
-   :target: https://badge.fury.io/py/fissa
+   :target: https://pypi.org/project/fissa
    :alt: Latest PyPI release
 .. |Travis| image:: https://travis-ci.org/rochefort-lab/fissa.svg?branch=master
    :target: https://travis-ci.org/rochefort-lab/fissa

--- a/README.rst
+++ b/README.rst
@@ -252,7 +252,7 @@ with this program. If not, see http://www.gnu.org/licenses/.
 .. |Gitter| image:: https://badges.gitter.im/Join%20Chat.svg
    :target: https://gitter.im/rochefort-lab/fissa
    :alt: Join the FISSA chat
-.. |PyPI badge| image:: https://badge.fury.io/py/fissa.svg
+.. |PyPI badge| image:: https://img.shields.io/pypi/v/fissa.svg
    :target: https://pypi.org/project/fissa
    :alt: Latest PyPI release
 .. |Travis| image:: https://travis-ci.org/rochefort-lab/fissa.svg?branch=master


### PR DESCRIPTION
- Change the PyPI badge URL to link straight to PyPI page instead of (broken) redirect through badge fury's domain.
- Change to using the official PyPI badge image instead of badge fury's image.