### PR TITLE
DOC: Docstring and README improvements

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -27,8 +27,9 @@ For details of the algorithm, please see our `companion paper <doi_>`_
 published in Scientific Reports. For the code used to generate the simulated
 data in the companion paper, see the `SimCalc repository`_.
 
-FISSA is compatible with both Python 2.7 and Python >=3.5, however Python 3 is
-strongly encouraged as Python 2 has `reached its end of life <sunset_python2_>`_.
+FISSA is compatible with both Python 2.7 and Python >=3.5, however it is
+strongly encouraged that you use Python 3, since as Python 2 has
+`reached its end of life <sunset_python2_>`_.
 FISSA is continually tested on Ubuntu, Windows, and Mac OSX during its
 development cycle.
 

--- a/README.rst
+++ b/README.rst
@@ -328,7 +328,7 @@ License
 -------
 
 Unless otherwise stated in individual files, all code is Copyright (c)
-2015–2020, Sander Keemink, Scott Lowe, and Nathalie Rochefort. All rights
+2015–2021, Sander Keemink, Scott Lowe, and Nathalie Rochefort. All rights
 reserved.
 
 This program is free software; you can redistribute it and/or modify it

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -255,14 +255,19 @@ epub_exclude_files = ['search.html']
 # -- Options for intersphinx extension ---------------------------------------
 
 # Example configuration for intersphinx: refer to the Python standard library.
+# Common intersphinx mappings can be found here:
+# https://gist.github.com/bskinn/0e164963428d4b51017cebdb6cda5209
 intersphinx_mapping = {
-    'python': ('https://docs.python.org/', None),
-    'NumPy': ('https://docs.scipy.org/doc/numpy/', None),
-    'SciPy': ('https://docs.scipy.org/doc/scipy/reference', None),
-    'matplotlib': ('https://matplotlib.org', None),
-    'sklearn': ('https://scikit-learn.org/stable', None),
-    'Pillow': ('https://pillow.readthedocs.io/en/stable/', None),
-    'skimage': ('https://github.com/scikit-image/docs/raw/gh-pages/dev/', None),
+    "python": ("https://docs.python.org/", None),
+    "python3": ("https://docs.python.org/3/", None),
+    "attrs": ("https://www.attrs.org/en/stable/", None),
+    "numpy": ("https://numpy.org/doc/stable/", None),
+    "scipy": ("https://docs.scipy.org/doc/scipy/reference/", None),
+    "matplotlib": ("https://matplotlib.org/stable/", None),
+    "pandas": ("https://pandas.pydata.org/docs/", None),
+    "Pillow": ("https://pillow.readthedocs.io/en/latest/", None),
+    "skimage": ("https://scikit-image.org/", None),
+    "sklearn": ("https://scikit-learn.org/stable/", None),
 }
 
 # -- Options for todo extension ----------------------------------------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -115,8 +115,12 @@ napoleon_use_admonition_for_examples = False
 napoleon_use_admonition_for_notes = False
 napoleon_use_admonition_for_references = False
 napoleon_use_ivar = False
-napoleon_use_param = True
 napoleon_use_rtype = True
+napoleon_use_param = True
+napoleon_type_aliases = {
+    "array_like": ":term:`array_like`",
+    "array-like": ":term:`array-like <array_like>`",
+}
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/fissa/ROI.py
+++ b/fissa/ROI.py
@@ -30,11 +30,12 @@ from shapely.geometry import MultiPolygon, Polygon, Point
 
 
 def poly2mask(polygons, im_size):
-    """Converts polygons to a sparse binary mask.
+    """
+    Convert polygons to a sparse binary mask.
 
     >>> from fissa.ROI import poly2mask
