### PR TITLE
BUG: Stop always unnecessarily redoing separate

### DIFF
--- a/fissa/core.py
+++ b/fissa/core.py
@@ -387,6 +387,7 @@ class Experiment():
         # Do data preparation
         if redo_prep or self.raw is None:
             self.separation_prep(redo_prep)
+        if redo_prep:
             redo_sep = True
 
         # Define filename to store data in

--- a/fissa/core.py
+++ b/fissa/core.py
@@ -285,7 +285,10 @@ class Experiment():
             try:
                 nCell, raw, roi_polys = np.load(fname, allow_pickle=True)
                 print('Reloading previously prepared data...')
-            except BaseException:
+            except BaseException as err:
+                print("An error occurred while loading {}".format(fname))
+                print(err)
+                print("Extraction will be redone and {} overwritten".format(fname))
                 redo = True
 
         if redo:
@@ -400,7 +403,13 @@ class Experiment():
             try:
                 info, mixmat, sep, result = np.load(fname, allow_pickle=True)
                 print('Reloading previously separated data...')
-            except BaseException:
+            except BaseException as err:
+                print("An error occurred while loading {}".format(fname))
+                print(err)
+                print(
+                    "Signal separation will be redone and {} overwritten"
+                    "".format(fname)
+                )
                 redo_sep = True
 
         # separate data, if necessary

--- a/fissa/core.py
+++ b/fissa/core.py
@@ -281,6 +281,8 @@ class Experiment():
             fname = os.path.join(self.folder, 'preparation.npy')
 
         # try to load data from filename
+        if fname is None or not os.path.isfile(fname):
+            redo = True
         if not redo:
             try:
                 nCell, raw, roi_polys = np.load(fname, allow_pickle=True)
@@ -399,6 +401,8 @@ class Experiment():
             redo_sep = True
         else:
             fname = os.path.join(self.folder, 'separated.npy')
+        if fname is None or not os.path.isfile(fname):
+            redo_sep = True
         if not redo_sep:
             try:
                 info, mixmat, sep, result = np.load(fname, allow_pickle=True)

--- a/fissa/tests/base_test.py
+++ b/fissa/tests/base_test.py
@@ -7,6 +7,7 @@ import contextlib
 import unittest
 import os.path
 from inspect import getsourcefile
+import sys
 
 import numpy as np
 from numpy.testing import (assert_almost_equal,
@@ -48,6 +49,33 @@ class BaseTestCase(unittest.TestCase):
     @pytest.fixture(autouse=True)
     def capsys(self, capsys):
         self.capsys = capsys
+
+    def recapsys(self, *captures):
+        """
+        Capture stdout and stderr, then write them back to stdout and stderr.
+
+        Capture is done using the `pytest.capsys` fixture.
+
+        Parameters
+        ----------
+        *captures : pytest.CaptureResult, optional
+            A series of extra captures to output. For each `capture` in
+            `captures`, `capture.out` and `capture.err` are written to stdout
+            and stderr.
+
+        Returns
+        -------
+        capture : pytest.CaptureResult
+            `capture.out` and `capture.err` contain all the outputs to stdout
+            and stderr since the previous capture with `~pytest.capsys`.
+        """
+        capture_now = self.capsys.readouterr()
+        for capture in captures:
+            sys.stdout.write(capture.out)
+            sys.stderr.write(capture.err)
+        sys.stdout.write(capture_now.out)
+        sys.stderr.write(capture_now.err)
+        return capture_now
 
     def assert_almost_equal(self, *args, **kwargs):
         return assert_almost_equal(*args, **kwargs)

--- a/fissa/tests/base_test.py
+++ b/fissa/tests/base_test.py
@@ -13,6 +13,7 @@ from numpy.testing import (assert_almost_equal,
                            assert_array_equal,
                            assert_allclose,
                            assert_equal)
+import pytest
 
 
 # Check where the test directory is located, to be used when fetching
@@ -43,6 +44,10 @@ class BaseTestCase(unittest.TestCase):
             yield super(BaseTestCase, self).subTest(*args, **kwargs)
         else:
             yield None
+
+    @pytest.fixture(autouse=True)
+    def capsys(self, capsys):
+        self.capsys = capsys
 
     def assert_almost_equal(self, *args, **kwargs):
         return assert_almost_equal(*args, **kwargs)

--- a/fissa/tests/base_test.py
+++ b/fissa/tests/base_test.py
@@ -72,3 +72,35 @@ class BaseTestCase(unittest.TestCase):
         self.assertEqual(desired.keys(), actual.keys())
         for k in desired.keys():
             self.assertEqual(desired[k], actual[k])
+
+    def assert_starts_with(self, desired, actual):
+        """
+        Check that a string starts with a certain substring.
+
+        Parameters
+        ----------
+        desired : str
+            Desired initial string.
+        actual : str-like
+            Actual string or string-like object.
+        """
+        try:
+            self.assertTrue(len(actual) >= len(desired))
+        except BaseException as err:
+            print("Actual string too short ({} < {} characters)".format(len(actual), len(desired)))
+            print("ACTUAL: {}".format(actual))
+            raise
+        try:
+            return assert_equal(str(actual)[:len(desired)], desired)
+        except BaseException as err:
+            msg = "ACTUAL: {}".format(actual)
+            if isinstance(getattr(err, "args", None), str):
+                err.args += "\n" + msg
+            elif isinstance(getattr(err, "args", None), tuple):
+                if len(err.args) == 1:
+                    err.args = (err.args[0] + "\n" + msg, )
+                else:
+                    err.args += (msg, )
+            else:
+                print(msg)
+            raise


### PR DESCRIPTION
In #171 preparation was no longer unnecessarily rerun. However, it introduced a new bug where now separation sometimes unnecessarily ran. This fixes that.