### PR TITLE
REL: Release version 0.6.5

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,20 @@ Categories for changes are: Added, Changed, Deprecated, Removed, Fixed,
 Security.
 
 
+Version `0.6.5 <https://github.com/rochefort-lab/fissa/tree/0.6.5>`__
+---------------------------------------------------------------------
+
+Release date: 2020-05-04.
+`Full commit changelog <https://github.com/rochefort-lab/fissa/compare/0.6.4...0.6.5>`__.
+
+Version 0.6.5 is a quick patch release to fix the Python version metadata on PyPI, indicating that Python 3.8 is supported.
+
+Changed
+~~~~~~~
+
+-   Metadata indicates Python 3.8 is supported.
+
+
 Version `0.6.4 <https://github.com/rochefort-lab/fissa/tree/0.6.4>`__
 ---------------------------------------------------------------------
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,6 +19,8 @@ Version `0.6.4 <https://github.com/rochefort-lab/fissa/tree/0.6.4>`__
 Release date: 2020-04-07.
 `Full commit changelog <https://github.com/rochefort-lab/fissa/compare/0.6.3...0.6.4>`__.
 
+.. _v0.6.4 Fixed:
+
 Fixed
 ~~~~~
 
@@ -31,6 +33,8 @@ Version `0.6.3 <https://github.com/rochefort-lab/fissa/tree/0.6.3>`__
 
 Release date: 2020-04-03.
 `Full commit changelog <https://github.com/rochefort-lab/fissa/compare/0.6.2...0.6.3>`__.
+
+.. _v0.6.3 Fixed:
 
 Fixed
 ~~~~~
@@ -60,6 +64,8 @@ Version `0.6.2 <https://github.com/rochefort-lab/fissa/tree/0.6.2>`__
 Release date: 2020-03-11.
 `Full commit changelog <https://github.com/rochefort-lab/fissa/compare/0.6.1...0.6.2>`__.
 
+.. _v0.6.2 Fixed:
+
 Fixed
 ~~~~~
 
@@ -84,6 +90,8 @@ Version `0.6.1 <https://github.com/rochefort-lab/fissa/tree/0.6.1>`__
 Release date: 2019-03-11.
 `Full commit changelog <https://github.com/rochefort-lab/fissa/compare/0.6.0...0.6.1>`__.
 
+.. _v0.6.1 Fixed:
+
 Fixed
 ~~~~~
 
@@ -106,6 +114,8 @@ Version `0.6.0 <https://github.com/rochefort-lab/fissa/tree/0.6.0>`__
 Release date: 2019-02-26.
 `Full commit changelog <https://github.com/rochefort-lab/fissa/compare/0.5.3...0.6.0>`__.
 
+.. _v0.6.0 Added:
+
 Added
 ~~~~~
 
@@ -121,6 +131,8 @@ Version `0.5.3 <https://github.com/rochefort-lab/fissa/tree/0.5.3>`__
 Release date: 2019-02-18.
 `Full commit changelog <https://github.com/rochefort-lab/fissa/compare/0.5.2...0.5.3>`__.
 
+.. _v0.5.3 Fixed:
+
 Fixed
 ~~~~~
 
@@ -133,6 +145,8 @@ Version `0.5.2 <https://github.com/rochefort-lab/fissa/tree/0.5.2>`__
 
 Release date: 2018-03-07.
 `Full commit changelog <https://github.com/rochefort-lab/fissa/compare/0.5.1...0.5.2>`__.
+
+.. _v0.5.2 Changed:
 
 Changed
 ~~~~~~~
@@ -147,6 +161,8 @@ Version `0.5.1 <https://github.com/rochefort-lab/fissa/tree/0.5.1>`__
 Release date: 2018-01-10.
 `Full commit changelog <https://github.com/rochefort-lab/fissa/compare/0.5.0...0.5.1>`__.
 
+.. _v0.5.1 Added:
+
 Added
 ~~~~~
 
@@ -158,6 +174,8 @@ Added
 -  Added the option for users to define a custom data and ROI loading
    script.
    (`#13 <https://github.com/rochefort-lab/fissa/pull/13>`__)
+
+.. _v0.5.1 Fixed:
 
 Fixed
 ~~~~~

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,6 +19,8 @@ Version `0.6.4 <https://github.com/rochefort-lab/fissa/tree/0.6.4>`__
 Release date: 2020-04-07.
 `Full commit changelog <https://github.com/rochefort-lab/fissa/compare/0.6.3...0.6.4>`__.
 
+**Note**: This version fully supports Python 3.8, but unfortunately this information was not noted correctly in the PyPI metadata for the release.
+
 .. _v0.6.4 Fixed:
 
 Fixed

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,12 +1,13 @@
 Changelog
 =========
 
-All notable changes to this project will be documented here.
+All notable changes to FISSA will be documented here.
 
