### PR TITLE
ENH: Add option to run without cache

### DIFF
--- a/examples/Basic usage.html
+++ b/examples/Basic usage.html
@@ -14713,7 +14713,11 @@ Define your inputs. All that's necessary to define are the image data and ROIs. 
 <span class="n">images_location</span> <span class="o">=</span> <span class="s1">&#39;exampleData/20150529&#39;</span>
 <span class="n">rois_location</span> <span class="o">=</span> <span class="s1">&#39;exampleData/20150429.zip&#39;</span>
 
-<span class="c1"># Folder where data will be stored. Make sure to use a different folder for each experiment.</span>
+<span class="c1"># Define the folder where FISSA&#39;s outputs will be stored, so they can be</span>
+<span class="c1"># quickly reloaded in the future without having to recompute them.</span>
+<span class="c1"># Make sure to use a different folder for each experiment.</span>
+<span class="c1"># This argument is optional; if it is not provided, FISSA will not save its</span>
+<span class="c1"># results for later use.</span>
 <span class="n">output_folder</span> <span class="o">=</span> <span class="s1">&#39;fissa_example&#39;</span>
 
 <span class="n">experiment</span> <span class="o">=</span> <span class="n">fissa</span><span class="o">.</span><span class="n">Experiment</span><span class="p">(</span><span class="n">images_location</span><span class="p">,</span> <span class="n">rois_location</span><span class="p">,</span> <span class="n">output_folder</span><span class="p">)</span>

--- a/examples/Basic usage.ipynb
+++ b/examples/Basic usage.ipynb
@@ -1611,7 +1611,11 @@
     "images_location = 'exampleData/20150529'\n",
     "rois_location = 'exampleData/20150429.zip'\n",
     "\n",
-    "# Folder where data will be stored. Make sure to use a different folder for each experiment.\n",
+    "# Define the folder where FISSA's outputs will be stored, so they can be\n",
+    "# quickly reloaded in the future without having to recompute them.\n",
+    "# Make sure to use a different folder for each experiment.\n",
+    "# This argument is optional; if it is not provided, FISSA will not save its\n",
+    "# results for later use.\n",
     "output_folder = 'fissa_example'\n",
     "\n",
     "experiment = fissa.Experiment(images_location, rois_location, output_folder)"

--- a/fissa/tests/test_core.py
+++ b/fissa/tests/test_core.py
@@ -145,6 +145,16 @@ class TestExperimentA(BaseTestCase):
         self.assert_equal(len(actual[0]), 1)
         self.assert_allclose(actual[0][0], self.expected_00)
 
+    def test_nocache(self):
+        image_path = os.path.join(self.resources_dir, self.images_dir)
+        roi_path = os.path.join(self.resources_dir, self.roi_zip_path)
+        exp = core.Experiment(image_path, roi_path)
+        exp.separate()
+        actual = exp.result
+        self.assert_equal(len(actual), 1)
+        self.assert_equal(len(actual[0]), 1)
+        self.assert_allclose(actual[0][0], self.expected_00)
+
     def test_ncores_preparation_1(self):
         image_path = os.path.join(self.resources_dir, self.images_dir)
         roi_path = os.path.join(self.resources_dir, self.roi_zip_path)
@@ -334,6 +344,13 @@ class TestExperimentA(BaseTestCase):
         exp.save_to_matlab(fname)
         self.assertTrue(os.path.isfile(fname))
         #TODO: Check contents of the .mat file
+
+    def test_matlab_no_cache_no_fname(self):
+        image_path = os.path.join(self.resources_dir, self.images_dir)
+        roi_path = os.path.join(self.resources_dir, self.roi_zip_path)
+        exp = core.Experiment(image_path, roi_path)
+        exp.separate()
+        self.assertRaises(ValueError, exp.save_to_matlab)
 
     def test_matlab_deltaf(self):
         image_path = os.path.join(self.resources_dir, self.images_dir)


### PR DESCRIPTION
The `folder` argument of `fissa.Experiment` is now optional. If it is not supplied, the data is not loaded from a cache, nor is it saved to a cache.

Also add a test to cover new functionality.

Requires #128.