### PR TITLE
DOC: Change test badge from Travis to GHA

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,7 +8,7 @@ FISSA
 +------------------+----------------------------------------------------------+
 | Documentation    | |readthedocs|                                            |
 +------------------+----------------------------------------------------------+
-| Build Status     | |Documentation| |Travis| |AppVeyor| |Codecov|            |
+| Build Status     | |Documentation| |GHA tests| |AppVeyor| |Codecov|         |
 +------------------+----------------------------------------------------------+
 | Interactive Demo | |Binder|                                                 |
 +------------------+----------------------------------------------------------+
@@ -356,9 +356,9 @@ with this program. If not, see http://www.gnu.org/licenses/.
 .. |Py Versions| image:: https://img.shields.io/pypi/pyversions/fissa
    :target: PyPI_
    :alt: Python Versions Supported
-.. |Travis| image:: https://img.shields.io/travis/rochefort-lab/fissa/master?label=Linux%20build
-   :target: https://travis-ci.org/rochefort-lab/fissa
-   :alt: Travis Build Status
+.. |GHA tests| image:: https://github.com/rochefort-lab/fissa/workflows/tests/badge.svg
+   :target: https://github.com/rochefort-lab/fissa/actions?query=workflow%3Atests
+   :alt: GHA Status
 .. |AppVeyor| image:: https://img.shields.io/appveyor/build/scottclowe/rochefort-lab-fissa/master?label=Windows%20build
    :target: https://ci.appveyor.com/project/scottclowe/rochefort-lab-fissa/branch/master
    :alt: AppVeyor Build Status


### PR DESCRIPTION
Follow up from #154.

We must drop Travis support because they only give a small amount of credits out to open source projects now [[1]](https://blog.travis-ci.com/2020-11-02-travis-ci-new-billing) [[2]](https://blog.travis-ci.com/oss-announcement) [[3]](https://travis-ci.com/plans), hence the move to GitHub Actions.