### PR TITLE
RF+ENH+BUG: Use npz for cache; store means

### DIFF
--- a/fissa/core.py
+++ b/fissa/core.py
@@ -280,22 +280,23 @@ class Experiment():
         Parameters
         ----------
         path : str or None, optional
-            Path to cache file. If ``None`` (default), the default cache paths
-            of ``"<folder>/preparation.npz"`` and ``"<folder>/separated.npz"``
-            are loaded, where ``<folder>`` is the `folder` parameter
-            (``self.folder``) which was provided when the object was
-            initialised.
+            Path to cache file (.npz format) or a directory containing
+            ``"preparation.npz"`` and/or ``"separated.npz"`` files.
+            If ``None`` (default), the `folder` parameter which was provided
+            when the object was initialised is used (``self.folder``).
         """
         if path is None:
             if self.folder is None:
                 raise ValueError(
                     "path must be provided if experiment folder is not defined"
                 )
+            path = self.folder
+        if os.path.isdir(path) or path == "":
             for fname in ("preparation.npz", "separated.npz"):
-                path = os.path.join(self.folder, fname)
-                if not os.path.exists(path):
+                fullfname = os.path.join(path, fname)
+                if not os.path.exists(fullfname):
                     continue
-                self.load(path)
+                self.load(fullfname)
             return
         print("Reloading data from cache {}...".format(path))
         cache = np.load(path, allow_pickle=True)

--- a/fissa/core.py
+++ b/fissa/core.py
@@ -330,7 +330,7 @@ class Experiment():
 
         print('Doing region growing and data extraction....')
         # define inputs
-        inputs = [0] * self.nTrials
+        inputs = [[]] * self.nTrials
         for trial in range(self.nTrials):
             inputs[trial] = [self.images[trial], self.rois[trial],
                              self.nRegions, self.expansion, self.datahandler]
@@ -355,7 +355,7 @@ class Experiment():
                 results = pool.map(extract_func, inputs)
 
         else:
-            results = [0] * self.nTrials
+            results = [[]] * self.nTrials
             for trial in range(self.nTrials):
                 results[trial] = extract_func(inputs[trial])
 
@@ -495,7 +495,7 @@ class Experiment():
         info = np.copy(sep)
 
         # loop over cells to define function inputs
-        inputs = [0] * int(self.nCell)
+        inputs = [[]] * int(self.nCell)
         for cell in range(self.nCell):
             # initiate concatenated data
             X = np.concatenate(self.raw[cell], axis=1)
@@ -528,7 +528,7 @@ class Experiment():
                 # run separation
                 results = pool.map(separate_func, inputs)
         else:
-            results = [0] * int(self.nCell)
+            results = [[]] * int(self.nCell)
             for cell in range(self.nCell):
                 results[cell] = separate_func(inputs[cell])
 

--- a/fissa/core.py
+++ b/fissa/core.py
@@ -567,7 +567,7 @@ class Experiment():
             Path to output file. The default destination is ``"separated.npz"``
             within the cache directory ``self.folder``.
         """
