### PR TITLE
CI: Push to codecov with bash script, not python script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -505,8 +505,8 @@ after_success:
   # coverage report wasn't published.
   - |
     if [[ "$TRAVIS" = "true" && "$SHIPPABLE" != "true" ]]; then
-        $PYTHONCMD -m pip install codecov;
-        travis_retry codecov || echo "Codecov push failed";
+        curl -s -S -L --connect-timeout 5 --retry 6 https://codecov.io/bash -o codecov-upload.sh || echo "Codecov script failed to download";
+        travis_retry bash codecov-upload.sh || echo "Codecov push failed";
         $PYTHONCMD -m pip install coveralls;
         travis_retry coveralls || echo "Coveralls push failed";
     fi;


### PR DESCRIPTION
Having problems pushing with the python script (installed via pip)
and it seems like the big name python packages (numpy, pytest)
tend to use the bash script instead, which is working for them.

I took this more robust version of the download command from pytest https://github.com/pytest-dev/pytest/blob/864338de71d6b56f0029b8ea8f45581001e2bab1/scripts/report-coverage.sh