### PR TITLE
CI: Travis don't test Py3.5 on OSX

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -89,32 +89,6 @@ jobs:
 
     # Python versions which need to be installed
     - if: type = cron OR branch =~ /^v?\d+(\.[x\d]+)+$/
-      name: "Python 3.5.9 on macOS 10.14 [oldest, no sima/suite2p]"
-      os: osx
-      osx_image: xcode11.13
-      language: shell
-      env:
-        - TRAVIS_PYTHON_VERSION="3.5.9"
-        - USE_OLDEST_DEPS="true"
-        - USE_SIMA="false"
-
-    - if: type = cron OR branch =~ /^v?\d+(\.[x\d]+)+$/
-      name: "Python 3.5.9 on macOS 10.14 [no suite2p]"
-      os: osx
-      osx_image: xcode11.13
-      language: shell
-      env:
-        - TRAVIS_PYTHON_VERSION="3.5.9"
-
-    - if: type = cron AND branch =~ /^v?\d+(\.[x\d]+)+$/
-      name: "Python 3.6.10 on macOS 10.14 [no suite2p]"
-      os: osx
-      osx_image: xcode11.13
-      language: shell
-      env:
-        - TRAVIS_PYTHON_VERSION="3.6.10"
-
-    - if: type = cron OR branch =~ /^v?\d+(\.[x\d]+)+$/
       name: "Python 3.8.2 on macOS 10.14 [no sima/suite2p]"
       os: osx
       osx_image: xcode11.13


### PR DESCRIPTION
Reduce the number of OSX jobs which are run for new releases - only test python versions baked into the image (Python 2.7.17 and 3.7.5) and the latest version (Python 3.8.2). Installing other Python versions is very slow (resulting in jobs which take 18 mins instead of 4 mins), and not necessary as they are tested on Ubuntu images.