### PR TITLE
MNT: Resolve deprecation warnings

### DIFF
--- a/fissa/core.py
+++ b/fissa/core.py
@@ -14,6 +14,10 @@ from multiprocessing import Pool
 import os.path
 import sys
 import warnings
+try:
+    from collections import abc
+except ImportError:
+    import collections as abc
 
 import numpy as np
 from scipy.io import savemat
@@ -198,7 +202,7 @@ class Experiment():
         """
         if isinstance(images, basestring):
             self.images = sorted(glob.glob(os.path.join(images, '*.tif*')))
-        elif isinstance(images, collections.abc.Sequence):
+        elif isinstance(images, abc.Sequence):
             self.images = images
         else:
             raise ValueError('images should either be string or list')
@@ -208,7 +212,7 @@ class Experiment():
                 self.rois = [rois] * len(self.images)
             else:
                 self.rois = sorted(glob.glob(os.path.join(rois, '*.zip')))
-        elif isinstance(rois, collections.abc.Sequence):
+        elif isinstance(rois, abc.Sequence):
             self.rois = rois
             if len(rois) == 1:  # if only one roiset is specified
                 self.rois *= len(self.images)

--- a/fissa/core.py
+++ b/fissa/core.py
@@ -198,7 +198,7 @@ class Experiment():
         """
         if isinstance(images, basestring):
             self.images = sorted(glob.glob(os.path.join(images, '*.tif*')))
-        elif isinstance(images, collections.Sequence):
+        elif isinstance(images, collections.abc.Sequence):
             self.images = images
         else:
             raise ValueError('images should either be string or list')
@@ -208,7 +208,7 @@ class Experiment():
                 self.rois = [rois] * len(self.images)
             else:
                 self.rois = sorted(glob.glob(os.path.join(rois, '*.zip')))
-        elif isinstance(rois, collections.Sequence):
+        elif isinstance(rois, collections.abc.Sequence):
             self.rois = rois
             if len(rois) == 1:  # if only one roiset is specified
                 self.rois *= len(self.images)

--- a/fissa/extraction.py
+++ b/fissa/extraction.py
@@ -8,7 +8,10 @@ Authors:
 
 from past.builtins import basestring
 
-import collections
+try:
+    from collections import abc
+except ImportError:
+    import collections as abc
 
 import numpy as np
 import tifffile
@@ -180,7 +183,7 @@ class DataHandlerTifffile(DataHandlerAbstract):
         if isinstance(rois, basestring):
             rois = roitools.readrois(rois)
 
-        if not isinstance(rois, collections.abc.Sequence):
+        if not isinstance(rois, abc.Sequence):
             raise TypeError(
                 'Wrong ROIs input format: expected a list or sequence, but got'
                 ' a {}'.format(rois.__class__)
@@ -310,7 +313,7 @@ class DataHandlerPillow(DataHandlerAbstract):
         if isinstance(rois, basestring):
             rois = roitools.readrois(rois)
 
-        if not isinstance(rois, collections.abc.Sequence):
+        if not isinstance(rois, abc.Sequence):
             raise TypeError(
                 'Wrong ROIs input format: expected a list or sequence, but got'
                 ' a {}'.format(rois.__class__)

--- a/fissa/extraction.py
+++ b/fissa/extraction.py
@@ -180,7 +180,7 @@ class DataHandlerTifffile(DataHandlerAbstract):
         if isinstance(rois, basestring):
             rois = roitools.readrois(rois)
 
-        if not isinstance(rois, collections.Sequence):
+        if not isinstance(rois, collections.abc.Sequence):
             raise TypeError(
                 'Wrong ROIs input format: expected a list or sequence, but got'
                 ' a {}'.format(rois.__class__)
@@ -310,7 +310,7 @@ class DataHandlerPillow(DataHandlerAbstract):
         if isinstance(rois, basestring):
             rois = roitools.readrois(rois)
 
-        if not isinstance(rois, collections.Sequence):
+        if not isinstance(rois, collections.abc.Sequence):
             raise TypeError(
                 'Wrong ROIs input format: expected a list or sequence, but got'
                 ' a {}'.format(rois.__class__)

--- a/fissa/tests/test_ROI.py
+++ b/fissa/tests/test_ROI.py
@@ -40,6 +40,8 @@ def test_poly2mask():
     masks = ROI.poly2mask([poly1, poly2], (3, 3))
     assert_equal(
         masks[0].todense(),
-        np.matrix([[True, False, False],
-                   [True, True, False],
-                   [False, False, False]], dtype=bool))
+        np.array(
+            [[True, False, False], [True, True, False], [False, False, False]],
+            dtype=bool,
+        ),
+    )


### PR DESCRIPTION
- Change `np.matrix` to `np.array`
- Use `collections.abc` for abstract base classes, instead of the deprecated alias to them on `collections`