### PR TITLE
DOC: Change full commit changelog link text

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,16 +15,14 @@ Security.
 Unreleased
 ----------
 
-Full commit changelog
-`on github <https://github.com/rochefort-lab/fissa/compare/0.6.4...master>`__.
+`Full commit changelog <https://github.com/rochefort-lab/fissa/compare/0.6.4...master>`__.
 
 
 Version `0.6.4 <https://github.com/rochefort-lab/fissa/tree/0.6.4>`__
 ---------------------------------------------------------------------
 
 Release date: 2020-04-07.
-Full commit changelog
-`on github <https://github.com/rochefort-lab/fissa/compare/0.6.3...0.6.4>`__.
+`Full commit changelog <https://github.com/rochefort-lab/fissa/compare/0.6.3...0.6.4>`__.
 
 Fixed
 ~~~~~
@@ -37,8 +35,7 @@ Version `0.6.3 <https://github.com/rochefort-lab/fissa/tree/0.6.3>`__
 ---------------------------------------------------------------------
 
 Release date: 2020-04-03.
-Full commit changelog
-`on github <https://github.com/rochefort-lab/fissa/compare/0.6.2...0.6.3>`__.
+`Full commit changelog <https://github.com/rochefort-lab/fissa/compare/0.6.2...0.6.3>`__.
 
 Fixed
 ~~~~~
@@ -66,8 +63,7 @@ Version `0.6.2 <https://github.com/rochefort-lab/fissa/tree/0.6.2>`__
 ---------------------------------------------------------------------
 
 Release date: 2020-03-11.
-Full commit changelog
-`on github <https://github.com/rochefort-lab/fissa/compare/0.6.1...0.6.2>`__.
+`Full commit changelog <https://github.com/rochefort-lab/fissa/compare/0.6.1...0.6.2>`__.
 
 Fixed
 ~~~~~
@@ -91,8 +87,7 @@ Version `0.6.1 <https://github.com/rochefort-lab/fissa/tree/0.6.1>`__
 ---------------------------------------------------------------------
 
 Release date: 2019-03-11.
-Full commit changelog
-`on github <https://github.com/rochefort-lab/fissa/compare/0.6.0...0.6.1>`__.
+`Full commit changelog <https://github.com/rochefort-lab/fissa/compare/0.6.0...0.6.1>`__.
 
 Fixed
 ~~~~~
@@ -114,8 +109,7 @@ Version `0.6.0 <https://github.com/rochefort-lab/fissa/tree/0.6.0>`__
 ---------------------------------------------------------------------
 
 Release date: 2019-02-26.
-Full commit changelog
-`on github <https://github.com/rochefort-lab/fissa/compare/0.5.3...0.6.0>`__.
+`Full commit changelog <https://github.com/rochefort-lab/fissa/compare/0.5.3...0.6.0>`__.
 
 Added
 ~~~~~
@@ -130,8 +124,7 @@ Version `0.5.3 <https://github.com/rochefort-lab/fissa/tree/0.5.3>`__
 ---------------------------------------------------------------------
 
 Release date: 2019-02-18.
-Full commit changelog
-`on github <https://github.com/rochefort-lab/fissa/compare/0.5.2...0.5.3>`__.
+`Full commit changelog <https://github.com/rochefort-lab/fissa/compare/0.5.2...0.5.3>`__.
 
 Fixed
 ~~~~~
@@ -144,8 +137,7 @@ Version `0.5.2 <https://github.com/rochefort-lab/fissa/tree/0.5.2>`__
 ---------------------------------------------------------------------
 
 Release date: 2018-03-07.
-Full commit changelog
-`on github <https://github.com/rochefort-lab/fissa/compare/0.5.1...0.5.2>`__.
+`Full commit changelog <https://github.com/rochefort-lab/fissa/compare/0.5.1...0.5.2>`__.
 
 Changed
 ~~~~~~~
@@ -158,8 +150,7 @@ Version `0.5.1 <https://github.com/rochefort-lab/fissa/tree/0.5.1>`__
 ---------------------------------------------------------------------
 
 Release date: 2018-01-10.
-Full commit changelog
-`on github <https://github.com/rochefort-lab/fissa/compare/0.5.0...0.5.1>`__.
+`Full commit changelog <https://github.com/rochefort-lab/fissa/compare/0.5.0...0.5.1>`__.
 
 Added
 ~~~~~


### PR DESCRIPTION
Make "Full commit changelog" be the anchor text, and remove "on github".