### PR TITLE
CI: Don't dynamically skip jobs on appveyor

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -99,17 +99,7 @@ for:
     - path: dist\*
 
 init:
-  # If there is a newer build queued for the same PR, cancel this one.
-  # The AppVeyor 'rollout builds' option is supposed to serve the same
-  # purpose but it is problematic because it tends to cancel builds pushed
-  # directly to master instead of just PR builds (or the converse).
-  # credits: JuliaLang developers.
-  - ps: if ($env:APPVEYOR_PULL_REQUEST_NUMBER -and $env:APPVEYOR_BUILD_NUMBER -ne ((Invoke-RestMethod `
-        https://ci.appveyor.com/api/projects/$env:APPVEYOR_ACCOUNT_NAME/$env:APPVEYOR_PROJECT_SLUG/history?recordsNumber=50).builds | `
-        Where-Object pullRequestId -eq $env:APPVEYOR_PULL_REQUEST_NUMBER)[0].buildNumber) { `
-          Write-Host "There are newer queued builds for this pull request, skipping build."
-          Exit-AppveyorBuild
-        }
+  - ECHO "init"
 
 install:
   - ECHO "Filesystem root:"


### PR DESCRIPTION
Remove the init section from .appveyor.yml, which is not working reliable with respect to PR jobs.
https://ci.appveyor.com/project/rochefortlab/fissa/builds/33049428