### PR TITLE
RF: Tidy up

### DIFF
--- a/fissa/ROI.py
+++ b/fissa/ROI.py
@@ -21,7 +21,6 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
 
-from builtins import filter
 from itertools import product
 # from warnings import warn
 

--- a/fissa/core.py
+++ b/fissa/core.py
@@ -10,6 +10,7 @@ from past.builtins import basestring
 
 import collections
 import glob
+from multiprocessing import Pool
 import os.path
 import sys
 import warnings
@@ -21,15 +22,6 @@ from . import datahandler
 from . import deltaf
 from . import neuropil as npil
 from . import roitools
-
-try:
-    from multiprocessing import Pool
-    has_multiprocessing = True
-except ImportError:
-    warnings.warn('Multiprocessing library is not installed, using single ' +
-                  'core instead. To use multiprocessing install it by: ' +
-                  'pip install multiprocessing')
-    has_multiprocessing = False
 
 
 def extract_func(inputs):
@@ -306,7 +298,6 @@ class Experiment():
 
             # Check whether we should use multiprocessing
             use_multiprocessing = (
-                has_multiprocessing and
                 (self.ncores_preparation is None or self.ncores_preparation > 1)
             )
             # Do the extraction
@@ -437,7 +428,6 @@ class Experiment():
 
             # Check whether we should use multiprocessing
             use_multiprocessing = (
-                has_multiprocessing and
                 (self.ncores_separation is None or self.ncores_separation > 1)
             )
             # Do the extraction

--- a/fissa/readimagejrois.py
+++ b/fissa/readimagejrois.py
@@ -14,9 +14,6 @@ from __future__ import division
 from __future__ import unicode_literals
 from past.builtins import basestring
 
-from builtins import str
-from builtins import range
-
 import sys
 from itertools import product
 

--- a/fissa/roitools.py
+++ b/fissa/roitools.py
@@ -6,8 +6,6 @@ Authors:
 
 from __future__ import division
 
-from builtins import range
-
 import numpy as np
 from skimage.measure import find_contours
 

--- a/fissa/tests/test_datahandler.py
+++ b/fissa/tests/test_datahandler.py
@@ -46,7 +46,7 @@ class TestRois2Masks(BaseTestCase):
 
     def test_imagej_zip(self):
         # load zip of rois
-        ROI_loc = 'fissa/tests/resources/RoiSet.zip'
+        ROI_loc = os.path.join(self.test_directory, 'resources', 'RoiSet.zip')
         actual = datahandler.rois2masks(ROI_loc, self.data)
 
         # assert equality

--- a/fissa/tests/test_datahandler_framebyframe.py
+++ b/fissa/tests/test_datahandler_framebyframe.py
@@ -42,7 +42,7 @@ class TestRois2Masks(BaseTestCase):
 
     def test_imagej_zip(self):
         # load zip of rois
-        ROI_loc = 'fissa/tests/resources/RoiSet.zip'
+        ROI_loc = os.path.join(self.test_directory, 'resources', 'RoiSet.zip')
         actual = datahandler.rois2masks(ROI_loc, self.data)
 
         # assert equality


### PR DESCRIPTION
- Don't need to import builtins.
- Can always assume multiprocessing is available as it has been part of the standard library since Py 2.7.
- Use os.path.join for building path to test data.