### PR TITLE
[WIP] RF: Move rois2masks from datahandler to roitools

### DIFF
--- a/examples/datahandler_custom.py
+++ b/examples/datahandler_custom.py
@@ -56,42 +56,6 @@ def getmean(data):
     return data.mean(axis=0)
 
 
-def rois2masks(rois, data):
-    """Take the object 'rois' and returns it as a list of binary masks.
-
-    Parameters
-    ----------
-    rois : unkown
-        Either a string with imagej roi zip location, list of arrays encoding
-        polygons, or binary arrays representing masks
-    data : array
-        Data array as made by image2array. Should be of shape [frames,y,x]
-
-    Returns
-    -------
-    list
-        List of binary arrays (i.e. masks)
-
-    """
-    # get the image shape
-    shape = data.shape[1:]
-
-    # if it's a list of strings
-    if isinstance(rois, basestring):
-        rois = roitools.readrois(rois)
-    if isinstance(rois, list):
-        # if it's a something by 2 array (or vice versa), assume polygons
-        if np.shape(rois[0])[1] == 2 or np.shape(rois[0])[0] == 2:
-            return roitools.getmasks(rois, shape)
-        # if it's a list of bigger arrays, assume masks
-        elif np.shape(rois[0]) == shape:
-            return rois
-
-    else:
-        raise ValueError('Wrong rois input format')
-
-
-
 def extracttraces(data, masks):
     """Get the traces for each mask in masks from data.
 

--- a/fissa/core.py
+++ b/fissa/core.py
@@ -59,7 +59,7 @@ def extract_func(inputs):
 
     # get data as arrays and rois as masks
     curdata = datahandler.image2array(image)
-    base_masks = datahandler.rois2masks(rois, curdata)
+    base_masks = roitools.rois2masks(rois, curdata)
 
     # get the mean image
     mean = datahandler.getmean(curdata)

--- a/fissa/datahandler.py
+++ b/fissa/datahandler.py
@@ -58,46 +58,6 @@ def getmean(data):
     return data.mean(axis=0)
 
 
-def rois2masks(rois, data):
-    """Take the object `rois` and returns it as a list of binary masks.
-
-    Parameters
-    ----------
-    rois : string or list of array_like
-        Either a string with imagej roi zip location, list of arrays encoding
-        polygons, or list of binary arrays representing masks
-    data : array
-        Data array as made by image2array. Must be shaped `(frames, y, x)`.
-
-    Returns
-    -------
-    list
-        List of binary arrays (i.e. masks)
-
-    """
-    # get the image shape
-    shape = data.shape[1:]
-
-    # if it's a list of strings
-    if isinstance(rois, basestring):
-        rois = roitools.readrois(rois)
-
-    if not isinstance(rois, collections.Sequence):
-        raise TypeError(
-            'Wrong ROIs input format: expected a list or sequence, but got'
-            ' a {}'.format(rois.__class__)
-        )
-
-    # if it's a something by 2 array (or vice versa), assume polygons
-    if np.shape(rois[0])[1] == 2 or np.shape(rois[0])[0] == 2:
-        return roitools.getmasks(rois, shape)
-    # if it's a list of bigger arrays, assume masks
-    elif np.shape(rois[0]) == shape:
-        return rois
-
-    raise ValueError('Wrong ROIs input format: unfamiliar shape.')
-
-
 def extracttraces(data, masks):
     """Extracts a temporal trace for each spatial mask.
 
@@ -128,3 +88,7 @@ def extracttraces(data, masks):
         out[i, :] = data[:, masks[i]].mean(axis=1)
 
     return out
+
+
+# backward compatability
+rois2masks = roitools.rois2masks

--- a/fissa/datahandler_framebyframe.py
+++ b/fissa/datahandler_framebyframe.py
@@ -71,46 +71,6 @@ def getmean(data):
     return avg
 
 