-        fields = ["info", "mixmat", "sep", "result"]
+        fields = ["deltaf_raw", "deltaf_result", "info", "mixmat", "sep", "result"]
         if destination is None:
             if self.folder is None:
                 raise ValueError(
@@ -662,6 +662,10 @@ class Experiment():
 
         self.deltaf_raw = deltaf_raw
         self.deltaf_result = deltaf_result
+
+        # Maybe save to cache file
+        if self.folder is not None:
+            self.save_separated()
 
     def save_to_matlab(self, fname=None):
         """Save the results to a MATLAB file.

--- a/fissa/core.py
+++ b/fissa/core.py
@@ -494,7 +494,7 @@ class Experiment():
         info = np.copy(sep)
 
         # loop over cells to define function inputs
-        inputs = [0] * self.nCell
+        inputs = [0] * int(self.nCell)
         for cell in range(self.nCell):
             # initiate concatenated data
             X = np.concatenate(self.raw[cell], axis=1)
@@ -527,7 +527,7 @@ class Experiment():
                 # run separation
                 results = pool.map(separate_func, inputs)
         else:
-            results = [0] * self.nCell
+            results = [0] * int(self.nCell)
             for cell in range(self.nCell):
                 results[cell] = separate_func(inputs[cell])
 

--- a/fissa/core.py
+++ b/fissa/core.py
@@ -249,7 +249,7 @@ class Experiment():
         # check if any data already exists
         if folder is None:
             pass
-        elif not os.path.exists(folder):
+        elif folder and not os.path.exists(folder):
             os.makedirs(folder)
         elif os.path.isfile(os.path.join(folder, "preparation.npz")):
             if os.path.isfile(os.path.join(folder, "separated.npz")):

--- a/fissa/core.py
+++ b/fissa/core.py
@@ -400,6 +400,9 @@ class Experiment():
                     " preparation outputs the cache."
                 )
             destination = os.path.join(self.folder, 'preparation.npz')
+        destdir = os.path.dirname(destination)
+        if destdir and not os.path.isdir(destdir):
+            os.makedirs(destdir)
         np.savez_compressed(
             destination,
             **{field: getattr(self, field) for field in fields}
@@ -571,6 +574,9 @@ class Experiment():
                     " separation outputs to the cache."
                 )
             destination = os.path.join(self.folder, "separated.npz")
+        destdir = os.path.dirname(destination)
+        if destdir and not os.path.isdir(destdir):
+            os.makedirs(destdir)
         np.savez_compressed(
             destination,
             **{field: getattr(self, field) for field in fields}

--- a/fissa/core.py
+++ b/fissa/core.py
@@ -381,9 +381,7 @@ class Experiment():
                 results = pool.map(extract_func, inputs)
 
         else:
-            results = [[]] * self.nTrials
-            for trial in range(self.nTrials):
-                results[trial] = extract_func(inputs[trial])
+            results = [extract_func(inputs[trial]) for trial in range(self.nTrials)]
 
         # get number of cells
         nCell = len(results[0][1])
@@ -539,9 +537,7 @@ class Experiment():
                 # run separation
                 results = pool.map(separate_func, inputs)
         else:
-            results = [[]] * int(self.nCell)
-            for cell in range(self.nCell):
-                results[cell] = separate_func(inputs[cell])
+            results = [separate_func(inputs[cell]) for cell in range(self.nCell)]
 
         # read results
         for cell in range(self.nCell):

--- a/fissa/core.py
+++ b/fissa/core.py
@@ -297,6 +297,7 @@ class Experiment():
             Wipe outputs, and attributes downstream of outputs.
             """
             # Wipe outputs
+            self.means = []
             self.nCell = None
             self.raw = None
             self.roi_polys = None
@@ -366,15 +367,15 @@ class Experiment():
         raw = np.asarray(raw)
         roi_polys = np.copy(raw)
 
-        # store results
+        # Set outputs
+        _wipe()
+
         for trial in range(self.nTrials):
             self.means += [results[trial][2]]
             for cell in range(nCell):
                 raw[cell][trial] = results[trial][0][cell]
                 roi_polys[cell][trial] = results[trial][1][cell]
 
-        # Set outputs
-        _wipe()
         self.nCell = nCell  # number of cells
         self.raw = raw
         self.roi_polys = roi_polys

--- a/fissa/core.py
+++ b/fissa/core.py
@@ -393,7 +393,7 @@ class Experiment():
             Path to output file. The default destination is ``"separated.npz"``
             within the cache directory ``self.folder``.
         """
-        fields = ["nCell", "raw", "roi_polys"]
+        fields = ["means", "nCell", "raw", "roi_polys"]
         if destination is None:
             if self.folder is None:
                 raise ValueError(

--- a/fissa/core.py
+++ b/fissa/core.py
@@ -328,6 +328,9 @@ class Experiment():
                 print(err)
                 print("Extraction will be redone and {} overwritten".format(fname))
 
+        # Wipe outputs
+        self.clear()
+        # Extract signals
         print('Doing region growing and data extraction....')
         # define inputs
         inputs = [[]] * self.nTrials
@@ -368,8 +371,6 @@ class Experiment():
         roi_polys = np.copy(raw)
 
         # Set outputs
-        self.clear()
-
         for trial in range(self.nTrials):
             self.means.append(results[trial][2])
             for cell in range(nCell):
@@ -472,7 +473,9 @@ class Experiment():
                     "".format(fname)
                 )
 
-        # separate data, if necessary
+        # Wipe outputs
+        self.clear_separated()
+        # Separate data
         print('Doing signal separation....')
         # predefine data structures
         sep = [[None for t in range(self.nTrials)]
@@ -534,8 +537,6 @@ class Experiment():
                 mixmat[cell][trial] = Xmixmat
                 info[cell][trial] = convergence
 
-        # Wipe outputs
-        self.clear_separated()
         # Set outputs
         self.info = info
         self.mixmat = mixmat

--- a/fissa/core.py
+++ b/fissa/core.py
@@ -371,7 +371,7 @@ class Experiment():
         _wipe()
 
         for trial in range(self.nTrials):
-            self.means += [results[trial][2]]
+            self.means.append(results[trial][2])
             for cell in range(nCell):
                 raw[cell][trial] = results[trial][0][cell]
                 roi_polys[cell][trial] = results[trial][1][cell]

--- a/fissa/tests/base_test.py
+++ b/fissa/tests/base_test.py
@@ -22,8 +22,8 @@ import pytest
 TEST_DIRECTORY = os.path.dirname(os.path.abspath(getsourcefile(lambda: 0)))
 
 
-def assert_equal_list_of_array_perm_inv(desired, actual):
-    assert_equal(len(desired), len(actual))
+def assert_equal_list_of_array_perm_inv(actual, desired):
+    assert_equal(len(actual), len(desired))
     for desired_i in desired:
         n_matches = 0
         for actual_j in actual:
@@ -31,12 +31,12 @@ def assert_equal_list_of_array_perm_inv(desired, actual):
                 n_matches += 1
         assert n_matches >= 0
 
-def assert_equal_dict_of_array(desired, actual):
-    assert_equal(desired.keys(), actual.keys())
+def assert_equal_dict_of_array(actual, desired):
+    assert_equal(actual.keys(), desired.keys())
     for k in desired.keys():
-        assert_equal(desired[k], actual[k])
+        assert_equal(actual[k], desired[k])
 
-def assert_starts_with(desired, actual):
+def assert_starts_with(actual, desired):
     """
     Check that a string starts with a certain substring.
 
@@ -139,11 +139,11 @@ class BaseTestCase(unittest.TestCase):
     def assert_equal(self, actual, desired, *args, **kwargs):
         return assert_equal(actual, desired, *args, **kwargs)
 
-    def assert_equal_list_of_array_perm_inv(self, desired, actual):
-        return assert_equal_list_of_array_perm_inv(desired, actual)
+    def assert_equal_list_of_array_perm_inv(self, actual, desired):
+        return assert_equal_list_of_array_perm_inv(actual, desired)
 
-    def assert_equal_dict_of_array(self, desired, actual):
-        return assert_equal_dict_of_array(desired, actual)
+    def assert_equal_dict_of_array(self, actual, desired):
+        return assert_equal_dict_of_array(actual, desired)
 
-    def assert_starts_with(self, desired, actual):
-        return assert_starts_with(desired, actual)
+    def assert_starts_with(self, actual, desired):
+        return assert_starts_with(actual, desired)

--- a/fissa/tests/base_test.py
+++ b/fissa/tests/base_test.py
@@ -22,6 +22,14 @@ import pytest
 TEST_DIRECTORY = os.path.dirname(os.path.abspath(getsourcefile(lambda: 0)))
 
 
+def assert_allclose_ragged(actual, desired):
+    assert_equal(np.shape(actual), np.shape(desired))
+    for desired_i, actual_i in zip(desired, actual):
+        if desired.dtype == object:
+            assert_allclose_ragged(actual_i, desired_i)
+        else:
+            assert_allclose(actual_i, desired_i)
+
 def assert_equal_list_of_array_perm_inv(actual, desired):
     assert_equal(len(actual), len(desired))
     for desired_i in desired:
@@ -138,6 +146,9 @@ class BaseTestCase(unittest.TestCase):
 
     def assert_equal(self, actual, desired, *args, **kwargs):
         return assert_equal(actual, desired, *args, **kwargs)
+
+    def assert_allclose_ragged(self, actual, desired):
+        return assert_allclose_ragged(actual, desired)
 
     def assert_equal_list_of_array_perm_inv(self, actual, desired):
         return assert_equal_list_of_array_perm_inv(actual, desired)

--- a/fissa/tests/base_test.py
+++ b/fissa/tests/base_test.py
@@ -124,20 +124,20 @@ class BaseTestCase(unittest.TestCase):
         sys.stderr.write(capture_now.err)
         return capture_now
 
-    def assert_almost_equal(self, *args, **kwargs):
-        return assert_almost_equal(*args, **kwargs)
+    def assert_almost_equal(self, actual, desired, *args, **kwargs):
+        return assert_almost_equal(actual, desired, *args, **kwargs)
 
-    def assert_array_equal(self, *args, **kwargs):
-        return assert_array_equal(*args, **kwargs)
+    def assert_array_equal(self, actual, desired, *args, **kwargs):
+        return assert_array_equal(actual, desired, *args, **kwargs)
 
-    def assert_allclose(self, *args, **kwargs):
+    def assert_allclose(self, actual, desired, *args, **kwargs):
         # Handle msg argument, which is passed from assertEqual, established
         # with addTypeEqualityFunc in __init__
         msg = kwargs.pop('msg', None)
-        return assert_allclose(*args, **kwargs)
+        return assert_allclose(actual, desired, *args, **kwargs)
 
-    def assert_equal(self, *args, **kwargs):
-        return assert_equal(*args, **kwargs)
+    def assert_equal(self, actual, desired, *args, **kwargs):
+        return assert_equal(actual, desired, *args, **kwargs)
 
     def assert_equal_list_of_array_perm_inv(self, desired, actual):
         return assert_equal_list_of_array_perm_inv(desired, actual)

--- a/fissa/tests/test_core.py
+++ b/fissa/tests/test_core.py
@@ -269,6 +269,21 @@ class TestExperimentA(BaseTestCase):
         exp = core.Experiment(self.images_dir, self.roi_zip_path, output_dir)
         exp.separate()
 
+    def test_folder_deleted_before_call(self):
+        """Check we can write to a folder that is deleted in the middle"""
+        exp = core.Experiment(self.images_dir, self.roi_zip_path, self.output_dir)
+        # Delete the folder between instantiating Experiment and separate()
+        self.tearDown()
+        exp.separate()
+
+    def test_folder_deleted_between_prep_sep(self):
+        """Check we can write to a folder that is deleted in the middle"""
+        exp = core.Experiment(self.images_dir, self.roi_zip_path, self.output_dir)
+        # Delete the folder between separation_prep() and separate()
+        exp.separation_prep()
+        self.tearDown()
+        exp.separate()
+
     def test_prepfirst(self):
         exp = core.Experiment(self.images_dir, self.roi_zip_path, self.output_dir)
         exp.separation_prep()

--- a/fissa/tests/test_core.py
+++ b/fissa/tests/test_core.py
@@ -354,17 +354,17 @@ class TestExperimentA(BaseTestCase):
         capture_pre = self.capsys.readouterr()  # Clear stdout
         exp = core.Experiment(image_path, roi_path, self.output_dir)
         capture_post = self.recapsys(capture_pre)  # Capture and then re-output
-        self.assert_starts_with("Reloading previously prepared", capture_post.out)
+        self.assert_starts_with("Reloading data", capture_post.out)
         # Ensure previous cache is loaded again when we run separation_prep
         capture_pre = self.capsys.readouterr()  # Clear stdout
         exp.separation_prep()
         capture_post = self.recapsys(capture_pre)
-        self.assert_starts_with("Reloading previously prepared", capture_post.out)
+        self.assert_starts_with("Reloading data", capture_post.out)
         # Ensure previous cache is loaded again when we run separate
         capture_pre = self.capsys.readouterr()  # Clear stdout
         exp.separate()
         capture_post = self.recapsys(capture_pre)
-        self.assert_starts_with("Reloading previously separated", capture_post.out)
+        self.assert_starts_with("Reloading data", capture_post.out)
         # Check the contents loaded from cache
         actual = exp.result
         self.assert_equal(len(actual), 1)
@@ -386,12 +386,12 @@ class TestExperimentA(BaseTestCase):
         capture_pre = self.capsys.readouterr()  # Clear stdout
         exp = core.Experiment(image_path, roi_path, self.output_dir)
         capture_post = self.recapsys(capture_pre)  # Capture and then re-output
-        self.assert_starts_with("Reloading previously prepared", capture_post.out)
+        self.assert_starts_with("Reloading data", capture_post.out)
         # Ensure previous cache is loaded again when we run separation_prep
         capture_pre = self.capsys.readouterr()  # Clear stdout
         exp.separation_prep()
         capture_post = self.recapsys(capture_pre)  # Capture and then re-output
-        self.assert_starts_with("Reloading previously prepared", capture_post.out)
+        self.assert_starts_with("Reloading data", capture_post.out)
         # Since we did not run and cache separate, this needs to run now
         capture_pre = self.capsys.readouterr()  # Clear stdout
         exp.separate()
@@ -421,7 +421,7 @@ class TestExperimentA(BaseTestCase):
         capture_pre = self.capsys.readouterr()  # Clear stdout
         exp = core.Experiment(image_path, roi_path, self.output_dir)
         capture_post = self.recapsys(capture_pre)  # Capture and then re-output
-        self.assert_starts_with("An error occurred", capture_post.out)
+        self.assertTrue("An error occurred" in capture_post.out)
 
         self.assertTrue(exp.raw is None)
 
@@ -441,7 +441,7 @@ class TestExperimentA(BaseTestCase):
         capture_pre = self.capsys.readouterr()  # Clear stdout
         exp = core.Experiment(image_path, roi_path, self.output_dir)
         capture_post = self.recapsys(capture_pre)  # Capture and then re-output
-        self.assert_starts_with("An error occurred", capture_post.out)
+        self.assertTrue("An error occurred" in capture_post.out)
 
         capture_pre = self.capsys.readouterr()  # Clear stdout
         exp.separation_prep()
@@ -464,7 +464,7 @@ class TestExperimentA(BaseTestCase):
         capture_pre = self.capsys.readouterr()  # Clear stdout
         exp.separation_prep()
         capture_post = self.recapsys(capture_pre)  # Capture and then re-output
-        self.assert_starts_with("An error occurred", capture_post.out)
+        self.assertTrue("An error occurred" in capture_post.out)
 
         capture_pre = self.capsys.readouterr()  # Clear stdout
         exp.separate()
@@ -493,7 +493,7 @@ class TestExperimentA(BaseTestCase):
         capture_pre = self.capsys.readouterr()  # Clear stdout
         exp.separate()
         capture_post = self.recapsys(capture_pre)  # Capture and then re-output
-        self.assert_starts_with("An error occurred", capture_post.out)
+        self.assertTrue("An error occurred" in capture_post.out)
 
         actual = exp.result
         self.assert_equal(len(actual), 1)

--- a/fissa/tests/test_core.py
+++ b/fissa/tests/test_core.py
@@ -263,6 +263,12 @@ class TestExperimentA(BaseTestCase):
         self.assert_equal(exp.means[0].shape, self.image_shape)
         self.assert_equal(exp.means[-1].shape, self.image_shape)
 
+    def test_subfolder(self):
+        """Check we can write to a subfolder"""
+        output_dir = os.path.join(self.output_dir, "subdir")
+        exp = core.Experiment(self.images_dir, self.roi_zip_path, output_dir)
+        exp.separate()
+
     def test_prepfirst(self):
         exp = core.Experiment(self.images_dir, self.roi_zip_path, self.output_dir)
         exp.separation_prep()

--- a/fissa/tests/test_core.py
+++ b/fissa/tests/test_core.py
@@ -502,6 +502,38 @@ class TestExperimentA(BaseTestCase):
         self.assert_equal(exp.means[0].shape, self.image_shape)
         self.assert_equal(exp.means[-1].shape, self.image_shape)
 
+    def test_manual_save_prep(self):
+        """Saving prep results with manually specified filename."""
+        destination = os.path.join(self.output_dir, "m", ".test_output.npz")
+        os.makedirs(os.path.dirname(destination))
+        exp = core.Experiment(self.images_dir, self.roi_zip_path)
+        exp.separation_prep()
+        exp.save_prep(destination=destination)
+        self.assertTrue(os.path.isfile(destination))
+
+    def test_manual_save_sep(self):
+        """Saving sep results with manually specified filename."""
+        destination = os.path.join(self.output_dir, "m", ".test_output.npz")
+        os.makedirs(os.path.dirname(destination))
+        exp = core.Experiment(self.images_dir, self.roi_zip_path)
+        exp.separate()
+        exp.save_separated(destination=destination)
+        self.assertTrue(os.path.isfile(destination))
+
+    def test_manual_save_sep_undefined(self):
+        """Saving prep results without specifying a filename."""
+        exp = core.Experiment(self.images_dir, self.roi_zip_path)
+        exp.separation_prep()
+        with self.assertRaises(ValueError):
+            exp.save_prep()
+
+    def test_manual_save_prep_undefined(self):
+        """Saving sep results without specifying a filename."""
+        exp = core.Experiment(self.images_dir, self.roi_zip_path)
+        exp.separate()
+        with self.assertRaises(ValueError):
+            exp.save_separated()
+
     def test_calcdeltaf(self):
         exp = core.Experiment(self.images_dir, self.roi_zip_path)
         exp.separate()

--- a/fissa/tests/test_core.py
+++ b/fissa/tests/test_core.py
@@ -318,11 +318,11 @@ class TestExperimentA(BaseTestCase):
         capture_pre = self.capsys.readouterr()  # Clear stdout
         exp.separate()
         capture_post = self.recapsys(capture_pre)
-        self.assert_starts_with("Doing", capture_post.out)
+        self.assert_starts_with(capture_post.out, "Doing")
         capture_pre = self.capsys.readouterr()  # Clear stdout
         exp.separate(redo_prep=True, redo_sep=True)
         capture_post = self.recapsys(capture_pre)
-        self.assert_starts_with("Doing", capture_post.out)
+        self.assert_starts_with(capture_post.out, "Doing")
 
     def test_load_cache(self):
         """Test whether cached output is loaded during init."""
@@ -354,17 +354,17 @@ class TestExperimentA(BaseTestCase):
         capture_pre = self.capsys.readouterr()  # Clear stdout
         exp = core.Experiment(image_path, roi_path, self.output_dir)
         capture_post = self.recapsys(capture_pre)  # Capture and then re-output
-        self.assert_starts_with("Reloading data", capture_post.out)
+        self.assert_starts_with(capture_post.out, "Reloading data")
         # Ensure previous cache is loaded again when we run separation_prep
         capture_pre = self.capsys.readouterr()  # Clear stdout
         exp.separation_prep()
         capture_post = self.recapsys(capture_pre)
-        self.assert_starts_with("Reloading data", capture_post.out)
+        self.assert_starts_with(capture_post.out, "Reloading data")
         # Ensure previous cache is loaded again when we run separate
         capture_pre = self.capsys.readouterr()  # Clear stdout
         exp.separate()
         capture_post = self.recapsys(capture_pre)
-        self.assert_starts_with("Reloading data", capture_post.out)
+        self.assert_starts_with(capture_post.out, "Reloading data")
         # Check the contents loaded from cache
         actual = exp.result
         self.assert_equal(len(actual), 1)
@@ -386,17 +386,17 @@ class TestExperimentA(BaseTestCase):
         capture_pre = self.capsys.readouterr()  # Clear stdout
         exp = core.Experiment(image_path, roi_path, self.output_dir)
         capture_post = self.recapsys(capture_pre)  # Capture and then re-output
-        self.assert_starts_with("Reloading data", capture_post.out)
+        self.assert_starts_with(capture_post.out, "Reloading data")
         # Ensure previous cache is loaded again when we run separation_prep
         capture_pre = self.capsys.readouterr()  # Clear stdout
         exp.separation_prep()
         capture_post = self.recapsys(capture_pre)  # Capture and then re-output
-        self.assert_starts_with("Reloading data", capture_post.out)
+        self.assert_starts_with(capture_post.out, "Reloading data")
         # Since we did not run and cache separate, this needs to run now
         capture_pre = self.capsys.readouterr()  # Clear stdout
         exp.separate()
         capture_post = self.recapsys(capture_pre)
-        self.assert_starts_with("Doing signal separation", capture_post.out)
+        self.assert_starts_with(capture_post.out, "Doing signal separation")
         # Check the contents loaded from cache
         actual = exp.result
         self.assert_equal(len(actual), 1)
@@ -446,7 +446,7 @@ class TestExperimentA(BaseTestCase):
         capture_pre = self.capsys.readouterr()  # Clear stdout
         exp.separation_prep()
         capture_post = self.recapsys(capture_pre)  # Capture and then re-output
-        self.assert_starts_with("Doing region growing", capture_post.out)
+        self.assert_starts_with(capture_post.out, "Doing region growing")
 
     def test_badprepcache(self):
         """
@@ -469,7 +469,7 @@ class TestExperimentA(BaseTestCase):
         capture_pre = self.capsys.readouterr()  # Clear stdout
         exp.separate()
         capture_post = self.recapsys(capture_pre)  # Capture and then re-output
-        self.assert_starts_with("Doing signal separation", capture_post.out)
+        self.assert_starts_with(capture_post.out, "Doing signal separation")
 
         actual = exp.result
         self.assert_equal(len(actual), 1)

--- a/fissa/tests/test_core.py
+++ b/fissa/tests/test_core.py
@@ -471,6 +471,31 @@ class TestExperimentA(BaseTestCase):
         self.assert_allclose_ragged(exp.raw, exp1.raw)
         self.assert_allclose_ragged(exp.result, exp1.result)
 
+    def test_load_empty_prep(self):
+        """Behaviour when loading a prep cache that is empty."""
+        exp = core.Experiment(self.images_dir, self.roi_zip_path, self.output_dir)
+        # Make an empty prep save file
+        np.savez_compressed(os.path.join(self.output_dir, "preparation.npz"))
+        #
+        exp.separation_prep()
+        actual = exp.raw
+        self.assert_equal(len(actual), 1)
+        self.assert_equal(len(actual[0]), 1)
+        self.assert_allclose(actual[0][0].shape, self.expected_00.shape)
+
+    def test_load_empty_sep(self):
+        """Behaviour when loading a separated cache that is empty."""
+        exp = core.Experiment(self.images_dir, self.roi_zip_path, self.output_dir)
+        # Make an empty separated save file
+        np.savez_compressed(os.path.join(self.output_dir, "separated.npz"))
+        exp.separate()
+        actual = exp.result
+        self.assert_equal(len(actual), 1)
+        self.assert_equal(len(actual[0]), 1)
+        self.assert_allclose(actual[0][0], self.expected_00)
+        self.assert_equal(exp.means[0].shape, self.image_shape)
+        self.assert_equal(exp.means[-1].shape, self.image_shape)
+
     @unittest.expectedFailure
     def test_badprepcache_init1(self):
         """

--- a/fissa/tests/test_core.py
+++ b/fissa/tests/test_core.py
@@ -31,6 +31,7 @@ class TestExperimentA(BaseTestCase):
         )
         self.images_dir = os.path.join(self.resources_dir, 'images')
         self.image_names = ['AVG_A01_R1_small.tif']
