### PR TITLE
CI: Add tests with GitHub Actions

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,0 +1,42 @@
+# Docs workflow
+#
+# Ensures that the docs can be built with sphinx.
+# - On every push and PR, checks the HTML documentation builds on linux.
+# - On every PR and tag, checks the documentation builds as a PDF on linux.
+
+name: docs
+
+on: [push, pull_request]
+
+jobs:
+  docs-html:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Build HTML docs
+      uses: ammaraskar/sphinx-action@master
+      with:
+        docs-folder: "docs/"
+
+  docs-pdf:
+    if: |
+      github.event_name == 'pull_request' ||
+      startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Build PDF docs
+      uses: ammaraskar/sphinx-action@master
+      with:
+        docs-folder: "docs/"
+        pre-build-command: "apt-get update -y && apt-get install -y latexmk texlive-latex-recommended texlive-latex-extra texlive-fonts-recommended"
+        build-command: "make latexpdf"
+
+    - uses: actions/upload-artifact@v2
+      if: startsWith(github.ref, 'refs/tags')
+      with:
+        name: Documentation
+        path: docs/_build/latex/*.pdf
+        retention-days: 7

--- a/.github/workflows/system_info.py
+++ b/.github/workflows/system_info.py
@@ -1,0 +1,21 @@
+"""
+Print out some handy system info.
+"""
+
+import os
+import platform
+import sys
+
+print("Build system information")
+print()
+
+print("sys.version\t\t", sys.version.split("\n"))
+print("os.name\t\t\t", os.name)
+print("sys.platform\t\t", sys.platform)
+print("platform.system()\t", platform.system())
+print("platform.machine()\t", platform.machine())
+print("platform.platform()\t", platform.platform())
+print("platform.version()\t", platform.version())
+print("platform.uname()\t", platform.uname())
+if sys.platform == "darwin":
+    print("platform.mac_ver()\t", platform.mac_ver())

--- a/.github/workflows/test-release-candidate.yaml
+++ b/.github/workflows/test-release-candidate.yaml
@@ -75,6 +75,13 @@ jobs:
     - name: System information
       run: python .github/workflows/system_info.py
 
+    - name: Dynamically determine extra variables depending on Python version
+      run: |
+        echo "Running on Python $PYTHON"
+        TEST_SIMA=$(python -c "import sys; print(sys.version_info[:2] <= (3, 6))")
+        echo "TEST_SIMA = $TEST_SIMA"
+        echo "test_sima=$TEST_SIMA" >> $GITHUB_ENV
+
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
@@ -96,17 +103,17 @@ jobs:
         python -m pytest --cov=fissa --cov-report term --cov-report xml --cov-config .coveragerc --junitxml=testresults.xml
 
     - name: "Notebooks: Remove SIMA notebooks"
-      if: ${{ matrix.test-sima != 'true' }}
+      if: ${{ env.test_sima != 'True' }}
       run: rm examples/*SIMA*;
 
     - name: "Notebooks: Remove Suite2p notebooks"
-      if: ${{ matrix.test-suite2p != 'true' }}
+      if: ${{ env.test_suite2p != 'True' }}
       run: rm examples/*Suite2p*;
 
     - name: "Notebooks: Install dependencies"
       run: |
         python -m pip install .[plotting]
-        if [[ "$USE_SIMA" == "true" ]]; then python -m pip install sima; fi;
+        if [[ "${{ env.test_sima }}" == "True" ]]; then python -m pip install sima; fi;
 
     - name: "Notebooks: Lint check"
       run: python -m pytest --nbsmoke-lint ./examples/

--- a/.github/workflows/test-release-candidate.yaml
+++ b/.github/workflows/test-release-candidate.yaml
@@ -91,6 +91,21 @@ jobs:
       run: |
         python -m pytest --cov=fissa --cov-report term --cov-report xml --cov-config .coveragerc --junitxml=testresults.xml
 
+    - name: "Notebooks: Remove unsupported notebooks"
+      run: |
+        rm examples/*SIMA*;
+        rm examples/*Suite2p*;
+
+    - name: "Notebooks: Install dependencies"
+      run: |
+        python -m pip install .[plotting]
+
+    - name: "Notebooks: Lint check"
+      run: python -m pytest --nbsmoke-lint ./examples/
+
+    - name: "Notebooks: Smoke test"
+      run: python -m pytest --nbsmoke-run ./examples/
+
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v1
       with:

--- a/.github/workflows/test-release-candidate.yaml
+++ b/.github/workflows/test-release-candidate.yaml
@@ -95,14 +95,18 @@ jobs:
       run: |
         python -m pytest --cov=fissa --cov-report term --cov-report xml --cov-config .coveragerc --junitxml=testresults.xml
 
-    - name: "Notebooks: Remove unsupported notebooks"
-      run: |
-        rm examples/*SIMA*;
-        rm examples/*Suite2p*;
+    - name: "Notebooks: Remove SIMA notebooks"
+      if: ${{ matrix.test-sima != 'true' }}
+      run: rm examples/*SIMA*;
+
+    - name: "Notebooks: Remove Suite2p notebooks"
+      if: ${{ matrix.test-suite2p != 'true' }}
+      run: rm examples/*Suite2p*;
 
     - name: "Notebooks: Install dependencies"
       run: |
         python -m pip install .[plotting]
+        if [[ "$USE_SIMA" == "true" ]]; then python -m pip install sima; fi;
 
     - name: "Notebooks: Lint check"
       run: python -m pytest --nbsmoke-lint ./examples/

--- a/.github/workflows/test-release-candidate.yaml
+++ b/.github/workflows/test-release-candidate.yaml
@@ -1,0 +1,149 @@
+# Tests for releases and release candidates
+#
+# Runs on every tag creation, and all pushes and PRs to release branches
+# named "v1.2.x", etc.
+#
+# This workflow is more extensive than the regular test workflow.
+# - Tests are executed on more Python versions
+# - Tests are run on more operating systems
+# - N.B. There is no pip cache here to ensure runs are always against the
+#   very latest versions of dependencies, even if this workflow ran recently.
+#
+# In addition, the package is built as a wheel on each OS/Python job, and these
+# are stored as artifacts to use for your distribution process. There is an
+# extra job (disabled by default) which can be enabled to push to Test PyPI.
+
+name: release candidate tests
+
+on:
+  push:
+    branches:
+      # Release branches.
+      # Examples: "v1", "v3.0", "v1.2.x", "1.5.0", "1.2rc0"
+      # Expected usage is (for example) a branch named "v1.2.x" which contains
+      # the latest release in the 1.2 series.
+      - 'v[0-9]+'
+      - 'v?[0-9]+.[0-9x]+'
+      - 'v?[0-9]+.[0-9]+.[0-9x]+'
+      - 'v?[0-9]+.[0-9]+.[0-9]+.[0-9x]+'
+      - 'v?[0-9]+.[0-9x]+rc[0-9]*'
+    tags:
+      # Run whenever any tag is created
+      - '**'
+  pull_request:
+    branches:
+      # Release branches
+      - 'v[0-9]+'
+      - 'v?[0-9]+.[0-9x]+'
+      - 'v?[0-9]+.[0-9]+.[0-9x]+'
+      - 'v?[0-9]+.[0-9]+.[0-9]+.[0-9x]+'
+      - 'v?[0-9]+.[0-9x]+rc[0-9]*'
+  release:
+    # Run on a new release
+    types: [created, edited, published]
+
+jobs:
+  test-build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+        python-version: ["2.7", "3.5", "3.6", "3.7", "3.8", "3.9"]
+        include:
+          - os: macos-latest
+            python-version: "2.7"
+          - os: macos-latest
+            python-version: "3.5"
+          - os: macos-latest
+            python-version: "3.9"
+    env:
+      OS: ${{ matrix.os }}
+      PYTHON: ${{ matrix.python-version }}
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: System information
+      run: python .github/workflows/system_info.py
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install flake8
+        python -m pip install .[dev]
+
+    - name: Sanity check with flake8
+      run: |
+        # stop the build if there are Python syntax errors or undefined names
+        python -m flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+        # exit-zero treats all errors as warnings
+        python -m flake8 . --count --exit-zero --statistics
+
+    - name: Debug environment
+      run: python -m pip freeze
+
+    - name: Test with pytest
+      run: |
+        python -m pytest --cov=fissa --cov-report term --cov-report xml --cov-config .coveragerc --junitxml=testresults.xml
+
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v1
+      with:
+        flags: unittests
+        env_vars: OS,PYTHON
+        name: Python ${{ matrix.python-version }} on ${{ runner.os }}
+
+    - name: Build wheels
+      run: |
+        python -m pip install --upgrade setuptools wheel twine
+        python setup.py sdist bdist_wheel
+
+    - name: Store wheel artifacts
+      uses: actions/upload-artifact@v2
+      with:
+        name: wheel-${{ matrix.os }}-${{ matrix.python-version }}
+        path: dist/*
+        retention-days: 7
+
+    - name: Build HTML docs
+      run: |
+        python -m pip install .[docs]
+        cd docs
+        make html
+        cd ..
+
+  publish:
+    # Disabled by default
+    if: |
+      false &&
+      startsWith(github.ref, 'refs/tags/')
+    needs: test-build
+
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Download wheel artifacts
+      uses: actions/download-artifact@v2
+      with:
+        name: wheel-*
+        path: dist/
+
+    - name: Store aggregated wheel artifacts
+      uses: actions/upload-artifact@v2
+      with:
+        name: wheels
+        path: dist/*
+        retention-days: 7
+
+    - name: Publish package to Test PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        user: __token__
+        password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+        repository_url: https://test.pypi.org/legacy/

--- a/.github/workflows/test-release-candidate.yaml
+++ b/.github/workflows/test-release-candidate.yaml
@@ -42,6 +42,10 @@ on:
     # Run on a new release
     types: [created, edited, published]
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   test-build:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,92 @@
+# Regular tests
+#
+# Use this to ensure your tests are passing on every push and PR (skipped on
+# pushes which only affect documentation).
+# There is also a cron job set to run weekly on the default branch, to check
+# against dependency chain rot.
+#
+# You should make sure you run jobs on at least the *oldest* and the *newest*
+# versions of python that your codebase is intended to support.
+
+name: tests
+
+on:
+  push:
+    paths-ignore:
+      - 'docs/**'
+      - '**.rst'
+      - '**.md'
+  pull_request:
+  schedule:
+    - cron:  "0 0 * * 1"
+      branches: [ $default-branch ]
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        python-version: ["2.7", "3.5", "3.9"]
+        include:
+          - os: windows-latest
+            python-version: "3.9"
+    env:
+      OS: ${{ matrix.os }}
+      PYTHON: ${{ matrix.python-version }}
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: System information
+      run: python .github/workflows/system_info.py
+
+    - name: Get pip cache dir
+      id: pip-cache
+      run: echo "::set-output name=dir::$(pip cache dir)"
+
+    - name: pip cache
+      uses: actions/cache@v2
+      with:
+        path: ${{ steps.pip-cache.outputs.dir }}
+        key: ${{ runner.os }}-pip-py${{ matrix.python-version }}-${{ hashFiles('**/requirements*.txt') }}
+        restore-keys: ${{ runner.os }}-pip-
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install flake8
+        python -m pip install .[dev]
+
+    - name: Sanity check with flake8
+      run: |
+        # stop the build if there are Python syntax errors or undefined names
+        python -m flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+        # exit-zero treats all errors as warnings
+        python -m flake8 . --count --exit-zero --statistics
+
+    - name: Debug environment
+      run: python -m pip freeze
+
+    - name: Test with pytest
+      run: |
+        python -m pytest --cov=fissa --cov-report term --cov-report xml --cov-config .coveragerc --junitxml=testresults.xml
+
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v1
+      with:
+        flags: unittests
+        env_vars: OS,PYTHON
+        name: Python ${{ matrix.python-version }} on ${{ runner.os }}
+
+    - name: Build HTML docs
+      run: |
+        python -m pip install .[docs]
+        cd docs
+        make html
+        cd ..

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -21,6 +21,10 @@ on:
     - cron:  "0 0 * * 1"
       branches: [ $default-branch ]
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   test:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -77,6 +77,21 @@ jobs:
       run: |
         python -m pytest --cov=fissa --cov-report term --cov-report xml --cov-config .coveragerc --junitxml=testresults.xml
 
