### PR TITLE
BUG: Don't needlessly redo prep

### DIFF
--- a/fissa/core.py
+++ b/fissa/core.py
@@ -384,8 +384,8 @@ class Experiment():
 
         """
         # Do data preparation
-        self.separation_prep(redo_prep)
-        if redo_prep:
+        if redo_prep or self.raw is None:
+            self.separation_prep(redo_prep)
             redo_sep = True
 
         # Define filename to store data in


### PR DESCRIPTION
At the moment, `separation_prep` is called every time `separate` is called.

If caching is enabled, that means `experiment.raw` is wiped and overwritten with a fresh version loaded from disc. If it is the same as the current `self.raw` this is a waste of time loading data which is already loaded. If it is not the same, that may be because the user actually wanted to run on the manually set `experiment.raw` data.

If caching is not enabled, this means the user can run `experiment.separation_prep`, then run `experiment.separate` and `experiment.separation_prep` is needlessly completely redone from scratch. Or they can run `experiment.separate` once, change `alpha` and re-run `experiment.separate` and the prep work is also redone.

This PR changes it so `separate` only calls `separation_prep` if `redo_prep` is enabled or if it does not have any raw data already loaded.