### PR TITLE
DOC: Fix docs preventing docs from building

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,1 +1,2 @@
+-r ../requirements.txt
 -r ../requirements_docs.txt

--- a/fissa/__meta__.py
+++ b/fissa/__meta__.py
@@ -1,7 +1,7 @@
 name = 'fissa'
 path = name
 version = '0.7.dev0'
-author = "Sander Keemink & Scott Lowe"
+author = "Sander Keemink and Scott Lowe"
 author_email = "swkeemink@scimail.eu"
 description = "A Python Library estimating somatic signals in 2-photon data"
 url = "https://github.com/rochefort-lab/fissa"


### PR DESCRIPTION
- Because we use apidoc to generate documentation on the fly, we need all of fissa's requirements installed to build the docs. So we add a reference to the main requirements.txt file to the docs/requirements.txt file that is used by the ammaraskar/sphinx-action@master action in our docs GHA workflow.
- Change the metadata to join authors with "and" instead of "&". This fixes a bug with building the docs as a LaTeX pdf file with sphinx.