### PR TITLE
BUG: Allow loading pickled numpy cache files

### DIFF
--- a/fissa/core.py
+++ b/fissa/core.py
@@ -285,7 +285,7 @@ class Experiment():
         # try to load data from filename
         if not redo:
             try:
-                nCell, raw, roi_polys = np.load(fname)
+                nCell, raw, roi_polys = np.load(fname, allow_pickle=True)
                 print('Reloading previously prepared data...')
             except BaseException:
                 redo = True
@@ -389,7 +389,7 @@ class Experiment():
         fname = os.path.join(self.folder, 'separated.npy')
         if not redo_sep:
             try:
-                info, mixmat, sep, result = np.load(fname)
+                info, mixmat, sep, result = np.load(fname, allow_pickle=True)
                 print('Reloading previously separated data...')
             except BaseException:
                 redo_sep = True


### PR DESCRIPTION
In numpy 1.16, the default behaviour of numpy.load changed to
stop loading files saved with pickle compression by default.
https://docs.scipy.org/doc/numpy/reference/generated/numpy.load.html
This is due to potential security problems.

However, the default numpy.save behaviour is still to save using
pickle. To preserve user experience, we change our behaviour to
allow loading from pickled files.

This is a short-term solution for #85.