### PR TITLE
DOC: Add JNB commit tag to contributing guidelines

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -205,11 +205,11 @@ You can use these flags at the start of your commit messages:
     DOC: documentation; only change/add/remove docstrings, markdown or comments
     ENH: enhancement; add a new feature without removing existing features
     MAINT: maintenance commit (refactoring, typos, etc.); no functional change
+    REL: related to releases
     REV: revert an earlier commit
     RF: refactoring
     STY: style fix (whitespace, PEP8)
     TST: addition or modification of tests
-    REL: related to releases
 
 Notes
 -----

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -204,6 +204,7 @@ You can use these flags at the start of your commit messages:
     DEV: development tool or utility
     DOC: documentation; only change/add/remove docstrings, markdown or comments
     ENH: enhancement; add a new feature without removing existing features
+    JNB: changing a jupyter notebook
     MAINT: maintenance commit (refactoring, typos, etc.); no functional change
     REL: related to releases
     REV: revert an earlier commit


### PR DESCRIPTION
Add a new commit tag, JNB, which pertains to changes to the notebooks.