### PR TITLE
CI: Require OSX jobs to pass when releasing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,8 +36,12 @@ env:
 
 jobs:
   fast_finish: true
+
   allow_failures:
-    - os: osx
+    # Don't wait for OSX job to finish whole job, except on release branches
+    - if: (NOT type = cron) AND ( NOT branch =~ /^v?\d+(\.\d+)+$/ )
+      os: osx
+
   include:
     - python: "2.7"
       env:
@@ -84,7 +88,9 @@ jobs:
         - TEST_NOTEBOOKS="true"
         - USE_OLDEST_DEPS="false"
 
-    - name: "Python 3.7.3 on macOS 10.14"
+    # Only run on release branches
+    - if: branch =~ /^v?\d+(\.\d+)+$/
+      name: "Python 3.7.3 on macOS 10.14"
       os: osx
       osx_image: xcode10.2
       language: shell

--- a/.travis.yml
+++ b/.travis.yml
@@ -84,6 +84,15 @@ jobs:
         - TEST_NOTEBOOKS="true"
         - USE_OLDEST_DEPS="false"
 
+    - name: "Python 3.7.3 on macOS 10.14"
+      os: osx
+      osx_image: xcode10.2
+      language: shell
+      env:
+        - TRAVIS_PYTHON_VERSION="3.7"
+        - TEST_NOTEBOOKS="false"
+        - USE_OLDEST_DEPS="false"
+
 ###############################################################################
 # Setup the environment before installing
 before_install:


### PR DESCRIPTION
We run an extra job on OSX only when pushing to or issuing a PR to a release branch, and require all OSX jobs to pass on a cron or release branch.