+        self.image_shape = (8, 17)
         self.roi_zip_path = os.path.join(self.resources_dir, 'rois.zip')
         self.roi_paths = [os.path.join('rois', r) for r in ['01.roi']]
 
@@ -82,6 +83,8 @@ class TestExperimentA(BaseTestCase):
         self.assert_equal(len(actual), 1)
         self.assert_equal(len(actual[0]), 1)
         self.assert_allclose(actual[0][0], self.expected_00)
+        self.assert_equal(exp.means[0].shape, self.image_shape)
+        self.assert_equal(exp.means[-1].shape, self.image_shape)
 
     def test_imagelist_roizip(self):
         image_paths = [
@@ -94,6 +97,9 @@ class TestExperimentA(BaseTestCase):
         self.assert_equal(len(actual), 1)
         self.assert_equal(len(actual[0]), 1)
         self.assert_allclose(actual[0][0], self.expected_00)
+        self.assert_equal(len(exp.means), len(image_paths))
+        self.assert_equal(exp.means[0].shape, self.image_shape)
+        self.assert_equal(exp.means[-1].shape, self.image_shape)
 
     def test_imagelistloaded_roizip(self):
         image_paths = [
@@ -108,6 +114,9 @@ class TestExperimentA(BaseTestCase):
         self.assert_equal(len(actual), 1)
         self.assert_equal(len(actual[0]), 1)
         self.assert_allclose(actual[0][0], self.expected_00)
+        self.assert_equal(len(exp.means), len(image_paths))
+        self.assert_equal(exp.means[0].shape, self.image_shape)
+        self.assert_equal(exp.means[-1].shape, self.image_shape)
 
     @unittest.expectedFailure
     def test_imagedir_roilistpath(self):
@@ -121,6 +130,8 @@ class TestExperimentA(BaseTestCase):
         self.assert_equal(len(actual), 1)
         self.assert_equal(len(actual[0]), 1)
         self.assert_allclose(actual[0][0], self.expected_00)
+        self.assert_equal(exp.means[0].shape, self.image_shape)
+        self.assert_equal(exp.means[-1].shape, self.image_shape)
 
     @unittest.expectedFailure
     def test_imagelist_roilistpath(self):
@@ -138,6 +149,9 @@ class TestExperimentA(BaseTestCase):
         self.assert_equal(len(actual), 1)
         self.assert_equal(len(actual[0]), 1)
         self.assert_allclose(actual[0][0], self.expected_00)
+        self.assert_equal(len(exp.means), len(image_paths))
+        self.assert_equal(exp.means[0].shape, self.image_shape)
+        self.assert_equal(exp.means[-1].shape, self.image_shape)
 
     def test_nocache(self):
         exp = core.Experiment(self.images_dir, self.roi_zip_path)
@@ -146,6 +160,8 @@ class TestExperimentA(BaseTestCase):
         self.assert_equal(len(actual), 1)
         self.assert_equal(len(actual[0]), 1)
         self.assert_allclose(actual[0][0], self.expected_00)
+        self.assert_equal(exp.means[0].shape, self.image_shape)
+        self.assert_equal(exp.means[-1].shape, self.image_shape)
 
     def test_ncores_preparation_1(self):
         exp = core.Experiment(
@@ -159,6 +175,8 @@ class TestExperimentA(BaseTestCase):
         self.assert_equal(len(actual), 1)
         self.assert_equal(len(actual[0]), 1)
         self.assert_allclose(actual[0][0], self.expected_00)
+        self.assert_equal(exp.means[0].shape, self.image_shape)
+        self.assert_equal(exp.means[-1].shape, self.image_shape)
 
     def test_ncores_preparation_2(self):
         exp = core.Experiment(
@@ -172,6 +190,8 @@ class TestExperimentA(BaseTestCase):
         self.assert_equal(len(actual), 1)
         self.assert_equal(len(actual[0]), 1)
         self.assert_allclose(actual[0][0], self.expected_00)
+        self.assert_equal(exp.means[0].shape, self.image_shape)
+        self.assert_equal(exp.means[-1].shape, self.image_shape)
 
     def test_ncores_separate_1(self):
         exp = core.Experiment(
@@ -185,6 +205,8 @@ class TestExperimentA(BaseTestCase):
         self.assert_equal(len(actual), 1)
         self.assert_equal(len(actual[0]), 1)
         self.assert_allclose(actual[0][0], self.expected_00)
+        self.assert_equal(exp.means[0].shape, self.image_shape)
+        self.assert_equal(exp.means[-1].shape, self.image_shape)
 
     def test_ncores_separate_2(self):
         exp = core.Experiment(
@@ -198,6 +220,8 @@ class TestExperimentA(BaseTestCase):
         self.assert_equal(len(actual), 1)
         self.assert_equal(len(actual[0]), 1)
         self.assert_allclose(actual[0][0], self.expected_00)
+        self.assert_equal(exp.means[0].shape, self.image_shape)
+        self.assert_equal(exp.means[-1].shape, self.image_shape)
 
     def test_lowmemorymode(self):
         exp = core.Experiment(
@@ -211,6 +235,8 @@ class TestExperimentA(BaseTestCase):
         self.assert_equal(len(actual), 1)
         self.assert_equal(len(actual[0]), 1)
         self.assert_allclose(actual[0][0], self.expected_00)
+        self.assert_equal(exp.means[0].shape, self.image_shape)
+        self.assert_equal(exp.means[-1].shape, self.image_shape)
 
     def test_manualhandler(self):
         exp = core.Experiment(
@@ -224,6 +250,8 @@ class TestExperimentA(BaseTestCase):
         self.assert_equal(len(actual), 1)
         self.assert_equal(len(actual[0]), 1)
         self.assert_allclose(actual[0][0], self.expected_00)
+        self.assert_equal(exp.means[0].shape, self.image_shape)
+        self.assert_equal(exp.means[-1].shape, self.image_shape)
 
     def test_nofolder(self):
         self.tearDown()
@@ -233,6 +261,8 @@ class TestExperimentA(BaseTestCase):
         self.assert_equal(len(actual), 1)
         self.assert_equal(len(actual[0]), 1)
         self.assert_allclose(actual[0][0], self.expected_00)
+        self.assert_equal(exp.means[0].shape, self.image_shape)
+        self.assert_equal(exp.means[-1].shape, self.image_shape)
 
     def test_prepfirst(self):
         exp = core.Experiment(self.images_dir, self.roi_zip_path, self.output_dir)
@@ -242,6 +272,8 @@ class TestExperimentA(BaseTestCase):
         self.assert_equal(len(actual), 1)
         self.assert_equal(len(actual[0]), 1)
         self.assert_allclose(actual[0][0], self.expected_00)
+        self.assert_equal(exp.means[0].shape, self.image_shape)
+        self.assert_equal(exp.means[-1].shape, self.image_shape)
 
     def test_redo(self):
         """Test whether experiment redoes work when requested."""
@@ -267,6 +299,8 @@ class TestExperimentA(BaseTestCase):
         self.assert_equal(len(actual), 1)
         self.assert_equal(len(actual[0]), 1)
         self.assert_allclose(actual[0][0], self.expected_00)
+        self.assert_equal(exp.means[0].shape, self.image_shape)
+        self.assert_equal(exp.means[-1].shape, self.image_shape)
 
     def test_load_cache_piecemeal(self):
         """
@@ -289,6 +323,8 @@ class TestExperimentA(BaseTestCase):
         self.assert_equal(len(actual), 1)
         self.assert_equal(len(actual[0]), 1)
         self.assert_allclose(actual[0][0], self.expected_00)
+        self.assert_equal(exp.means[0].shape, self.image_shape)
+        self.assert_equal(exp.means[-1].shape, self.image_shape)
 
     def test_load_cached_prep(self):
         """
@@ -405,6 +441,8 @@ class TestExperimentA(BaseTestCase):
         self.assert_equal(len(actual), 1)
         self.assert_equal(len(actual[0]), 1)
         self.assert_allclose(actual[0][0], self.expected_00)
+        self.assert_equal(exp.means[0].shape, self.image_shape)
+        self.assert_equal(exp.means[-1].shape, self.image_shape)
 
     def test_calcdeltaf(self):
         exp = core.Experiment(self.images_dir, self.roi_zip_path, self.output_dir)

--- a/fissa/tests/test_core.py
+++ b/fissa/tests/test_core.py
@@ -76,7 +76,7 @@ class TestExperimentA(BaseTestCase):
             shutil.rmtree(self.output_dir)
 
     def test_imagedir_roizip(self):
-        exp = core.Experiment(self.images_dir, self.roi_zip_path, self.output_dir)
+        exp = core.Experiment(self.images_dir, self.roi_zip_path)
         exp.separate()
         actual = exp.result
         self.assert_equal(len(actual), 1)
@@ -90,7 +90,7 @@ class TestExperimentA(BaseTestCase):
             os.path.join(self.images_dir, img)
             for img in self.image_names
         ]
-        exp = core.Experiment(image_paths, self.roi_zip_path, self.output_dir)
+        exp = core.Experiment(image_paths, self.roi_zip_path)
         exp.separate()
         actual = exp.result
         self.assert_equal(len(actual), 1)
@@ -107,7 +107,7 @@ class TestExperimentA(BaseTestCase):
         ]
         datahandler = DataHandlerTifffile()
         images = [datahandler.image2array(pth) for pth in image_paths]
-        exp = core.Experiment(images, self.roi_zip_path, self.output_dir)
+        exp = core.Experiment(images, self.roi_zip_path)
         exp.separate()
         actual = exp.result
         self.assert_equal(len(actual), 1)
@@ -123,7 +123,7 @@ class TestExperimentA(BaseTestCase):
             os.path.join(self.resources_dir, r)
             for r in self.roi_paths
         ]
-        exp = core.Experiment(self.images_dir, roi_paths, self.output_dir)
+        exp = core.Experiment(self.images_dir, roi_paths)
         exp.separate()
         actual = exp.result
         self.assert_equal(len(actual), 1)
@@ -142,7 +142,7 @@ class TestExperimentA(BaseTestCase):
             os.path.join(self.resources_dir, r)
             for r in self.roi_paths
         ]
-        exp = core.Experiment(image_paths, roi_paths, self.output_dir)
+        exp = core.Experiment(image_paths, roi_paths)
         exp.separate()
         actual = exp.result
         self.assert_equal(len(actual), 1)
@@ -166,7 +166,6 @@ class TestExperimentA(BaseTestCase):
         exp = core.Experiment(
             self.images_dir,
             self.roi_zip_path,
-            self.output_dir,
             ncores_preparation=1,
         )
         exp.separate()
@@ -181,7 +180,6 @@ class TestExperimentA(BaseTestCase):
         exp = core.Experiment(
             self.images_dir,
             self.roi_zip_path,
-            self.output_dir,
             ncores_preparation=2,
         )
         exp.separate()
@@ -196,7 +194,6 @@ class TestExperimentA(BaseTestCase):
         exp = core.Experiment(
             self.images_dir,
             self.roi_zip_path,
-            self.output_dir,
             ncores_separation=1,
         )
         exp.separate()
@@ -211,7 +208,6 @@ class TestExperimentA(BaseTestCase):
         exp = core.Experiment(
             self.images_dir,
             self.roi_zip_path,
-            self.output_dir,
             ncores_separation=2,
         )
         exp.separate()
@@ -226,7 +222,6 @@ class TestExperimentA(BaseTestCase):
         exp = core.Experiment(
             self.images_dir,
             self.roi_zip_path,
-            self.output_dir,
             lowmemory_mode=True,
         )
         exp.separate()
@@ -251,6 +246,10 @@ class TestExperimentA(BaseTestCase):
         self.assert_allclose(actual[0][0], self.expected_00)
         self.assert_equal(exp.means[0].shape, self.image_shape)
         self.assert_equal(exp.means[-1].shape, self.image_shape)
+
+    def test_caching(self):
+        exp = core.Experiment(self.images_dir, self.roi_zip_path, self.output_dir)
+        exp.separate()
 
     def test_prefolder(self):
         os.makedirs(self.output_dir)
@@ -489,6 +488,15 @@ class TestExperimentA(BaseTestCase):
         self.assert_equal(exp.means[-1].shape, self.image_shape)
 
     def test_calcdeltaf(self):
+        exp = core.Experiment(self.images_dir, self.roi_zip_path)
+        exp.separate()
+        exp.calc_deltaf(4)
+        actual = exp.deltaf_result
+        self.assert_equal(len(actual), 1)
+        self.assert_equal(len(actual[0]), 1)
+        #TODO: Check contents of exp.deltaf_result
+
+    def test_calcdeltaf_cache(self):
         exp = core.Experiment(self.images_dir, self.roi_zip_path, self.output_dir)
         exp.separate()
         exp.calc_deltaf(4)
@@ -498,7 +506,7 @@ class TestExperimentA(BaseTestCase):
         #TODO: Check contents of exp.deltaf_result
 
     def test_calcdeltaf_notrawf0(self):
-        exp = core.Experiment(self.images_dir, self.roi_zip_path, self.output_dir)
+        exp = core.Experiment(self.images_dir, self.roi_zip_path)
         exp.separate()
         exp.calc_deltaf(4, use_raw_f0=False)
         actual = exp.deltaf_result
@@ -507,7 +515,7 @@ class TestExperimentA(BaseTestCase):
         #TODO: Check contents of exp.deltaf_result
 
     def test_calcdeltaf_notacrosstrials(self):
-        exp = core.Experiment(self.images_dir, self.roi_zip_path, self.output_dir)
+        exp = core.Experiment(self.images_dir, self.roi_zip_path)
         exp.separate()
         exp.calc_deltaf(4, across_trials=False)
         actual = exp.deltaf_result
@@ -516,7 +524,7 @@ class TestExperimentA(BaseTestCase):
         #TODO: Check contents of exp.deltaf_result
 
     def test_calcdeltaf_notrawf0_notacrosstrials(self):
-        exp = core.Experiment(self.images_dir, self.roi_zip_path, self.output_dir)
+        exp = core.Experiment(self.images_dir, self.roi_zip_path)
         exp.separate()
         exp.calc_deltaf(4, use_raw_f0=False, across_trials=False)
         actual = exp.deltaf_result

--- a/fissa/tests/test_core.py
+++ b/fissa/tests/test_core.py
@@ -263,6 +263,30 @@ class TestExperimentA(BaseTestCase):
         self.assert_equal(exp.means[0].shape, self.image_shape)
         self.assert_equal(exp.means[-1].shape, self.image_shape)
 
+    def test_cache_pwd_explict(self):
+        """Check we can use pwd as the cache folder"""
+        prevdir = os.getcwd()
+        if not os.path.exists(self.output_dir):
+            os.makedirs(self.output_dir)
+        try:
+            os.chdir(self.output_dir)
+            exp = core.Experiment(self.images_dir, self.roi_zip_path, ".")
+            exp.separate()
+        finally:
+            os.chdir(prevdir)
+
+    def test_cache_pwd_implicit(self):
+        """Check we can use pwd as the cache folder"""
+        prevdir = os.getcwd()
+        if not os.path.exists(self.output_dir):
+            os.makedirs(self.output_dir)
+        try:
+            os.chdir(self.output_dir)
+            exp = core.Experiment(self.images_dir, self.roi_zip_path, "")
+            exp.separate()
+        finally:
+            os.chdir(prevdir)
+
     def test_subfolder(self):
         """Check we can write to a subfolder"""
         output_dir = os.path.join(self.output_dir, "subdir")

--- a/fissa/tests/test_core.py
+++ b/fissa/tests/test_core.py
@@ -70,7 +70,6 @@ class TestExperimentA(BaseTestCase):
 
     def setUp(self):
         self.tearDown()
-        os.makedirs(self.output_dir)
 
     def tearDown(self):
         if os.path.isdir(self.output_dir):
@@ -253,8 +252,8 @@ class TestExperimentA(BaseTestCase):
         self.assert_equal(exp.means[0].shape, self.image_shape)
         self.assert_equal(exp.means[-1].shape, self.image_shape)
 
-    def test_nofolder(self):
-        self.tearDown()
+    def test_prefolder(self):
+        os.makedirs(self.output_dir)
         exp = core.Experiment(self.images_dir, self.roi_zip_path, self.output_dir)
         exp.separate()
         actual = exp.result

--- a/fissa/tests/test_core.py
+++ b/fissa/tests/test_core.py
@@ -415,7 +415,7 @@ class TestExperimentA(BaseTestCase):
         exp1.separation_prep()
         # Make a new experiment we will test
         new_folder = os.path.join(self.output_dir, "b")
-        exp = core.Experiment(self.images_dir, self.roi_zip_path, new_folder)
+        exp = core.Experiment(image_path, roi_path, new_folder)
         exp.load(os.path.join(prev_folder, "preparation.npz"))
         # Cached prep should now be loaded correctly
         self.assert_allclose_ragged(exp.raw, exp1.raw)
@@ -430,7 +430,7 @@ class TestExperimentA(BaseTestCase):
         exp1.separate()
         # Make a new experiment we will test
         new_folder = os.path.join(self.output_dir, "b")
-        exp = core.Experiment(self.images_dir, self.roi_zip_path, new_folder)
+        exp = core.Experiment(image_path, roi_path, new_folder)
         exp.load(os.path.join(prev_folder, "separated.npz"))
         # Cached results should now be loaded correctly
         self.assert_allclose_ragged(exp.result, exp1.result)
@@ -445,7 +445,7 @@ class TestExperimentA(BaseTestCase):
         exp1.separate()
         # Make a new experiment we will test
         new_folder = os.path.join(self.output_dir, "b")
-        exp = core.Experiment(self.images_dir, self.roi_zip_path, new_folder)
+        exp = core.Experiment(image_path, roi_path, new_folder)
         exp.load(prev_folder)
         # Cache should now be loaded correctly
         self.assert_allclose_ragged(exp.raw, exp1.raw)
@@ -461,7 +461,7 @@ class TestExperimentA(BaseTestCase):
         exp1.separate()
         # Make a new experiment we will test
         new_folder = os.path.join(self.output_dir, "b")
-        exp = core.Experiment(self.images_dir, self.roi_zip_path, new_folder)
+        exp = core.Experiment(image_path, roi_path, new_folder)
         # Copy the contents from the old cache to the new cache
         shutil.rmtree(new_folder)
         shutil.copytree(prev_folder, new_folder)

--- a/fissa/tests/test_core.py
+++ b/fissa/tests/test_core.py
@@ -463,7 +463,8 @@ class TestExperimentA(BaseTestCase):
         new_folder = os.path.join(self.output_dir, "b")
         exp = core.Experiment(self.images_dir, self.roi_zip_path, new_folder)
         # Copy the contents from the old cache to the new cache
-        shutil.copytree(prev_folder, new_folder, dirs_exist_ok=True)
+        shutil.rmtree(new_folder)
+        shutil.copytree(prev_folder, new_folder)
         # Manually trigger loading the new cache
         exp.load()
         # Cache should now be loaded correctly

--- a/fissa/tests/test_core.py
+++ b/fissa/tests/test_core.py
@@ -359,7 +359,7 @@ class TestExperimentA(BaseTestCase):
         roi_path = self.roi_zip_path
         if not os.path.exists(self.output_dir):
             os.makedirs(self.output_dir)
-        with open(os.path.join(self.output_dir, "preparation.npy"), "w") as f:
+        with open(os.path.join(self.output_dir, "preparation.npz"), "w") as f:
             f.write("badfilecontents")
 
         capture_pre = self.capsys.readouterr()  # Clear stdout
@@ -378,7 +378,7 @@ class TestExperimentA(BaseTestCase):
         roi_path = self.roi_zip_path
         if not os.path.exists(self.output_dir):
             os.makedirs(self.output_dir)
-        with open(os.path.join(self.output_dir, "preparation.npy"), "w") as f:
+        with open(os.path.join(self.output_dir, "preparation.npz"), "w") as f:
             f.write("badfilecontents")
 
         capture_pre = self.capsys.readouterr()  # Clear stdout
@@ -400,7 +400,7 @@ class TestExperimentA(BaseTestCase):
         if not os.path.exists(self.output_dir):
             os.makedirs(self.output_dir)
         exp = core.Experiment(image_path, roi_path, self.output_dir)
-        with open(os.path.join(self.output_dir, "preparation.npy"), "w") as f:
+        with open(os.path.join(self.output_dir, "preparation.npz"), "w") as f:
             f.write("badfilecontents")
 
         capture_pre = self.capsys.readouterr()  # Clear stdout
@@ -428,7 +428,7 @@ class TestExperimentA(BaseTestCase):
             os.makedirs(self.output_dir)
         exp = core.Experiment(image_path, roi_path, self.output_dir)
         exp.separation_prep()
-        with open(os.path.join(self.output_dir, "separated.npy"), "w") as f:
+        with open(os.path.join(self.output_dir, "separated.npz"), "w") as f:
             f.write("badfilecontents")
 
         capture_pre = self.capsys.readouterr()  # Clear stdout

--- a/fissa/tests/test_core.py
+++ b/fissa/tests/test_core.py
@@ -387,6 +387,8 @@ class TestExperimentA(BaseTestCase):
         self.assert_equal(len(actual), 1)
         self.assert_equal(len(actual[0]), 1)
         self.assert_allclose(actual[0][0], self.expected_00)
+        self.assert_equal(exp.means[0].shape, self.image_shape)
+        self.assert_equal(exp.means[-1].shape, self.image_shape)
 
     @unittest.expectedFailure
     def test_badprepcache_init1(self):

--- a/fissa/tests/test_core.py
+++ b/fissa/tests/test_core.py
@@ -328,8 +328,10 @@ class TestExperimentA(BaseTestCase):
         """Test whether cached output is loaded during init."""
         image_path = self.images_dir
         roi_path = self.roi_zip_path
+        # Run an experiment to generate the cache
         exp1 = core.Experiment(image_path, roi_path, self.output_dir)
         exp1.separate()
+        # Make a new experiment we will test
         exp = core.Experiment(image_path, roi_path, self.output_dir)
         # Cache should be loaded without calling separate
         actual = exp.result
@@ -345,17 +347,25 @@ class TestExperimentA(BaseTestCase):
         """
         image_path = self.images_dir
         roi_path = self.roi_zip_path
+        # Run an experiment to generate the cache
         exp1 = core.Experiment(image_path, roi_path, self.output_dir)
         exp1.separate()
+        # Make a new experiment we will test; this should load the cache
+        capture_pre = self.capsys.readouterr()  # Clear stdout
         exp = core.Experiment(image_path, roi_path, self.output_dir)
+        capture_post = self.recapsys(capture_pre)  # Capture and then re-output
+        self.assert_starts_with("Reloading previously prepared", capture_post.out)
+        # Ensure previous cache is loaded again when we run separation_prep
         capture_pre = self.capsys.readouterr()  # Clear stdout
         exp.separation_prep()
         capture_post = self.recapsys(capture_pre)
         self.assert_starts_with("Reloading previously prepared", capture_post.out)
+        # Ensure previous cache is loaded again when we run separate
         capture_pre = self.capsys.readouterr()  # Clear stdout
         exp.separate()
         capture_post = self.recapsys(capture_pre)
         self.assert_starts_with("Reloading previously separated", capture_post.out)
+        # Check the contents loaded from cache
         actual = exp.result
         self.assert_equal(len(actual), 1)
         self.assert_equal(len(actual[0]), 1)
@@ -369,20 +379,25 @@ class TestExperimentA(BaseTestCase):
         """
         image_path = self.images_dir
         roi_path = self.roi_zip_path
+        # Run an experiment to generate the cache
         exp1 = core.Experiment(image_path, roi_path, self.output_dir)
         exp1.separation_prep()
+        # Make a new experiment we will test; this should load the cache
         capture_pre = self.capsys.readouterr()  # Clear stdout
         exp = core.Experiment(image_path, roi_path, self.output_dir)
         capture_post = self.recapsys(capture_pre)  # Capture and then re-output
         self.assert_starts_with("Reloading previously prepared", capture_post.out)
+        # Ensure previous cache is loaded again when we run separation_prep
         capture_pre = self.capsys.readouterr()  # Clear stdout
         exp.separation_prep()
         capture_post = self.recapsys(capture_pre)  # Capture and then re-output
         self.assert_starts_with("Reloading previously prepared", capture_post.out)
+        # Since we did not run and cache separate, this needs to run now
         capture_pre = self.capsys.readouterr()  # Clear stdout
         exp.separate()
         capture_post = self.recapsys(capture_pre)
         self.assert_starts_with("Doing signal separation", capture_post.out)
+        # Check the contents loaded from cache
         actual = exp.result
         self.assert_equal(len(actual), 1)
         self.assert_equal(len(actual[0]), 1)
@@ -399,6 +414,7 @@ class TestExperimentA(BaseTestCase):
         roi_path = self.roi_zip_path
         if not os.path.exists(self.output_dir):
             os.makedirs(self.output_dir)
+        # Make a bad cache
         with open(os.path.join(self.output_dir, "preparation.npz"), "w") as f:
             f.write("badfilecontents")
 
@@ -418,6 +434,7 @@ class TestExperimentA(BaseTestCase):
         roi_path = self.roi_zip_path
         if not os.path.exists(self.output_dir):
             os.makedirs(self.output_dir)
+        # Make a bad cache
         with open(os.path.join(self.output_dir, "preparation.npz"), "w") as f:
             f.write("badfilecontents")
 
@@ -440,6 +457,7 @@ class TestExperimentA(BaseTestCase):
         if not os.path.exists(self.output_dir):
             os.makedirs(self.output_dir)
         exp = core.Experiment(image_path, roi_path, self.output_dir)
+        # Make a bad cache
         with open(os.path.join(self.output_dir, "preparation.npz"), "w") as f:
             f.write("badfilecontents")
 
@@ -468,6 +486,7 @@ class TestExperimentA(BaseTestCase):
             os.makedirs(self.output_dir)
         exp = core.Experiment(image_path, roi_path, self.output_dir)
         exp.separation_prep()
+        # Make a bad cache
         with open(os.path.join(self.output_dir, "separated.npz"), "w") as f:
             f.write("badfilecontents")
 

--- a/fissa/tests/test_core.py
+++ b/fissa/tests/test_core.py
@@ -282,7 +282,7 @@ class TestExperimentA(BaseTestCase):
 
     def test_subfolder(self):
         """Check we can write to a subfolder"""
-        output_dir = os.path.join(self.output_dir, "subdir")
+        output_dir = os.path.join(self.output_dir, "a", "b", "c")
         exp = core.Experiment(self.images_dir, self.roi_zip_path, output_dir)
         exp.separate()
 

--- a/fissa/tests/test_core.py
+++ b/fissa/tests/test_core.py
@@ -255,12 +255,6 @@ class TestExperimentA(BaseTestCase):
         os.makedirs(self.output_dir)
         exp = core.Experiment(self.images_dir, self.roi_zip_path, self.output_dir)
         exp.separate()
-        actual = exp.result
-        self.assert_equal(len(actual), 1)
-        self.assert_equal(len(actual[0]), 1)
-        self.assert_allclose(actual[0][0], self.expected_00)
-        self.assert_equal(exp.means[0].shape, self.image_shape)
-        self.assert_equal(exp.means[-1].shape, self.image_shape)
 
     def test_cache_pwd_explict(self):
         """Check we can use pwd as the cache folder"""

--- a/fissa/tests/test_roitools.py
+++ b/fissa/tests/test_roitools.py
@@ -185,8 +185,7 @@ class TestSplitNpil(BaseTestCase):
             np.array([[False, False], [True, False]]),
             np.array([[True, False], [False, False]]),
         ]
-        self.assert_equal_list_of_array_perm_inv(desired_npil_masks,
-                                                 npil_masks)
+        self.assert_equal_list_of_array_perm_inv(npil_masks, desired_npil_masks)
 
     def test_bottom(self):
         mask = [[0, 0], [1, 1]]
@@ -197,8 +196,7 @@ class TestSplitNpil(BaseTestCase):
             np.array([[False, False], [False, False]]),
             np.array([[False, False], [True, False]]),
         ]
-        self.assert_equal_list_of_array_perm_inv(desired_npil_masks,
-                                                 npil_masks)
+        self.assert_equal_list_of_array_perm_inv(npil_masks, desired_npil_masks)
 
     def test_bottom2(self):
         mask = [[0, 0], [1, 1]]
@@ -207,8 +205,7 @@ class TestSplitNpil(BaseTestCase):
             np.array([[False, False], [False,  True]]),
             np.array([[False, False], [True, False]]),
         ]
-        self.assert_equal_list_of_array_perm_inv(desired_npil_masks,
-                                                 npil_masks)
+        self.assert_equal_list_of_array_perm_inv(npil_masks, desired_npil_masks)
 
     def test_bottom_adaptive(self):
         mask = [[0, 0], [1, 1]]
@@ -218,8 +215,7 @@ class TestSplitNpil(BaseTestCase):
             np.array([[False, False], [False,  True]]),
             np.array([[False, False], [True, False]]),
         ]
-        self.assert_equal_list_of_array_perm_inv(desired_npil_masks,
-                                                 npil_masks)
+        self.assert_equal_list_of_array_perm_inv(npil_masks, desired_npil_masks)
 
 
 class TestGetNpilMask(BaseTestCase):


### PR DESCRIPTION
Change from saving a list of a few numpy.ndarrays with [numpy.save](https://numpy.org/doc/stable/reference/generated/numpy.save.html), we save several arrays associated with keys using
[numpy.savez_compressed](https://numpy.org/doc/stable/reference/generated/numpy.savez_compressed.html).

At the same time, we refactor some code to remove a superfluous nesting depth for the main preparation and separation code blocks.

We now save the means into the .npz file, so this is now restored. This resolves the issue (described in PR #169) that running an experiment that loads from cache does not set `experiment.means`.