### PR TITLE
Use precise versions in Binder env; test notebooks with that env

### DIFF
--- a/.binder/environment.yml
+++ b/.binder/environment.yml
@@ -1,16 +1,30 @@
 name: fissa-example-environment
 channels:
+  - defaults
   - conda-forge
 dependencies:
-  - python=3.6
-  - pip
-  - mkl_fft>=1.0.10
-  - mkl>=2019.3
-  - numpy>=1.16
-  - numba>=0.43.1
-  - matplotlib>=2.0.2
-  - scipy>=0.19.0
+  - numpy==1.18.4
+  - mkl=2020.0=166
+  - mkl_fft=1.0.15=py36ha843d7b_0
+  - pip==20.1
+  - python=3.6.10=hcf32534_1
+  - scipy=1.4.1=py36h0b6359f_0
+  - six=1.14.0=py36_0
   - pip:
+    - bokeh==2.0.2
     - fissa[plotting]
-    - sima
-    - suite2p
+    - future==0.18.2
+    - h5py==2.10.0
+    - holoviews==1.13.2
+    - imagecodecs==2020.2.18
+    - imageio==2.8.0
+    - numba==0.49.0
+    - pandas==1.0.3
+    - pillow==7.1.2
+    - read-roi==1.5.2
+    - scikit-image==0.16.2
+    - scikit-learn==0.22.2.post1
+    - shapely==1.7.0
+    - sima==1.3.2
+    - suite2p==0.7.1
+    - tifffile==2020.2.16

--- a/.travis.yml
+++ b/.travis.yml
@@ -69,7 +69,6 @@ jobs:
       language: shell
       env:
         - TRAVIS_PYTHON_VERSION="2.7.17"
-        - USE_SUITE2P="false"
 
     - name: "Python 2.7.17 on macOS 10.14 [oldest, no sima/suite2p]"
       os: osx
@@ -79,7 +78,6 @@ jobs:
         - TRAVIS_PYTHON_VERSION="2.7.17"
         - USE_OLDEST_DEPS="true"
         - USE_SIMA="false"
-        - USE_SUITE2P="false"
 
     - name: "Python 3.7.5 on macOS 10.14 [no sima/suite2p]"
       os: osx
@@ -88,7 +86,6 @@ jobs:
       env:
         - TRAVIS_PYTHON_VERSION="3.7.5"
         - USE_SIMA="false"
-        - USE_SUITE2P="false"
 
     # Python versions which need to be installed
     - if: type = cron OR branch =~ /^v?\d+(\.[x\d]+)+$/
@@ -100,7 +97,6 @@ jobs:
         - TRAVIS_PYTHON_VERSION="3.5.9"
         - USE_OLDEST_DEPS="true"
         - USE_SIMA="false"
-        - USE_SUITE2P="false"
 
     - if: type = cron OR branch =~ /^v?\d+(\.[x\d]+)+$/
       name: "Python 3.5.9 on macOS 10.14 [no suite2p]"
@@ -109,7 +105,6 @@ jobs:
       language: shell
       env:
         - TRAVIS_PYTHON_VERSION="3.5.9"
-        - USE_SUITE2P="false"
 
     - if: type = cron AND branch =~ /^v?\d+(\.[x\d]+)+$/
       name: "Python 3.6.10 on macOS 10.14 [no suite2p]"
@@ -118,7 +113,6 @@ jobs:
       language: shell
       env:
         - TRAVIS_PYTHON_VERSION="3.6.10"
-        - USE_SUITE2P="false"
 
     - if: type = cron OR branch =~ /^v?\d+(\.[x\d]+)+$/
       name: "Python 3.8.2 on macOS 10.14 [no sima/suite2p]"
@@ -128,48 +122,38 @@ jobs:
       env:
         - TRAVIS_PYTHON_VERSION="3.8.2"
         - USE_SIMA="false"
-        - USE_SUITE2P="false"
 
     # Ubuntu -------------------------------------
     # Jobs to run on Conda
     - python: "3.6"
       env:
-        - USE_CONDA="numpy"
+        - USE_CONDA="binder"
+        - USE_SUITE2P="true"
 
     # All versions pre-installed
     - python: "3.8"
       env:
         - USE_SIMA="false"
-        - USE_SUITE2P="false"
 
     - python: "2.7"
       env:
         - USE_OLDEST_DEPS="true"
-        - USE_SUITE2P="false"
 
     - python: "2.7"
-      env:
-        - USE_SUITE2P="false"
 
     - python: "3.5"
       env:
         - USE_OLDEST_DEPS="true"
-        - USE_SUITE2P="false"
 
     - python: "3.5"
-      env:
-        - USE_SUITE2P="false"
 
     - if: type = cron OR branch =~ /^v?\d+(\.[x\d]+)+$/
       python: "3.6"
-      env:
-        - USE_SUITE2P="false"
 
     - if: type = cron OR branch =~ /^v?\d+(\.[x\d]+)+$/
       python: "3.7"
       env:
         - USE_SIMA="false"
-        - USE_SUITE2P="false"
 
 ###############################################################################
 # Setup the environment before installing

--- a/.travis.yml
+++ b/.travis.yml
@@ -327,7 +327,11 @@ before_install:
   # are in requirements.txt)
   - |
     if [[ "$USE_CONDA" != "false" && "$USE_CONDA" != "" ]]; then
-        conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION pip $NUMPY_REQUIREMENT $SCIPY_REQUIREMENT;
+        if [[ "$USE_CONDA" == "binder" ]]; then
+            conda env create -q -f .binder/environment.yml -n test-environment;
+        else
+            conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION pip $NUMPY_REQUIREMENT $SCIPY_REQUIREMENT;
+        fi;
         source activate test-environment;
         PYTHONCMD=python;
     fi;

--- a/.travis.yml
+++ b/.travis.yml
@@ -409,7 +409,7 @@ install:
   # Install required packages listed in requirements.txt. We install this
   # with the upgrade flag to ensure we have the most recent version of
   # the dependency which is compatible with the specification.
-  - if [[ "$USE_OLDEST_DEPS" == "true" ]]; then
+  - if [[ "$USE_OLDEST_DEPS" == "true" || "$USE_CONDA" == "binder" ]]; then
         $PYTHONCMD -m pip install -r requirements_all.txt;
     else
         $PYTHONCMD -m pip install --upgrade -r requirements_all.txt;


### PR DESCRIPTION
We now specify the versions for the Binder environment more precisely, so it is less fragile to changes in other repositories.

The conda env used to test the suite2p notebook now exactly matches that in the Binder environment.

This was motivated by suite2p's current release not working (https://github.com/MouseLand/suite2p/issues/324) with the latest version of skimage=0.17.2. In that release, skimage removed its copy of `tifffile` from `skimage.external.tifffile`. We don't want Binder and our CI test suite to break just because the latest version of two third-party packages are incompatible.