+    - name: "Notebooks: Remove unsupported notebooks"
+      run: |
+        rm examples/*SIMA*;
+        rm examples/*Suite2p*;
+
+    - name: "Notebooks: Install dependencies"
+      run: |
+        python -m pip install .[plotting]
+
+    - name: "Notebooks: Lint check"
+      run: python -m pytest --nbsmoke-lint ./examples/
+
+    - name: "Notebooks: Smoke test"
+      run: python -m pytest --nbsmoke-run ./examples/
+
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v1
       with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -81,14 +81,18 @@ jobs:
       run: |
         python -m pytest --cov=fissa --cov-report term --cov-report xml --cov-config .coveragerc --junitxml=testresults.xml
 
-    - name: "Notebooks: Remove unsupported notebooks"
-      run: |
-        rm examples/*SIMA*;
-        rm examples/*Suite2p*;
+    - name: "Notebooks: Remove SIMA notebooks"
+      if: ${{ matrix.test-sima != 'true' }}
+      run: rm examples/*SIMA*;
+
+    - name: "Notebooks: Remove Suite2p notebooks"
+      if: ${{ matrix.test-suite2p != 'true' }}
+      run: rm examples/*Suite2p*;
 
     - name: "Notebooks: Install dependencies"
       run: |
         python -m pip install .[plotting]
+        if [[ "$USE_SIMA" == "true" ]]; then python -m pip install sima; fi;
 
     - name: "Notebooks: Lint check"
       run: python -m pytest --nbsmoke-lint ./examples/

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -33,11 +33,15 @@ jobs:
         os: [ubuntu-latest]
         python-version: ["2.7", "3.5", "3.9"]
         include:
+          - os: ubuntu-latest
+            python-version: "3.6"
+            use-sima: "true"
           - os: windows-latest
             python-version: "3.9"
     env:
       OS: ${{ matrix.os }}
       PYTHON: ${{ matrix.python-version }}
+      USE_SIMA: ${{ matrix.use-sima }}
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -33,15 +33,11 @@ jobs:
         os: [ubuntu-latest]
         python-version: ["2.7", "3.5", "3.9"]
         include:
-          - os: ubuntu-latest
-            python-version: "3.6"
-            use-sima: "true"
           - os: windows-latest
             python-version: "3.9"
     env:
       OS: ${{ matrix.os }}
       PYTHON: ${{ matrix.python-version }}
-      USE_SIMA: ${{ matrix.use-sima }}
 
     steps:
     - uses: actions/checkout@v2
@@ -53,6 +49,13 @@ jobs:
 
     - name: System information
       run: python .github/workflows/system_info.py
+
+    - name: Dynamically determine extra variables depending on Python version
+      run: |
+        echo "Running on Python $PYTHON"
+        TEST_SIMA=$(python -c "import sys; print(sys.version_info[:2] <= (3, 6))")
+        echo "TEST_SIMA = $TEST_SIMA"
+        echo "test_sima=$TEST_SIMA" >> $GITHUB_ENV
 
     - name: Get pip cache dir
       id: pip-cache
@@ -86,17 +89,17 @@ jobs:
         python -m pytest --cov=fissa --cov-report term --cov-report xml --cov-config .coveragerc --junitxml=testresults.xml
 
     - name: "Notebooks: Remove SIMA notebooks"
-      if: ${{ matrix.test-sima != 'true' }}
+      if: ${{ env.test_sima != 'True' }}
       run: rm examples/*SIMA*;
 
     - name: "Notebooks: Remove Suite2p notebooks"
-      if: ${{ matrix.test-suite2p != 'true' }}
+      if: ${{ env.test_suite2p != 'True' }}
       run: rm examples/*Suite2p*;
 
     - name: "Notebooks: Install dependencies"
       run: |
         python -m pip install .[plotting]
-        if [[ "$USE_SIMA" == "true" ]]; then python -m pip install sima; fi;
+        if [[ "${{ env.test_sima }}" == "True" ]]; then python -m pip install sima; fi;
 
     - name: "Notebooks: Lint check"
       run: python -m pytest --nbsmoke-lint ./examples/

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -19,21 +19,27 @@ sys.path.insert(0, os.path.abspath('.'))
 sys.path.insert(0, os.path.abspath('../'))
 
 
-from fissa import __meta__ as meta  # noqa: E402
+# Can't import __meta__.py if the requirements aren't installed
+# due to imports in __init__.py. This is a workaround.
+def read(fname):
+    return open(os.path.join(os.path.dirname(__file__), fname)).read()
+
+meta = {}
+exec(read("../fissa/__meta__.py"), meta)
 
 
 # -- Project information -----------------------------------------------------
 
 now = datetime.datetime.now()
 
-project = meta.name.upper()
-project_path = meta.path
-author = meta.author
+project = meta["name"].upper()
+project_path = meta["path"]
+author = meta["author"]
 copyright = '{}, {}'.format(now.year, author)
 
 
 # The full version, including alpha/beta/rc tags
-release = meta.version
+release = meta["version"]
 # The short X.Y version
 version = '.'.join(release.split('.')[0:2])
 
@@ -200,7 +206,7 @@ latex_elements = {
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
     (master_doc, project + '.tex', project + ' Documentation',
-     meta.author, 'manual'),
+     meta["author"], 'manual'),
 ]
 
 
@@ -221,7 +227,7 @@ man_pages = [
 #  dir menu entry, description, category)
 texinfo_documents = [
     (master_doc, project, project + ' Documentation',
-     author, project, meta.description,
+     author, project, meta["description"],
      'Miscellaneous'),
 ]
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,1 @@
+-r ../requirements_docs.txt

--- a/fissa/readimagejrois.py
+++ b/fissa/readimagejrois.py
@@ -12,6 +12,7 @@ Modified
 
 from __future__ import division
 from __future__ import unicode_literals
+from past.builtins import basestring
 
 from builtins import str
 from builtins import range


### PR DESCRIPTION
We need to migrate from TravisCI to GitHub Actions because Travis has ended their "free for open source" policy. (GHA is free to use.)

Based on my template at https://github.com/scottclowe/python-template-repo, this PR adds three workflows:
- doc
- tests
- test-release-candidate

Notes:
- The docs workflow ensures the docs can be built.
- The test workflow runs the unit tests on Python 2.7, 3.5, and 3.9 on Linux, and Py 3.9 on Windows. Unlike the Travis workflow, we don't test compatibility with the oldest versions of our dependencies though.
- The test-release-candidate workflow runs a larger range of OS and Python combinations. It also builds and saves wheels. This only runs on new releases and on PRs to release branches.
- As we are testing Windows here, this will make the AppVeyor deployment not really necessary (which is good because it is slow to run on AppVeyor's free plan). Though AppVeyor does test in 32-bit as well as 64-bit, which we don't do with this GHA workflow.
- The notebooks are lint and smoke tested (check whether they run, but not the output) However the Suite2p notebook is not tested since it requires a conda build. The SIMA notebook is tested for all Python <=3.6 (since they do not support higher python versions).
- Test results are pushed to CodeCov, but not Coveralls (we will drop Coveralls and just use CodeCov in a later PR).

We also catch a bug with an unimported `basestring` from `past` in `fissa/readimagejrois.py`. This wasn't an issue in Python 3.8 and below, but becomes a bug in Python 3.9 which dropped `basestring`.

We also change `docs/conf.py` so it can run without having the `fissa` package installed, so now only the dependencies in `requirements_docs.txt` are needed to build the documentation.