-The format is based on `Keep a
-Changelog <https://keepachangelog.com/en/1.0.0/>`__, and this project
-adheres to `Semantic
-Versioning <https://semver.org/spec/v2.0.0.html>`__.
+The format is based on `Keep a Changelog`_, and this project adheres to
+`Semantic Versioning`_.
+
+.. _Keep a Changelog: https://keepachangelog.com/en/1.0.0/
+.. _Semantic Versioning: https://semver.org/spec/v2.0.0.html
 
 Categories for changes are: Added, Changed, Deprecated, Removed, Fixed,
 Security.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,8 +16,7 @@ Version `0.6.4 <https://github.com/rochefort-lab/fissa/tree/0.6.4>`__
 ---------------------------------------------------------------------
 
 Release date: 2020-04-07.
-Full commit changelog
-`on github <https://github.com/rochefort-lab/fissa/compare/0.6.3...0.6.4>`__.
+`Full commit changelog <https://github.com/rochefort-lab/fissa/compare/0.6.3...0.6.4>`__.
 
 Fixed
 ~~~~~
@@ -30,8 +29,7 @@ Version `0.6.3 <https://github.com/rochefort-lab/fissa/tree/0.6.3>`__
 ---------------------------------------------------------------------
 
 Release date: 2020-04-03.
-Full commit changelog
-`on github <https://github.com/rochefort-lab/fissa/compare/0.6.2...0.6.3>`__.
+`Full commit changelog <https://github.com/rochefort-lab/fissa/compare/0.6.2...0.6.3>`__.
 
 Fixed
 ~~~~~
@@ -59,8 +57,7 @@ Version `0.6.2 <https://github.com/rochefort-lab/fissa/tree/0.6.2>`__
 ---------------------------------------------------------------------
 
 Release date: 2020-03-11.
-Full commit changelog
-`on github <https://github.com/rochefort-lab/fissa/compare/0.6.1...0.6.2>`__.
+`Full commit changelog <https://github.com/rochefort-lab/fissa/compare/0.6.1...0.6.2>`__.
 
 Fixed
 ~~~~~
@@ -84,8 +81,7 @@ Version `0.6.1 <https://github.com/rochefort-lab/fissa/tree/0.6.1>`__
 ---------------------------------------------------------------------
 
 Release date: 2019-03-11.
-Full commit changelog
-`on github <https://github.com/rochefort-lab/fissa/compare/0.6.0...0.6.1>`__.
+`Full commit changelog <https://github.com/rochefort-lab/fissa/compare/0.6.0...0.6.1>`__.
 
 Fixed
 ~~~~~
@@ -107,8 +103,7 @@ Version `0.6.0 <https://github.com/rochefort-lab/fissa/tree/0.6.0>`__
 ---------------------------------------------------------------------
 
 Release date: 2019-02-26.
-Full commit changelog
-`on github <https://github.com/rochefort-lab/fissa/compare/0.5.3...0.6.0>`__.
+`Full commit changelog <https://github.com/rochefort-lab/fissa/compare/0.5.3...0.6.0>`__.
 
 Added
 ~~~~~
@@ -123,8 +118,7 @@ Version `0.5.3 <https://github.com/rochefort-lab/fissa/tree/0.5.3>`__
 ---------------------------------------------------------------------
 
 Release date: 2019-02-18.
-Full commit changelog
-`on github <https://github.com/rochefort-lab/fissa/compare/0.5.2...0.5.3>`__.
+`Full commit changelog <https://github.com/rochefort-lab/fissa/compare/0.5.2...0.5.3>`__.
 
 Fixed
 ~~~~~
@@ -137,8 +131,7 @@ Version `0.5.2 <https://github.com/rochefort-lab/fissa/tree/0.5.2>`__
 ---------------------------------------------------------------------
 
 Release date: 2018-03-07.
-Full commit changelog
-`on github <https://github.com/rochefort-lab/fissa/compare/0.5.1...0.5.2>`__.
+`Full commit changelog <https://github.com/rochefort-lab/fissa/compare/0.5.1...0.5.2>`__.
 
 Changed
 ~~~~~~~
@@ -151,8 +144,7 @@ Version `0.5.1 <https://github.com/rochefort-lab/fissa/tree/0.5.1>`__
 ---------------------------------------------------------------------
 
 Release date: 2018-01-10.
-Full commit changelog
-`on github <https://github.com/rochefort-lab/fissa/compare/0.5.0...0.5.1>`__.
+`Full commit changelog <https://github.com/rochefort-lab/fissa/compare/0.5.0...0.5.1>`__.
 
 Added
 ~~~~~

--- a/fissa/__meta__.py
+++ b/fissa/__meta__.py
@@ -1,6 +1,6 @@
 name = 'fissa'
 path = name
-version = '0.6.4'
+version = '0.6.5'
 author = "Sander Keemink & Scott Lowe"
 author_email = "swkeemink@scimail.eu"
 description = "A Python Library estimating somatic signals in 2-photon data"

--- a/setup.py
+++ b/setup.py
@@ -77,6 +77,7 @@ setup(
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
         "Topic :: Scientific/Engineering",
         "Topic :: Scientific/Engineering :: Bio-Informatics",
         "Topic :: Scientific/Engineering :: Information Analysis",


### PR DESCRIPTION
Version 0.6.5 is a quick patch release to fix the Python version metadata on PyPI, indicating that Python 3.8 is supported.

### Changed

-   Metadata indicates Python 3.8 is supported.
-   Integrates changes to Changelog from #115 and #121 into 0.6.x.