### PR TITLE
DEPS: Maximum version of panel needed on Python 3.5

### DIFF
--- a/.ci/test_notebooks.sh
+++ b/.ci/test_notebooks.sh
@@ -125,7 +125,7 @@ do
         echo "[TESTNB] Converting notebook '$NBFILE' into a script";
         echo "------------------------------------------------------------------";
     fi;
-    CONVERT_OUTPUT=$(jupyter nbconvert --to=script "$NBFILE");
+    CONVERT_OUTPUT=$(python -m jupyter nbconvert --to=script "$NBFILE");
     CONVERT_STATUS=$?;
     if [ $CONVERT_STATUS -ne 0 ]; then
         RETURNVALUE=$((RETURNVALUE + 1));
@@ -146,7 +146,7 @@ do
         echo "[TESTNB] Trying to run the generated script '$PYFILE'";
         echo "------------------------------------------------------------------";
     fi
-    NB_OUTPUT=$(ipython "$PYFILE")
+    NB_OUTPUT=$(python -m IPython "$PYFILE")
     NB_STATUS=$?;
     if [ $NB_STATUS -ne 0 ]; then
         RETURNVALUE=$((RETURNVALUE + 1));

--- a/.travis.yml
+++ b/.travis.yml
@@ -204,9 +204,9 @@ install:
   # Conditionally install the packages which are needed for plotting
   # Also, tell matplotlib to use the agg backend and not X server
   - if [[ "$TEST_NOTEBOOKS" == "true" ]]; then
+      export MPLBACKEND="agg";
       pip install -r requirements_plots.txt;
       pip install sima;
-      export MPLBACKEND="agg";
     fi
   # ---------------------------------------------------------------------------
   # Install our package

--- a/.travis.yml
+++ b/.travis.yml
@@ -179,6 +179,8 @@ before_install:
   #
   # Activate the test environment
   - source activate test-environment
+  # Reset the cache of paths to executables, for executables inside the env
+  - hash -r
 
 ###############################################################################
 # install requirements

--- a/.travis.yml
+++ b/.travis.yml
@@ -218,6 +218,7 @@ before_script:
   - conda info -a
   - which python
   - python --version
+  - which ipython || echo "No ipython found"
   - conda env export > environment.yml && cat environment.yml
   - pip freeze
   # ---------------------------------------------------------------------------

--- a/requirements_plots.txt
+++ b/requirements_plots.txt
@@ -2,3 +2,4 @@ ipython>=4.1.0
 jupyter>=1.00
 matplotlib>=2.0.2
 holoviews>=1.8.2
+panel<0.9.0; python_version<'3.6'

--- a/requirements_plots.txt
+++ b/requirements_plots.txt
@@ -1,4 +1,4 @@
 ipython>=4.1.0
+jupyter>=1.00
 matplotlib>=2.0.2
 holoviews>=1.8.2
-jupyter>=1.00


### PR DESCRIPTION
Add a minimum panel version on Python 3.5, fixing a problem with the holoviews requirements chain.

This problem is because holoviews requires panel, and panel requires bokeh. Bokeh had a big 2.0.0 release which dropped support for Python 3.5, and panel moved to the new bokeh api in panel 0.9.0 but didn't specify it no longer supported Python 3.5 until panel 0.9.4. This means installations on Python 3.5 try to install panel 0.9.3, and then find the requirement bokeh>=2.0.0 cannot be satisfied. We fix this by enforcing panel<0.9.0 if python<3.6.

Update some CI settings as well, which I changed to debug this problem but were not necessary to resolve it.