-    >>> poly1 = [[0,0], [0,1], [1,1], [1,0]]
-    >>> poly2 = [[0,1], [0,2], [2,2], [2,1]]
+    >>> poly1 = [[0, 0], [0, 1], [1, 1], [1, 0]]
+    >>> poly2 = [[0, 1], [0, 2], [2, 2], [2, 1]]
     >>> mask = poly2mask([poly1, poly2], (3, 3))
     >>> mask[0].todense()
     matrix([[ True, False, False],
@@ -44,11 +45,11 @@ def poly2mask(polygons, im_size):
     Parameters
     ----------
     polygons : sequence of coordinates or sequence of Polygons
-        A sequence of polygons where each is either a sequence of (x,y) or
-        (x,y,z) coordinate pairs, an Nx2 or Nx3 numpy array, or a Polygon
+        A sequence of polygons where each is either a sequence of ``(x, y)`` or
+        ``(x, y, z)`` coordinate pairs, an Nx2 or Nx3 numpy array, or a Polygon
         object.
     im_size : tuple
-        Final size of the resulting mask
+        Final size of the resulting mask.
 
     Returns
     -------
@@ -94,7 +95,8 @@ def poly2mask(polygons, im_size):
 
 
 def _reformat_polygons(polygons):
-    """Convert polygons to a MulitPolygon.
+    """
+    Convert polygons to a MultiPolygon.
 
     Accepts one more more sequence of 2- or 3-element sequences or a sequence
     of shapely Polygon objects.
@@ -103,13 +105,12 @@ def _reformat_polygons(polygons):
     ----------
     polygons : sequence of 2- or 3-element coordinates or sequence of Polygons
         Polygon(s) to be converted to a MulitPolygon.  Coordinates are used to
-        initialize a shapely MultiPolygon, and thus should follow a (x, y, z)
-        coordinate space convention.
+        initialize a shapely MultiPolygon, and thus should follow a
+        ``(x, y, z)`` coordinate space convention.
 
     Returns
     -------
     MultiPolygon
-
     """
     if len(polygons) == 0:
         # Just return an empty MultiPolygon

--- a/fissa/deltaf.py
+++ b/fissa/deltaf.py
@@ -1,32 +1,33 @@
-'''
+"""
 Functions for computing correcting fluorescence signals for changes in
 baseline activity.
 
 Authors:
-    - Scott C Lowe
-'''
+    - Scott C Lowe <scott.code.lowe@gmail.com>
+"""
 
 import numpy as np
 import scipy.signal
 
 
 def findBaselineF0(rawF, fs, axis=0, keepdims=False):
-    """Find the baseline for a fluorescence imaging trace line.
+    """
+    Find the baseline for a fluorescence imaging trace line.
 
     The baseline, F0, is the 5th-percentile of the 1Hz
     lowpass filtered signal.
 
     Parameters
     ----------
-    rawF : array_like
+    rawF : :term:`array_like`
         Raw fluorescence signal.
     fs : float
-        Sampling frequency of rawF, in Hz.
+        Sampling frequency of `rawF`, in Hz.
     axis : int, optional
-        Dimension which contains the time series. Default is 0.
+        Dimension which contains the time series. Default is ``0``.
     keepdims : bool, optional
         Whether to preserve the dimensionality of the input. Default is
-        `False`.
+        ``False``.
 
     Returns
     -------
@@ -35,10 +36,9 @@ def findBaselineF0(rawF, fs, axis=0, keepdims=False):
 
     Note
     ----
-    In typical usage, the input rawF is expected to be sized
-    `(numROI, numTimePoints, numRecs)`
-    and the output will then be sized `(numROI, 1, numRecs)`
-    if `keepdims` is `True`.
+    In typical usage, the input `rawF` is expected to be sized
+    ``(numROI, numTimePoints, numRecs)``, and the output is correspondingly
+    sized ``(numROI, 1, numRecs)`` if `keepdims` is ``True``.
     """
     # Parameters --------------------------------------------------------------
     nfilt = 30  # Number of taps to use in FIR filter

--- a/fissa/extraction.py
+++ b/fissa/extraction.py
@@ -44,12 +44,12 @@ class DataHandlerAbstract():
 
         Parameters
         ----------
-        image : type
+        image : image_type
             Some handle to, or representation of, the raw imagery data.
 
         Returns
         -------
-        data : type
+        data : data_type
             Internal representation of the images which will be used by all
             the other methods in this class.
         """
@@ -64,7 +64,7 @@ class DataHandlerAbstract():
 
         Parameters
         ----------
-        data : type
+        data : data_type
             The same object as returned by :meth:`image2array`.
 
         Returns
@@ -90,7 +90,7 @@ class DataHandlerAbstract():
 
         Returns
         -------
-        masks : type
+        masks : mask_type
             Masks, in a format accepted by :meth:`extracttraces`.
 
         See Also
@@ -108,9 +108,9 @@ class DataHandlerAbstract():
 
         Parameters
         ----------
-        data : type
+        data : data_type
             The same object as returned by :meth:`image2array`.
-        masks : type
+        masks : mask_type
             The same object as returned by :meth:`rois2masks`.
 
         Returns

--- a/fissa/extraction.py
+++ b/fissa/extraction.py
@@ -31,12 +31,11 @@ class DataHandlerAbstract():
       :meth:`extracttraces` must be the same format as the output to
       :meth:`image2array`.
     - The `masks` input into :meth:`extracttraces` must be the same format
-      as the output of :meth:`rois2mask`.
+      as the output of :meth:`rois2masks`.
 
     See Also
     --------
-    See :class:`DataHandlerTifffile` and :class:`DataHandlerPillow` for example
-    subclasses.
+    DataHandlerTifffile, DataHandlerPillow
     """
     @staticmethod
     def image2array(image):
@@ -78,19 +77,25 @@ class DataHandlerAbstract():
     @staticmethod
     def rois2masks(rois, data):
         """
-        Convert `rois` into a collection of binary masks.
+        Convert ROIs into a collection of binary masks.
 
         Parameters
         ----------
-        rois : type
-            Incoming ROIs are formatted before becoming binary masks.
-        data : type
+        rois : str or :term:`list` of :term:`array_like`
+            Either a string containing a path to an ImageJ roi zip file,
+            or a list of arrays encoding polygons, or list of binary arrays
+            representing masks.
+        data : data_type
             The same object as returned by :meth:`image2array`.
 
         Returns
         -------
         masks : type
             Masks, in a format accepted by :meth:`extracttraces`.
+
+        See Also
+        --------
+        fissa.roitools.getmasks, fissa.roitools.readrois
         """
         raise NotImplementedError()
 
@@ -127,8 +132,8 @@ class DataHandlerTifffile(DataHandlerAbstract):
 
         Parameters
         ----------
-        image : str or array_like
-            Either a path to a TIFF file, or array_like data.
+        image : str or :term:`array_like`
+            Either a path to a TIFF file, or :term:`array_like` data.
 
         Returns
         -------
@@ -147,7 +152,7 @@ class DataHandlerTifffile(DataHandlerAbstract):
 
         Parameters
         ----------
-        data : array_like
+        data : :term:`array_like`
             Data array as made by :meth:`image2array`, shaped ``(frames, y, x)``.
 
         Returns
@@ -163,17 +168,17 @@ class DataHandlerTifffile(DataHandlerAbstract):
 
         Parameters
         ----------
-        rois : str or list of array_like
+        rois : str or :term:`list` of :term:`array_like`
             Either a string containing a path to an ImageJ roi zip file,
             or a list of arrays encoding polygons, or list of binary arrays
             representing masks.
-        data : array
+        data : :term:`array_like`
             Data array as made by :meth:`image2array`. Must be shaped
             ``(frames, y, x)``.
 
         Returns
         -------
-        masks : list of numpy.ndarray
+        masks : :term:`list` of :class:`numpy.ndarray`
             List of binary arrays.
         """
         # get the image shape
@@ -205,9 +210,9 @@ class DataHandlerTifffile(DataHandlerAbstract):
 
         Parameters
         ----------
-        data : array_like
+        data : :term:`array_like`
             Data array as made by :meth:`image2array`, shaped ``(frames, y, x)``.
-        masks : list of array_like
+        masks : :class:`list` of :term:`array_like`
             List of binary arrays.
 
         Returns
@@ -294,7 +299,7 @@ class DataHandlerPillow(DataHandlerAbstract):
 
         Parameters
         ----------
-        rois : str or list of array_like
+        rois : str or :term:`list` of :term:`array_like`
             Either a string containing a path to an ImageJ roi zip file,
             or a list of arrays encoding polygons, or list of binary arrays
             representing masks.
@@ -337,7 +342,7 @@ class DataHandlerPillow(DataHandlerAbstract):
         ----------
         data : PIL.Image
             An open :class:`PIL.Image` handle to a multi-frame TIFF image.
-        masks : list of array_like
+        masks : list of :term:`array_like`
             List of binary arrays.
 
         Returns

--- a/fissa/neuropil.py
+++ b/fissa/neuropil.py
@@ -2,8 +2,8 @@
 Functions for removal of neuropil from calcium signals.
 
 Authors:
-    - Sander W Keemink (swkeemink@scimail.eu)
-    - Scott C Lowe
+    - Sander W Keemink <swkeemink@scimail.eu>
+    - Scott C Lowe <scott.code.lowe@gmail.com>
 Created:
     2015-05-15
 """
@@ -21,66 +21,67 @@ def separate(
 
     Parameters
     ----------
-    S : array_like
+    S : :term:`array_like`
         2-d array containing mixed input signals.
         Each column of `S` should be a different signal, and each row an
-        observation of the signals. For `S[i,j]`, `j` = each signal,
-        `i` = signal content.
-        The first column, `j = 0`, is considered the primary signal and the
+        observation of the signals. For ``S[i,j]``, `j` = each signal,
+        ``i`` = signal content.
+        The first column, ``j = 0``, is considered the primary signal and the
         one for which we will try to extract a decontaminated equivalent.
 
-    sep_method : {'ica','nmf'}
+    sep_method : {"ica", "nmf"}
         Which source separation method to use, either ICA or NMF.
 
-        - `'ica'`: Independent Component Analysis
-        - `'nmf'`: Non-negative Matrix Factorization
+        - ``"ica"``: Independent Component Analysis
+        - ``"nmf"``: Non-negative Matrix Factorization
 
     n : int, optional
-        How many components to estimate. If `None` (default), use PCA to
+        How many components to estimate. If ``None`` (default), use PCA to
         estimate how many components would explain at least 99% of the
-        variance and adopt this value for `n`.
+        variance and adopt this value for ``n``.
     maxiter : int, optional
-        Number of maximally allowed iterations. Default is 500.
+        Number of maximally allowed iterations. Default is ``500``.
     tol : float, optional
-        Error tolerance for termination. Default is 1e-5.
-    random_state : int, optional
-        Initial state for the random number generator. Set to None to use
-        the numpy.random default. Default seed is 892.
+        Error tolerance for termination. Default is ``1e-5``.
+    random_state : int or None, optional
+        Initial state for the random number generator. Set to ``None`` to use
+        the numpy.random default. Default seed is ``892``.
     maxtries : int, optional
         Maximum number of tries before algorithm should terminate.
-        Default is 10.
-    W0 : array_like, optional
-        Optional starting condition for `W` in NMF algorithm.
+        Default is ``10``.
+    W0 : :term:`array_like`, optional
+        Optional starting condition for ``W`` in NMF algorithm.
         (Ignored when using the ICA method.)
-    H0 : array_like, optional
-        Optional starting condition for `H` in NMF algorithm.
+    H0 : :term:`array_like`, optional
+        Optional starting condition for ``H`` in NMF algorithm.
         (Ignored when using the ICA method.)
     alpha : float, optional
         Sparsity regularizaton weight for NMF algorithm. Set to zero to
-        remove regularization. Default is 0.1.
+        remove regularization. Default is ``0.1``.
         (Ignored when using the ICA method.)
 
     Returns
     -------
-    numpy.ndarray
+    S_sep : numpy.ndarray
         The raw separated traces.
-    numpy.ndarray
+    S_matched : numpy.ndarray
         The separated traces matched to the primary signal, in order
         of matching quality (see Methods below).
-    numpy.ndarray
+    A_sep : numpy.ndarray
         Mixing matrix.
-    dict
+    convergence : dict
         Metadata for the convergence result, with keys:
 
-        - `'random_state'`: seed for ICA initiation
-        - `'iterations'`: number of iterations needed for convergence
-        - `'max_iterations'`: maximum number of iterations allowed
-        - `'converged'`: whether the algorithm converged or not (bool)
+        - ``"random_state"``: seed for ICA initiation
+        - ``"iterations"``: number of iterations needed for convergence
+        - ``"max_iterations"``: maximum number of iterations allowed
+        - ``"converged"``: whether the algorithm converged or not (`bool`)
 
     Notes
     -----
     Concept by Scott Lowe and Sander Keemink.
-    Normalize the columns in estimated mixing matrix A so that `sum(column)=1`.
+    Normalize the columns in estimated mixing matrix A so that
+    ``sum(column) = 1``.
     This results in a relative score of how strongly each separated signal
     is represented in each ROI signal.
     """

--- a/fissa/readimagejrois.py
+++ b/fissa/readimagejrois.py
@@ -26,7 +26,8 @@ if sys.version_info >= (3, 0):
 
 
 def _parse_roi_file_py2(roi_obj):
-    """Parses an individual ImageJ ROI
+    """
+    Parse an individual ImageJ ROI.
 
     This is based on the Java implementation:
     http://rsbweb.nih.gov/ij/developer/source/ij/io/RoiDecoder.java.html
@@ -42,16 +43,15 @@ def _parse_roi_file_py2(roi_obj):
     Returns
     -------
     dict
-        Returns a parsed ROI object, a dictionary with either a `'polygons'`
-        or a `'mask'` field.
+        Returns a parsed ROI object, a dictionary with either a ``"polygons"``
+        or a ``"mask"`` field.
 
     Raises
     ------
     IOError
-        If there is an error reading the roi file object
+        If there is an error reading the roi file object.
     ValueError
-        If unable to parse ROI
-
+        If unable to parse ROI.
     """
     # If this is a string, try opening the path as a file and running on its
     # contents
@@ -274,13 +274,13 @@ def _parse_roi_file_py3(roi_source):
     Parameters
     ----------
     roi_source : str or file object
-        Path to file, or file object containing a single ImageJ ROI
+        Path to file, or file object containing a single ImageJ ROI.
 
     Returns
     -------
     dict
-        Returns a parsed ROI object, a dictionary with either a `'polygons'`
-        or a `'mask'` field.
+        Returns a parsed ROI object, a dictionary with either a ``"polygons"``
+        or a ``"mask"`` field.
 
     Raises
     ------
@@ -411,17 +411,18 @@ parse_roi_file = _parse_roi_file_py3 if sys.version_info >= (3, 0) else _parse_r
 
 
 def read_imagej_roi_zip(filename):
-    """Reads an ImageJ ROI zip set and parses each ROI individually
+    """
+    Read an ImageJ ROI zip set and parse each ROI individually.
 
     Parameters
     ----------
     filename : str
-        Path to the ImageJ ROis zip file
+        Path to the ImageJ ROis zip file.
 
     Returns
     -------
     roi_list : list
-        List of the parsed ImageJ ROIs
+        List of the parsed ImageJ ROIs.
     """
     roi_list = []
     with zipfile.ZipFile(filename) as zf:

--- a/fissa/roitools.py
+++ b/fissa/roitools.py
@@ -1,8 +1,9 @@
-'''Functions used for ROI manipulation.
+"""
+Functions used for ROI manipulation.
 
 Authors:
     - Sander W Keemink <swkeemink@scimail.eu>
-'''
+"""
 
 from __future__ import division
 
@@ -14,21 +15,21 @@ from .ROI import poly2mask
 
 
 def get_mask_com(mask):
-    '''
+    """
     Get the center of mass for a boolean mask.
 
     Parameters
     ----------
-    mask : array_like
+    mask : :term:`array_like`
         A two-dimensional boolean-mask.
 
     Returns
     -------
-    float
+    x : float
         Center of mass along first dimension.
-    float
+    y : float
         Center of mass along second dimension.
-    '''
+    """
     # Ensure array_like input is a numpy.ndarray
     mask = np.asarray(mask)
 
@@ -44,31 +45,29 @@ def get_mask_com(mask):
 
 
 def split_npil(mask, centre, num_slices, adaptive_num=False):
-    '''
-    Splits a mask into a number of approximately equal slices by area around
-    the center of the mask.
+    """
+    Split a mask into approximately equal slices by area around its center.
 
     Parameters
     ----------
-    mask : array_like
+    mask : :term:`array_like`
         Mask as a 2d boolean array.
     centre : tuple
         The center co-ordinates around which the mask will be split.
     num_slices : int
         The number of slices into which the mask will be divided.
     adaptive_num : bool, optional
-        If True, the `num_slices` input is treated as the number of
+        If ``True``, the `num_slices` input is treated as the number of
         slices to use if the ROI is surrounded by valid pixels, and
         automatically reduces the number of slices if it is on the
         boundary of the sampled region.
 
     Returns
     -------
-    list
+    masks : list
         A list with `num_slices` many masks, each of which is a 2d
         boolean numpy array.
-
-    '''
+    """
     #TODO: This should yield an iterable instead.
 
     # Ensure array_like input is a numpy.ndarray
@@ -134,25 +133,24 @@ def split_npil(mask, centre, num_slices, adaptive_num=False):
 
 
 def shift_2d_array(a, shift=1, axis=0):
-    '''
+    """
     Shifts an entire array in the direction of axis by the amount shift,
     without refilling the array.
 
     Parameters
     ----------
-    a : array_like
+    a : :term:`array_like`
         Input array.
     shift : int, optional
-        How much to shift array by. Default is 1.
+        How much to shift array by. Default is ``1``.
     axis : int, optional
-        The axis along which elements are shifted. Default is 0.
+        The axis along which elements are shifted. Default is ``0``.
 
     Returns
     -------
-    numpy.ndarray
-        Array with the same shape as a, but shifted appropriately.
-
-    '''
+    out : numpy.ndarray
+        Array with the same shape as `a`, but shifted appropriately.
+    """
     # Ensure array_like input is a numpy.ndarray
     a = np.asarray(a)
 
@@ -181,26 +179,9 @@ def shift_2d_array(a, shift=1, axis=0):
 
 
 def get_npil_mask(mask, totalexpansion=4):
-    '''
+    """
     Given the masks for a ROI, find the surrounding neuropil.
 
-    Parameters
-    ----------
-    mask : array_like
-        The reference ROI mask to expand the neuropil from. The array
-        should contain only boolean values.
-    expansion : float, optional
-        How much larger to make the neuropil total area than mask area.
-
-    Returns
-    -------
-    numpy.ndarray
-        A boolean numpy.ndarray mask, where the region surrounding
-        the input is now True and the region of the input mask is
-        False.
-
-    Notes
-    -----
     Our implementation is as follows:
 
     - On even iterations (where indexing begins at zero), expand
@@ -211,11 +192,27 @@ def get_npil_mask(mask, totalexpansion=4):
     This procedure generates a neuropil whose shape is similar to the
     shape of the input ROI mask.
 
+    Parameters
+    ----------
+    mask : :term:`array_like`
+        The reference ROI mask to expand the neuropil from. The array
+        should contain only boolean values.
+    totalexpansion : float, optional
+        How much larger to make the neuropil total area than mask area.
+        Default is ``4``.
+
+    Returns
+    -------
+    grown_mask : numpy.ndarray
+        A boolean numpy.ndarray mask, where the region surrounding
+        the input is now ``True`` and the region of the input mask is
+        ``False``.
+
     Note
     ----
     For fixed number of `iterations`, squarer input masks will have
     larger output neuropil masks.
-    '''
+    """
     # Ensure array_like input is a numpy.ndarray
     mask = np.asarray(mask)
 
@@ -280,22 +277,24 @@ def get_npil_mask(mask, totalexpansion=4):
 
 
 def getmasks_npil(cellMask, nNpil=4, expansion=1):
-    '''Generate neuropil masks using the get_npil_mask function.
+    """
+    Generate neuropil masks using :func:`get_npil_mask` function.
 
     Parameters
     ----------
-    cellMask : array_like
-        the cell mask (boolean 2d arrays)
-    nNpil : int
-        number of neuropil subregions
-    expansion : float
-        How much larger to make neuropil subregion area than in `cellMask`
+    cellMask : :term:`array_like`
+        The cell mask (boolean 2d arrays).
+    nNpil : int, optional
+        Number of neuropil subregions. Default is ``4``.
+    expansion : float, optional
+        Area of each neuropil region, relative to the area of `cellMask`.
+        Default is ``1``.
 
     Returns
     -------
-    list
-        Returns a list with soma + neuropil masks (boolean 2d arrays)
-    '''
+    masks_split : list
+        Returns a list with soma and neuropil masks (boolean 2d arrays).
+    """
     # Ensure array_like input is a numpy.ndarray
     cellMask = np.asarray(cellMask)
 
@@ -312,19 +311,22 @@ def getmasks_npil(cellMask, nNpil=4, expansion=1):
 
 
 def readrois(roiset):
-    ''' read the imagej rois in the zipfile roiset, and make sure that the
-    third dimension (i.e. frame number) is always zero.
+    """
+    Read ImageJ rois from a roiset zipfile.
+
+    We ensure that the third dimension (i.e. frame number) is always zero.
 
     Parameters
     ----------
     roiset : str
-        folder to a zip file with rois
+        Path to a roiset zipfile.
 
     Returns
     -------
-    list
-        Returns the rois as polygons
-    '''
+    rois : list
+        The ROIs (regions of interest) from within roiset, as polygons
+        describing the outline of each ROI.
+    """
     # read rois
     rois = read_imagej_roi_zip(roiset)
 
@@ -358,26 +360,27 @@ def readrois(roiset):
 
 
 def getmasks(rois, shpe):
-    '''Get the masks for the specified rois.
+    """
+    Get the masks for the specified rois.
 
     Parameters
     ----------
-    rois : list
-        list of roi coordinates. Each roi coordinate should be a 2d-array
+    rois : :term:`array_like`
+        List of roi coordinates. Each roi coordinate should be a 2d-array
         or equivalent list. i.e.:
-        ``roi = [[0,0], [0,1], [1,1], [1,0]]``
+        ``roi = [[0, 0], [0, 1], [1, 1], [1, 0]]``
         or
-        ``roi = np.array([[0,0], [0,1], [1,1], [1,0]])``
+        ``roi = np.array([[0, 0], [0, 1], [1, 1], [1, 0]])``
         i.e. a n by 2 array, where n is the number of coordinates.
         If a 2 by n array is given, this will be transposed.
-    shpe : array/list
-        shape of underlying image [width,height]
+    shpe : :term:`array_like`
+        Shape of underlying image ``(width, height)``.
 
     Returns
     -------
-    list of numpy.ndarray
-        List of masks for each roi in the rois list
-    '''
+    masks : :term:`list` of :class:`numpy.ndarray`
+        List of masks for each ROI in `rois`.
+    """
     # get number of rois
     nrois = len(rois)
 
@@ -398,21 +401,21 @@ def getmasks(rois, shpe):
 
 
 def find_roi_edge(mask):
-    '''
-    Finds the outline of a mask, using the find_contour function from
-    skimage.measure.
+    """
+    Find the outline of a mask.
+
+    Uses :func:`skimage.measure.find_contours`.
 
     Parameters
     ----------
-    mask : array_like
-        the mask, a binary array
+    mask : :term:`array_like`
+        The mask, as a binary array.
 
     Returns
     -------
-    outline : list of (n,2)-ndarrays
-        Array with coordinates of pixels in the outline of the mask
-    '''
-
+    outline : :term:`list` of (n,2)-:class:`~numpy.ndarray`
+        Array with coordinates of pixels in the outline of the mask.
+    """
     # Ensure array_like input is a numpy.ndarray
     mask = np.asarray(mask)
 

--- a/fissa/tests/generate_downsampled_resources.py
+++ b/fissa/tests/generate_downsampled_resources.py
@@ -46,7 +46,7 @@ def downscale_roi(source_file, dest_file, downsamp=[1, 1], offsets=[0, 0]):
         filename already exists, it will be overwritten.
     downsamp : list or array_like, optional
         Downsampling factor for [x, y]. This must be a length two list,
-        tuple, or array_like. Default is `[1, 1]`, which corresponds to
+        tuple, or :term:`array-like`. Default is `[1, 1]`, which corresponds to
         an output roi the same size as the original roi. If `downsamp=[2, 2]`,
         the output will be half the size.
     offsets : list or array_like, optional

--- a/setup.py
+++ b/setup.py
@@ -75,6 +75,7 @@ setup(
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
         "Topic :: Scientific/Engineering",
         "Topic :: Scientific/Engineering :: Bio-Informatics",
         "Topic :: Scientific/Engineering :: Information Analysis",


### PR DESCRIPTION
- General docstring improvements.
- Fix rendering of markup in compiled documentation (verified locally against the HTML docs). I had to add `:term:` around some of the type entries which weren't getting picked up automatically. There are still some `str` entries which did not get picked up and still wouldn't work with a `:term:` attribute added.
- Fix some intersphinx issues (numpy moved their documentation, which broke that intersphinx link up). However, `PIL.Image` is still not working correctly; I was unable to resolve that.
- A couple of fixes to the name of the variable in the docstring, where it didn't match the name of the variable accepted by the function/method.
- Blacken sample code within docstrings.
- Change copyright year to 2021.
- Add Python 3.9 to our list of Trove classifiers, since we now test on python3.9 in our CI.