### PR TITLE
TST: Test rois2masks unsupported arguments

### DIFF
--- a/fissa/datahandler.py
+++ b/fissa/datahandler.py
@@ -83,7 +83,7 @@ def rois2masks(rois, data):
         rois = roitools.readrois(rois)
 
     if not isinstance(rois, collections.Sequence):
-        raise ValueError(
+        raise TypeError(
             'Wrong ROIs input format: expected a list or sequence, but got'
             ' a {}'.format(rois.__class__)
         )

--- a/fissa/datahandler_framebyframe.py
+++ b/fissa/datahandler_framebyframe.py
@@ -96,7 +96,7 @@ def rois2masks(rois, data):
         rois = roitools.readrois(rois)
 
     if not isinstance(rois, collections.Sequence):
-        raise ValueError(
+        raise TypeError(
             'Wrong ROIs input format: expected a list or sequence, but got'
             ' a {}'.format(rois.__class__)
         )

--- a/fissa/tests/test_datahandler.py
+++ b/fissa/tests/test_datahandler.py
@@ -58,6 +58,12 @@ class TestRois2Masks(BaseTestCase):
         # assert equality
         self.assert_equal(actual, self.expected)
 
+    def test_transposed_polys(self):
+        # load from array
+        actual = datahandler.rois2masks([x.T for x in self.polys], self.data)
+        # assert equality
+        self.assert_equal(actual, self.expected)
+
     def test_masks(self):
         # load from masks
         actual = datahandler.rois2masks(self.expected, self.data)

--- a/fissa/tests/test_datahandler.py
+++ b/fissa/tests/test_datahandler.py
@@ -64,3 +64,25 @@ class TestRois2Masks(BaseTestCase):
 
         # assert equality
         self.assert_equal(actual, self.expected)
+
+    def test_rois_not_list(self):
+        # check that rois2masks fails when the rois are not a list
+        with self.assertRaises(TypeError):
+            datahandler.rois2masks({}, self.data)
+        with self.assertRaises(TypeError):
+            datahandler.rois2masks(self.polys[0], self.data)
+
+    def test_polys_not_2d(self):
+        # check that rois2masks fails when the polys are not 2d
+        polys1d = [
+            np.array([[39.,]]),
+            np.array([[72.,]]),
+        ]
+        with self.assertRaises(ValueError):
+            datahandler.rois2masks(polys1d, self.data)
+        polys3d = [
+            np.array([[39., 62., 0.], [60., 45., 0.], [48., 71., 0.]]),
+            np.array([[72., 107., 0.], [78., 130., 0.], [100., 110., 0.]]),
+        ]
+        with self.assertRaises(ValueError):
+            datahandler.rois2masks(polys3d, self.data)

--- a/fissa/tests/test_datahandler.py
+++ b/fissa/tests/test_datahandler.py
@@ -37,8 +37,7 @@ class TestImage2Array(BaseTestCase):
 
 
 class TestRois2Masks(BaseTestCase):
-    ''' Tests for rois2array
-    '''
+    '''Tests for rois2masks.'''
     def setup_class(self):
         self.polys = [np.array([[39., 62.], [60., 45.], [48., 71.]]),
                       np.array([[72., 107.], [78., 130.], [100., 110.]])]

--- a/fissa/tests/test_datahandler_framebyframe.py
+++ b/fissa/tests/test_datahandler_framebyframe.py
@@ -54,6 +54,12 @@ class TestRois2Masks(BaseTestCase):
         # assert equality
         self.assert_equal(actual, self.expected)
 
+    def test_transposed_polys(self):
+        # load from array
+        actual = datahandler.rois2masks([x.T for x in self.polys], self.data)
+        # assert equality
+        self.assert_equal(actual, self.expected)
+
     def test_masks(self):
         # load from masks
         actual = datahandler.rois2masks(self.expected, self.data)

--- a/fissa/tests/test_datahandler_framebyframe.py
+++ b/fissa/tests/test_datahandler_framebyframe.py
@@ -33,8 +33,7 @@ class TestImage2Array(BaseTestCase):
 
 
 class TestRois2Masks(BaseTestCase):
-    ''' Tests for rois2array
-    '''
+    '''Tests for rois2masks.'''
     def setup_class(self):
         self.polys = [np.array([[39., 62.], [60., 45.], [48., 71.]]),
                       np.array([[72., 107.], [78., 130.], [100., 110.]])]

--- a/fissa/tests/test_datahandler_framebyframe.py
+++ b/fissa/tests/test_datahandler_framebyframe.py
@@ -60,3 +60,25 @@ class TestRois2Masks(BaseTestCase):
 
         # assert equality
         self.assert_equal(actual, self.expected)
+
+    def test_rois_not_list(self):
+        # check that rois2masks fails when the rois are not a list
+        with self.assertRaises(TypeError):
+            datahandler.rois2masks({}, self.data)
+        with self.assertRaises(TypeError):
+            datahandler.rois2masks(self.polys[0], self.data)
+
+    def test_polys_not_2d(self):
+        # check that rois2masks fails when the polys are not 2d
+        polys1d = [
+            np.array([[39.,]]),
+            np.array([[72.,]]),
+        ]
+        with self.assertRaises(ValueError):
+            datahandler.rois2masks(polys1d, self.data)
+        polys3d = [
+            np.array([[39., 62., 0.], [60., 45., 0.], [48., 71., 0.]]),
+            np.array([[72., 107., 0.], [78., 130., 0.], [100., 110., 0.]]),
+        ]
+        with self.assertRaises(ValueError):
+            datahandler.rois2masks(polys3d, self.data)


### PR DESCRIPTION
- Change rois2masks to generate a TypeError instead of ValueError when the wrong type of input is given
- Test that errors are raised when the wrong arguments are given
- Also test with polygons which are transposed