### PR TITLE
MNT: Use ndarray for all outputs, not list for some

### DIFF
--- a/fissa/core.py
+++ b/fissa/core.py
@@ -325,6 +325,7 @@ class Experiment():
 
             # predefine data structures
             raw = [[None for t in range(self.nTrials)] for c in range(nCell)]
+            raw = np.asarray(raw)
             roi_polys = np.copy(raw)
 
             # store results
@@ -407,6 +408,7 @@ class Experiment():
             # predefine data structures
             sep = [[None for t in range(self.nTrials)]
                    for c in range(self.nCell)]
+            sep = np.asarray(sep)
             result = np.copy(sep)
             mixmat = np.copy(sep)
             info = np.copy(sep)
@@ -499,6 +501,7 @@ class Experiment():
         """
         deltaf_raw = [[None for t in range(self.nTrials)]
                       for c in range(self.nCell)]
+        deltaf_raw = np.asarray(deltaf_raw)
         deltaf_result = np.copy(deltaf_raw)
 
         # loop over cells


### PR DESCRIPTION
Because we make the first of each output type with list comprehension and then copy it with `np.copy()`, that means one output is a list of lists of x and the others are 2d numpy arrays of x.

This PR changes the odd-one-out so it is a numpy array as well.