### PR TITLE
TST: Change npil tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ env:
     # Values are "true", "false" or "".
     - TEST_NOTEBOOKS="true"
     - USE_SIMA="true"
-    - USE_SUITE2P="true"
+    - USE_SUITE2P="false"
     # Set flag for whether to use a conda environment
     # values can be:
     # "" or "false":  conda not used

--- a/fissa/tests/test_neuropil.py
+++ b/fissa/tests/test_neuropil.py
@@ -63,3 +63,7 @@ class TestNeuropilFuns(BaseTestCase):
         with self.subTest(i_subtest):
             run_method('nmf', expected_converged=True, alpha=.2)
         i_subtest += 1
+
+    def test_badmethod(self):
+        with self.assertRaises(ValueError):
+            npil.separate(self.S, sep_method='bogus_method')

--- a/fissa/tests/test_neuropil.py
+++ b/fissa/tests/test_neuropil.py
@@ -21,20 +21,8 @@ class TestNeuropilFuns(BaseTestCase):
 
     def test_separate(self):
         """Tests the separate function data format."""
-        # TODO: Successfullness of methods are hard to test with unittests.
-        #       Need to make a test case where answer is known, and test
-        #       against that.
-
         # desired shapes
         shape_desired = (2, self.l)
-        con_desired_ica = {'converged': False,
-                           'iterations': 1,
-                           'max_iterations': 1,
-                           'random_state': 892}
-        con_desired_nmf = {'converged': True,
-                           'iterations': 0,
-                           'max_iterations': 1,
-                           'random_state': 892}
 
         # setup fake data
         data = np.array([np.sin(self.x), np.cos(3 * self.x)]) + 1
@@ -44,28 +32,36 @@ class TestNeuropilFuns(BaseTestCase):
         S = np.dot(W, data)
 
         # function for testing a method
-        def run_method(method, expected=None):
-            """Test a single method.
-
-            Parameters
-            ----------
-            method : str
-                What method to test: 'nmf', 'ica', or 'nmf_sklearn')
-
-            """
-            # unmix data with ica
+        def run_method(method, expected_converged=None, **kwargs):
+            """Test a single method, with specific parameters."""
+            # Run the separation routine
             S_sep, S_matched, A_sep, convergence = npil.separate(
-                S, sep_method=method, n=2, maxiter=1, maxtries=1)
-
-            # assert if formats are good
+                S, sep_method=method, **kwargs
+            )
+            # Ensure output shapes are as expected
             self.assert_equal(S_sep.shape, shape_desired)
             self.assert_equal(S_matched.shape, shape_desired)
             self.assert_equal(S_sep.shape, shape_desired)
-            if expected is not None:
-                self.assert_equal(convergence, expected)
+            # If specified, assert that the result is as expected
+            if expected_converged is not None:
+                self.assert_equal(convergence['converged'], expected_converged)
 
-        # test all two methods
-        with self.subTest(0):
-            run_method('nmf', con_desired_nmf)
-        with self.subTest(1):
-            run_method('ica', con_desired_ica)
+        # Run tests
+        i_subtest = 0
+        for method in ['nmf', 'ica']:
+            with self.subTest(i_subtest):
+                run_method(method, expected_converged=True, maxtries=1, n=2)
+            i_subtest += 1
+            with self.subTest(i_subtest):
+                run_method(method, expected_converged=True, maxtries=1)
+            i_subtest += 1
+            with self.subTest(i_subtest):
+                run_method(method, expected_converged=True, maxtries=1, random_state=0)
+            i_subtest += 1
+            with self.subTest(i_subtest):
+                run_method(method, maxiter=1, maxtries=3)
+            i_subtest += 1
+
+        with self.subTest(i_subtest):
+            run_method('nmf', expected_converged=True, alpha=.2)
+        i_subtest += 1

--- a/fissa/tests/test_neuropil.py
+++ b/fissa/tests/test_neuropil.py
@@ -44,7 +44,7 @@ class TestNeuropilFuns(BaseTestCase):
         S = np.dot(W, data)
 
         # function for testing a method
-        def run_method(method):
+        def run_method(method, expected=None):
             """Test a single method.
 
             Parameters
@@ -61,13 +61,11 @@ class TestNeuropilFuns(BaseTestCase):
             self.assert_equal(S_sep.shape, shape_desired)
             self.assert_equal(S_matched.shape, shape_desired)
             self.assert_equal(S_sep.shape, shape_desired)
-            if method == 'ica':
-                self.assert_equal(convergence, con_desired_ica)
-            elif method == 'nmf':
-                self.assert_equal(convergence, con_desired_nmf)
+            if expected is not None:
+                self.assert_equal(convergence, expected)
 
         # test all two methods
         with self.subTest(0):
-            run_method('nmf')
+            run_method('nmf', con_desired_nmf)
         with self.subTest(1):
-            run_method('ica')
+            run_method('ica', con_desired_ica)

--- a/fissa/tests/test_neuropil.py
+++ b/fissa/tests/test_neuropil.py
@@ -18,25 +18,23 @@ class TestNeuropilFuns(BaseTestCase):
         self.l = 100
         # setup basic x values for fake data
         self.x = np.linspace(0, np.pi * 2, self.l)
+        # Generate simple source data
+        self.data = np.array([np.sin(self.x), np.cos(3 * self.x)]) + 1
+        # Mix to make test data
+        self.W = np.array([[0.2, 0.8], [0.8, 0.2]])
+        self.S = np.dot(self.W, self.data)
 
     def test_separate(self):
         """Tests the separate function data format."""
         # desired shapes
         shape_desired = (2, self.l)
 
-        # setup fake data
-        data = np.array([np.sin(self.x), np.cos(3 * self.x)]) + 1
-
-        # mix fake data
-        W = np.array([[0.2, 0.8], [0.8, 0.2]])
-        S = np.dot(W, data)
-
         # function for testing a method
         def run_method(method, expected_converged=None, **kwargs):
             """Test a single method, with specific parameters."""
             # Run the separation routine
             S_sep, S_matched, A_sep, convergence = npil.separate(
-                S, sep_method=method, **kwargs
+                self.S, sep_method=method, **kwargs
             )
             # Ensure output shapes are as expected
             self.assert_equal(S_sep.shape, shape_desired)

--- a/fissa/tests/test_neuropil.py
+++ b/fissa/tests/test_neuropil.py
@@ -67,5 +67,7 @@ class TestNeuropilFuns(BaseTestCase):
                 self.assert_equal(convergence, con_desired_nmf)
 
         # test all two methods
-        run_method('nmf')
-        run_method('ica')
+        with self.subTest(0):
+            run_method('nmf')
+        with self.subTest(1):
+            run_method('ica')


### PR DESCRIPTION
Tests for neuropil now:
- use subtest contexts
- test running neuropil separation with different parameter sets
- only test the convergence status of the result, and not the exact number of iterations

This fixes a test which was broken when scikit-learn moved from version 0.22.2.post1 to 0.23.0.
