### PR TITLE
BUG: Allow first diagonal expansion based on initial mask

### DIFF
--- a/fissa/roitools.py
+++ b/fissa/roitools.py
@@ -262,15 +262,14 @@ def get_npil_mask(mask, totalexpansion=4):
                     movedmask = shift_2d_array(movedmask, dy, 1)
                     grown_mask[movedmask] = True
 
-        # Don't expand based on the original mask; any expansion into
-        # this region is marked as False once more.
-        grown_mask[mask] = False
-
         # update area
-        area_current = grown_mask.sum()
+        area_current = grown_mask.sum() - area_orig
 
         # iterate counter
         count += 1
+
+    # Remove original mask from the neuropil mask
+    grown_mask[mask] = False
 
     # Return the finished neuropil mask
     return grown_mask

--- a/fissa/tests/test_roitools.py
+++ b/fissa/tests/test_roitools.py
@@ -226,7 +226,6 @@ class TestGetNpilMask(BaseTestCase):
 
     '''Tests for get_npil_mask.'''
 
-    @unittest.expectedFailure
     def test_empty(self):
         mask = [
             [True, False, False],
@@ -259,7 +258,6 @@ class TestGetNpilMask(BaseTestCase):
         actual = roitools.get_npil_mask(mask, 1000)
         self.assert_equal(actual, desired)
 
-    @unittest.expectedFailure
     def test_corner(self):
         mask = [
             [True, False, False],


### PR DESCRIPTION
If we remove the original mask from the grown mask after the first expansion step, we can't use it to grow the first diagonals which is problematic because it leaves checkerboard patterned holes in the npil mask. 

This changes the output of FISSA (not conceptually, but in terms of the exact values outputed), making it match the algorithm described in the paper.

This PR was split out from #54.