### PR TITLE
CI: Trim down number of jobs running on Travis and AppVeyor

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -22,36 +22,20 @@ environment:
     # Otherwise, the requested version of Python will be downloaded
     # and installed using the script .ci/appveyor/install.ps1
 
-    - PYTHON: C:\Python38-x64
-      PYTHON_VERSION: "3.8.x"
-      PYTHON_ARCH: "64"
-      USE_SIMA: "false"
-      SKIPPABLE: "false"
-
     - PYTHON: C:\Python35
       PYTHON_VERSION: "3.5.x"
       PYTHON_ARCH: "32"
       SKIPPABLE: "false"
 
-    - PYTHON: C:\Python35-x64
-      PYTHON_VERSION: "3.5.x"
-      PYTHON_ARCH: "64"
-      SKIPPABLE: "true"
-
-    - PYTHON: C:\Python36-x64
-      PYTHON_VERSION: "3.6.x"
-      PYTHON_ARCH: "64"
-      SKIPPABLE: "true"
-
-    - PYTHON: C:\Python37-x64
-      PYTHON_VERSION: "3.7.x"
-      PYTHON_ARCH: "64"
-      USE_SIMA: "false"
-      SKIPPABLE: "true"
-
     - PYTHON: C:\Python38
       PYTHON_VERSION: "3.8.x"
       PYTHON_ARCH: "32"
+      USE_SIMA: "false"
+      SKIPPABLE: "true"
+
+    - PYTHON: C:\Python38-x64
+      PYTHON_VERSION: "3.8.x"
+      PYTHON_ARCH: "64"
       USE_SIMA: "false"
       SKIPPABLE: "true"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -67,7 +67,8 @@ jobs:
         - USE_SUITE2P="true"
 
     # All versions pre-installed
-    - python: "3.8"
+    - if: branch =~ /^v?\d+(\.[x\d]+)+$/
+      python: "3.8"
       env:
         - USE_SIMA="false"
 
@@ -76,22 +77,11 @@ jobs:
         - USE_OLDEST_DEPS="true"
         - TEST_NOTEBOOKS="false"
 
-    - python: "2.7"
-
     - python: "3.5"
       env:
         - USE_OLDEST_DEPS="true"
         - TEST_NOTEBOOKS="false"
 
-    - python: "3.5"
-
-    - if: type = cron OR branch =~ /^v?\d+(\.[x\d]+)+$/
-      python: "3.6"
-
-    - if: type = cron OR branch =~ /^v?\d+(\.[x\d]+)+$/
-      python: "3.7"
-      env:
-        - USE_SIMA="false"
 
 ###############################################################################
 # Setup the environment before installing


### PR DESCRIPTION
We don't need to replicate jobs running on GHA on the other systems.

Now AppVeyor just runs tests on 32 bit Windows, and Travis just checks on the oldest versions of our dependencies, and the Suite2P notebook (which still builds correctly on Travis).