-def rois2masks(rois, data):
-    """Take the object 'rois' and returns it as a list of binary masks.
-
-    Parameters
-    ----------
-    rois : str or list of array_like
-        Either a string with imagej roi zip location, list of arrays encoding
-        polygons, or list of binary arrays representing masks
-    data : PIL.Image
-        An open PIL.Image handle to a multi-frame TIFF image.
-
-    Returns
-    -------
-    list
-        List of binary arrays (i.e. masks).
-
-    """
-    # get the image shape
-    shape = data.size[::-1]
-
-    # If rois is string, we first need to read the contents of the file
-    if isinstance(rois, basestring):
-        rois = roitools.readrois(rois)
-
-    if not isinstance(rois, collections.Sequence):
-        raise TypeError(
-            'Wrong ROIs input format: expected a list or sequence, but got'
-            ' a {}'.format(rois.__class__)
-        )
-
-    # if it's a something by 2 array (or vice versa), assume polygons
-    if np.shape(rois[0])[1] == 2 or np.shape(rois[0])[0] == 2:
-        return roitools.getmasks(rois, shape)
-    # if it's a list of bigger arrays, assume masks
-    elif np.shape(rois[0]) == shape:
-        return rois
-
-    raise ValueError('Wrong ROIs input format: unfamiliar shape.')
-
-
 def extracttraces(data, masks):
     """Get the traces for each mask in masks from data.
 
@@ -151,3 +111,7 @@ def extracttraces(data, masks):
             out[i, f] = np.mean(curframe[masks[i]])
 
     return out
+
+
+# backward compatability
+rois2masks = roitools.rois2masks

--- a/fissa/roitools.py
+++ b/fissa/roitools.py
@@ -5,6 +5,7 @@ Authors:
 '''
 
 from __future__ import division
+from past.builtins import basestring
 
 from builtins import range
 
@@ -434,3 +435,43 @@ def find_roi_edge(mask):
         outline[i] -= 0.5
 
     return outline
+
+
+def rois2masks(rois, data):
+    """Take the object `rois` and returns it as a list of binary masks.
+
+    Parameters
+    ----------
+    rois : string or list of array_like
+        Either a string with imagej roi zip location, list of arrays encoding
+        polygons, or list of binary arrays representing masks
+    data : array
+        Data array as made by image2array. Must be shaped `(frames, y, x)`.
+
+    Returns
+    -------
+    list
+        List of binary arrays (i.e. masks)
+
+    """
+    # get the image shape
+    shape = data.shape[1:]
+
+    # if it's a list of strings
+    if isinstance(rois, basestring):
+        rois = roitools.readrois(rois)
+
+    if not isinstance(rois, collections.Sequence):
+        raise TypeError(
+            'Wrong ROIs input format: expected a list or sequence, but got'
+            ' a {}'.format(rois.__class__)
+        )
+
+    # if it's a something by 2 array (or vice versa), assume polygons
+    if np.shape(rois[0])[1] == 2 or np.shape(rois[0])[0] == 2:
+        return getmasks(rois, shape)
+    # if it's a list of bigger arrays, assume masks
+    elif np.shape(rois[0]) == shape:
+        return rois
+
+    raise ValueError('Wrong ROIs input format: unfamiliar shape.')

--- a/fissa/tests/test_datahandler.py
+++ b/fissa/tests/test_datahandler.py
@@ -8,7 +8,6 @@ import tifffile
 
 from .base_test import BaseTestCase
 from .. import datahandler
-from .. import roitools
 
 
 class TestImage2Array(BaseTestCase):
@@ -34,61 +33,3 @@ class TestImage2Array(BaseTestCase):
         actual = datahandler.image2array(self.expected)
         # assert equality
         self.assert_equal(actual, self.expected)
-
-
-class TestRois2Masks(BaseTestCase):
-    '''Tests for rois2masks.'''
-    def setup_class(self):
-        self.polys = [np.array([[39., 62.], [60., 45.], [48., 71.]]),
-                      np.array([[72., 107.], [78., 130.], [100., 110.]])]
-        self.expected = roitools.getmasks(self.polys, (176, 156))
-        self.data = np.zeros((1, 176, 156))
-
-    def test_imagej_zip(self):
-        # load zip of rois
-        ROI_loc = 'fissa/tests/resources/RoiSet.zip'
-        actual = datahandler.rois2masks(ROI_loc, self.data)
-
-        # assert equality
-        self.assert_equal(actual, self.expected)
-
-    def test_arrays(self):
-        # load from array
-        actual = datahandler.rois2masks(self.polys, self.data)
-        # assert equality
-        self.assert_equal(actual, self.expected)
-
-    def test_transposed_polys(self):
-        # load from array
-        actual = datahandler.rois2masks([x.T for x in self.polys], self.data)
-        # assert equality
-        self.assert_equal(actual, self.expected)
-
-    def test_masks(self):
-        # load from masks
-        actual = datahandler.rois2masks(self.expected, self.data)
-
-        # assert equality
-        self.assert_equal(actual, self.expected)
-
-    def test_rois_not_list(self):
-        # check that rois2masks fails when the rois are not a list
-        with self.assertRaises(TypeError):
-            datahandler.rois2masks({}, self.data)
-        with self.assertRaises(TypeError):
-            datahandler.rois2masks(self.polys[0], self.data)
-
-    def test_polys_not_2d(self):
-        # check that rois2masks fails when the polys are not 2d
-        polys1d = [
-            np.array([[39.,]]),
-            np.array([[72.,]]),
-        ]
-        with self.assertRaises(ValueError):
-            datahandler.rois2masks(polys1d, self.data)
-        polys3d = [
-            np.array([[39., 62., 0.], [60., 45., 0.], [48., 71., 0.]]),
-            np.array([[72., 107., 0.], [78., 130., 0.], [100., 110., 0.]]),
-        ]
-        with self.assertRaises(ValueError):
-            datahandler.rois2masks(polys3d, self.data)

--- a/fissa/tests/test_datahandler_framebyframe.py
+++ b/fissa/tests/test_datahandler_framebyframe.py
@@ -9,7 +9,6 @@ from PIL import Image
 
 from .base_test import BaseTestCase
 from .. import datahandler_framebyframe as datahandler
-from .. import roitools
 
 
 class TestImage2Array(BaseTestCase):
@@ -30,61 +29,3 @@ class TestImage2Array(BaseTestCase):
     def teardown_class(self):
         # remove tif
         os.remove('test.tif')
-
-
-class TestRois2Masks(BaseTestCase):
-    '''Tests for rois2masks.'''
-    def setup_class(self):
-        self.polys = [np.array([[39., 62.], [60., 45.], [48., 71.]]),
-                      np.array([[72., 107.], [78., 130.], [100., 110.]])]
-        self.expected = roitools.getmasks(self.polys, (176, 156))
-        self.data = Image.fromarray(np.zeros((176, 156), dtype=np.uint8))
-
-    def test_imagej_zip(self):
-        # load zip of rois
-        ROI_loc = 'fissa/tests/resources/RoiSet.zip'
-        actual = datahandler.rois2masks(ROI_loc, self.data)
-
-        # assert equality
-        self.assert_equal(actual, self.expected)
-
-    def test_arrays(self):
-        # load from array
-        actual = datahandler.rois2masks(self.polys, self.data)
-        # assert equality
-        self.assert_equal(actual, self.expected)
-
-    def test_transposed_polys(self):
-        # load from array
-        actual = datahandler.rois2masks([x.T for x in self.polys], self.data)
-        # assert equality
-        self.assert_equal(actual, self.expected)
-
-    def test_masks(self):
-        # load from masks
-        actual = datahandler.rois2masks(self.expected, self.data)
-
-        # assert equality
-        self.assert_equal(actual, self.expected)
-
-    def test_rois_not_list(self):
-        # check that rois2masks fails when the rois are not a list
-        with self.assertRaises(TypeError):
-            datahandler.rois2masks({}, self.data)
-        with self.assertRaises(TypeError):
-            datahandler.rois2masks(self.polys[0], self.data)
-
-    def test_polys_not_2d(self):
-        # check that rois2masks fails when the polys are not 2d
-        polys1d = [
-            np.array([[39.,]]),
-            np.array([[72.,]]),
-        ]
-        with self.assertRaises(ValueError):
-            datahandler.rois2masks(polys1d, self.data)
-        polys3d = [
-            np.array([[39., 62., 0.], [60., 45., 0.], [48., 71., 0.]]),
-            np.array([[72., 107., 0.], [78., 130., 0.], [100., 110., 0.]]),
-        ]
-        with self.assertRaises(ValueError):
-            datahandler.rois2masks(polys3d, self.data)

--- a/fissa/tests/test_roitools.py
+++ b/fissa/tests/test_roitools.py
@@ -318,3 +318,60 @@ class TestGetNpilMask(BaseTestCase):
         for area in [5, 6, 7, 8]:
             actual = roitools.get_npil_mask(mask, area)
             self.assert_equal(actual, desired)
+
+class TestRois2Masks(BaseTestCase):
+    '''Tests for rois2masks.'''
+    def setup_class(self):
+        self.polys = [np.array([[39., 62.], [60., 45.], [48., 71.]]),
+                      np.array([[72., 107.], [78., 130.], [100., 110.]])]
+        self.expected = roitools.getmasks(self.polys, (176, 156))
+        self.data = np.zeros((1, 176, 156))
+
+    def test_imagej_zip(self):
+        # load zip of rois
+        ROI_loc = 'fissa/tests/resources/RoiSet.zip'
+        actual = roitools.rois2masks(ROI_loc, self.data)
+
+        # assert equality
+        self.assert_equal(actual, self.expected)
+
+    def test_arrays(self):
+        # load from array
+        actual = roitools.rois2masks(self.polys, self.data)
+        # assert equality
+        self.assert_equal(actual, self.expected)
+
+    def test_transposed_polys(self):
+        # load from array
+        actual = roitools.rois2masks([x.T for x in self.polys], self.data)
+        # assert equality
+        self.assert_equal(actual, self.expected)
+
+    def test_masks(self):
+        # load from masks
+        actual = roitools.rois2masks(self.expected, self.data)
+
+        # assert equality
+        self.assert_equal(actual, self.expected)
+
+    def test_rois_not_list(self):
+        # check that rois2masks fails when the rois are not a list
+        with self.assertRaises(TypeError):
+            roitools.rois2masks({}, self.data)
+        with self.assertRaises(TypeError):
+            roitools.rois2masks(self.polys[0], self.data)
+
+    def test_polys_not_2d(self):
+        # check that rois2masks fails when the polys are not 2d
+        polys1d = [
+            np.array([[39.,]]),
+            np.array([[72.,]]),
+        ]
+        with self.assertRaises(ValueError):
+            roitools.rois2masks(polys1d, self.data)
+        polys3d = [
+            np.array([[39., 62., 0.], [60., 45., 0.], [48., 71., 0.]]),
+            np.array([[72., 107., 0.], [78., 130., 0.], [100., 110., 0.]]),
+        ]
+        with self.assertRaises(ValueError):
+            roitools.rois2masks(polys3d, self.data)


### PR DESCRIPTION
It is a tool for manipulating rois! I don't know why it isn't in datahandler already. This simplifies things because we don't need to repeat rois2masks in the framebyframe version of datahandler.