### PR TITLE
MAINT: Use splitlines so setup.py has requirements as a list of strings

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,25 +15,23 @@ def read(fname):
 meta = {}
 exec(read('fissa/__meta__.py'), meta)
 
-install_requires = read('requirements.txt')
+install_requires = read('requirements.txt').splitlines()
 
 extras_require = {}
 
 # Notebook dependencies for plotting
-extras_require['plotting'] = read('requirements_plots.txt')
+extras_require['plotting'] = read('requirements_plots.txt').splitlines()
 
 # Dependencies for generating documentation
-extras_require['docs'] = read('requirements_docs.txt')
+extras_require['docs'] = read('requirements_docs.txt').splitlines()
 
 # Dev dependencies
-extras_require['dev'] = read('requirements-dev.txt')
+extras_require['dev'] = read('requirements-dev.txt').splitlines()
 
-# Everything
-extras_require['all'] = (
-    extras_require['plotting']
-    + extras_require['docs']
-    + extras_require['dev']
-)
+# Everything as a list. Replicated items are removed by use of set with {}.
+extras_require['all'] = sorted(list(
+    {x for v in extras_require.values() for x in v}
+))
 
 
 class PyTest(TestCommand):


### PR DESCRIPTION
... instead of a single string with new lines as deliminators.

This is not necessary, as either is acceptable, but I think having
a list of strings is cleaner.
https://setuptools.readthedocs.io/en/latest/setuptools.html#declaring-dependencies

We also ensure the ['all'] requirement has no repeated entries
by combining all the individual items together into a set.