### PR TITLE
CI: Require OSX success expect on non-release PRs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,8 +38,9 @@ jobs:
   fast_finish: true
 
   allow_failures:
-    # Don't wait for OSX job to finish whole job, except on release branches
-    - if: (NOT type = cron) AND ( NOT branch =~ /^v?\d+(\.\d+)+$/ )
+    # PR can be deemed okay without waiting for OSX job to finish whole job,
+    # except on release branches
+    - if: type = pull_request AND NOT branch =~ /^v?\d+(\.\d+)+$/
       os: osx
 
   include:


### PR DESCRIPTION
We actually do want to require OSX builds to succeed for updates to master, and new tags, etc, so we only allow jobs to fast finish without OSX when they are PRs (and not PRs into release branches).