### PR TITLE
ENH: Lazy tifffile

### DIFF
--- a/fissa/core.py
+++ b/fissa/core.py
@@ -224,7 +224,7 @@ class Experiment():
         if datahandler is not None:
             self.datahandler = datahandler
         elif lowmemory_mode:
-            self.datahandler = extraction.DataHandlerPillow()
+            self.datahandler = extraction.DataHandlerTifffileLazy()
         else:
             self.datahandler = extraction.DataHandlerTifffile()
 

--- a/fissa/extraction.py
+++ b/fissa/extraction.py
@@ -275,6 +275,145 @@ class DataHandlerTifffile(DataHandlerAbstract):
         return out
 
 
+class DataHandlerTifffileLazy(DataHandlerAbstract):
+    """
+    Extract data from TIFF images using tifffile, with lazy loading.
+    """
+
+    @staticmethod
+    def image2array(image):
+        """
+        Load a TIFF image from disk.
+
+        Parameters
+        ----------
+        image : str
+            A path to a TIFF file.
+
+        Returns
+        -------
+        data : tifffile.TiffFile
+            Open tifffile.TiffFile object.
+        """
+        return tifffile.TiffFile(image)
+
+    @staticmethod
+    def getmean(data):
+        """
+        Determine the mean image across all frames.
+
+        Parameters
+        ----------
+        data : tifffile.TiffFile
+            Open tifffile.TiffFile object.
+
+        Returns
+        -------
+        numpy.ndarray
+            y by x array for the mean values
+        """
+        # We don't load the entire image into memory at once, because
+        # it is likely to be rather large.
+        memory = None
+        n_frames = 0
+
+        for page in data.pages:
+            page = page.asarray()
+            shp = [-1] + list(page.shape[-2:])
+            page = page.reshape(shp)
+            if memory is None:
+                # Initialise holding array with zeros, now we know the shape
+                # of the image frames
+                memory = np.zeros(page.shape[-2:], dtype=np.float64)
+            memory += np.mean(page, dtype=np.float64, axis=0) * page.shape[0]
+            n_frames += page.shape[0]
+
+        return memory / n_frames
+
+    @staticmethod
+    def rois2masks(rois, data):
+        """Take the object `rois` and returns it as a list of binary masks.
+
+        Parameters
+        ----------
+        rois : str or list of array_like
+            Either a string containing a path to an ImageJ roi zip file,
+            or a list of arrays encoding polygons, or list of binary arrays
+            representing masks.
+        data : tifffile.TiffFile
+            Open tifffile.TiffFile object.
+
+        Returns
+        -------
+        masks : list of numpy.ndarray
+            List of binary arrays.
+        """
+        # Get the image shape
+        shape = data.pages[0].shape[-2:]
+
+        # If it's a string, parse the string
+        if isinstance(rois, basestring):
+            rois = roitools.readrois(rois)
+
+        if not isinstance(rois, abc.Sequence):
+            raise TypeError(
+                "Wrong ROIs input format: expected a list or sequence, but got"
+                " a {}".format(rois.__class__)
+            )
+
+        # If it's a something by 2 array (or vice versa), assume polygons
+        if np.shape(rois[0])[1] == 2 or np.shape(rois[0])[0] == 2:
+            return roitools.getmasks(rois, shape)
+        # If it's a list of bigger arrays, assume masks
+        elif np.shape(rois[0]) == shape:
+            return rois
+
+        raise ValueError("Wrong ROIs input format: unfamiliar shape.")
+
+    @staticmethod
+    def extracttraces(data, masks):
+        """
+        Extract a temporal trace for each spatial mask.
+
+        Parameters
+        ----------
+        data : tifffile.TiffFile
+            Open tifffile.TiffFile object.
+        masks : list of array_like
+            List of binary arrays.
+
+        Returns
+        -------
+        traces : numpy.ndarray
+            Trace for each mask, shaped ``(len(masks), n_frames)``.
+        """
+        # Get the number rois
+        nrois = len(masks)
+
+        # Initialise output as a list, because we don't know how many frames
+        # there will be
+        out = []
+
+        # For each frame, get the data
+        for page in data.pages:
+            page = page.asarray()
+            shp = [-1] + list(page.shape[-2:])
+            page = page.reshape(shp)
+
+            page_traces = np.zeros((nrois, page.shape[0]), dtype=np.float64)
+            for i in range(nrois):
+                # Get mean data from mask
+                page_traces[i, :] = np.mean(
+                    page[..., masks[i]],
+                    dtype=np.float64,
+                    axis=-1,
+                )
+            out.append(page_traces)
+
+        out = np.concatenate(out, axis=-1)
+        return out
+
+
 class DataHandlerPillow(DataHandlerAbstract):
     """
     Extract data from TIFF images frame-by-frame using Pillow (:class:`PIL.Image`).

--- a/fissa/extraction.py
+++ b/fissa/extraction.py
@@ -317,8 +317,33 @@ class DataHandlerTifffileLazy(DataHandlerAbstract):
         memory = None
         n_frames = 0
 
+        n_pages = len(data.pages)
         for page in data.pages:
             page = page.asarray()
+            if (
+                n_pages > 1 and
+                page.ndim > 2 and
+                (np.array(page.shape[:-2]) > 1).sum() > 0
+            ):
+                warnings.warn(
+                    "Multipage TIFF {} with {} pages has at least one page"
+                    " with {} dimensions (page shaped {})."
+                    " All dimensions before the final two (height and"
+                    " width) will be treated as time-like and flattened."
+                    "".format(
+                        "", n_pages, page.ndim, page.shape
+                    )
+                )
+            elif page.ndim > 3 and (np.array(page.shape[:-2]) > 1).sum() > 1:
+                warnings.warn(
+                    "TIFF {} has at least one page with {} dimensions"
+                    " (page shaped {})."
+                    " All dimensions before the final two (height and"
+                    " width) will be treated as time-like and flattened."
+                    "".format(
+                        "", page.ndim, page.shape
+                    )
+                )
             shp = [-1] + list(page.shape[-2:])
             page = page.reshape(shp)
             if memory is None:

--- a/fissa/tests/base_test.py
+++ b/fissa/tests/base_test.py
@@ -10,6 +10,7 @@ import random
 import shutil
 import string
 import sys
+import tempfile
 import unittest
 from inspect import getsourcefile
 
@@ -89,7 +90,7 @@ class BaseTestCase(unittest.TestCase):
         super(BaseTestCase, self).__init__(*args, **kwargs)  # Works on Python2
         self.addTypeEqualityFunc(np.ndarray, self.assert_allclose)
         self.tempdir = os.path.join(
-            self.test_directory,
+            tempfile.gettempdir(),
             "out-" + self.generate_temp_name(),
         )
 

--- a/fissa/tests/base_test.py
+++ b/fissa/tests/base_test.py
@@ -79,10 +79,10 @@ class BaseTestCase(unittest.TestCase):
     # a top-level variable
     test_directory = TEST_DIRECTORY
 
-    def __init__(self, *args, **kw):
+    def __init__(self, *args, **kwargs):
         '''Add test for numpy type'''
         # super(self).__init__(*args, **kw)  # Only works on Python3
-        super(BaseTestCase, self).__init__(*args, **kw)  # Works on Python2
+        super(BaseTestCase, self).__init__(*args, **kwargs)  # Works on Python2
         self.addTypeEqualityFunc(np.ndarray, self.assert_allclose)
 
     @contextlib.contextmanager

--- a/fissa/tests/base_test.py
+++ b/fissa/tests/base_test.py
@@ -4,10 +4,14 @@ and also provides the numpy testing functions.
 '''
 
 import contextlib
-import unittest
+import datetime
 import os.path
-from inspect import getsourcefile
+import random
+import shutil
+import string
 import sys
+import unittest
+from inspect import getsourcefile
 
 import numpy as np
 from numpy.testing import (assert_almost_equal,
@@ -84,6 +88,28 @@ class BaseTestCase(unittest.TestCase):
         # super(self).__init__(*args, **kw)  # Only works on Python3
         super(BaseTestCase, self).__init__(*args, **kwargs)  # Works on Python2
         self.addTypeEqualityFunc(np.ndarray, self.assert_allclose)
+        self.tempdir = os.path.join(
+            self.test_directory,
+            "out-" + self.generate_temp_name(),
+        )
+
+    def generate_temp_name(self, n_character=12):
+        """
+        Generate a random string to use as a temporary output path.
+        """
+        population = string.ascii_uppercase + string.digits
+        if hasattr(random, "choices"):
+            # Python 3.6+
+            rstr = "".join(random.choices(population, k=n_character))
+        else:
+            # Python 2.7/3.5
+            rstr = "".join(random.choice(population) for _ in range(n_character))
+        return "{}-{}".format(datetime.datetime.now().strftime("%M%S%f"), rstr)
+
+    def tearDown(self):
+        # If it was created, delete the randomly generated temporary directory
+        if os.path.isdir(self.tempdir):
+            shutil.rmtree(self.tempdir)
 
     @contextlib.contextmanager
     def subTest(self, *args, **kwargs):

--- a/fissa/tests/test_core.py
+++ b/fissa/tests/test_core.py
@@ -18,8 +18,8 @@ from .. import extraction
 class TestExperimentA(BaseTestCase):
     '''Test Experiment class and its methods.'''
 
-    def __init__(self, *args, **kw):
-        super(TestExperimentA, self).__init__(*args, **kw)
+    def __init__(self, *args, **kwargs):
+        super(TestExperimentA, self).__init__(*args, **kwargs)
 
         self.resources_dir = os.path.join(self.test_directory, 'resources', 'a')
         self.output_dir = os.path.join(

--- a/fissa/tests/test_core.py
+++ b/fissa/tests/test_core.py
@@ -12,7 +12,7 @@ import numpy as np
 
 from .base_test import BaseTestCase
 from .. import core
-from ..extraction import DataHandlerTifffile
+from .. import extraction
 
 
 class TestExperimentA(BaseTestCase):
@@ -100,7 +100,7 @@ class TestExperimentA(BaseTestCase):
             os.path.join(self.images_dir, img)
             for img in self.image_names
         ]
-        datahandler = DataHandlerTifffile()
+        datahandler = extraction.DataHandlerTifffile()
         images = [datahandler.image2array(pth) for pth in image_paths]
         exp = core.Experiment(images, self.roi_zip_path, self.output_dir)
         exp.separate()
@@ -212,12 +212,38 @@ class TestExperimentA(BaseTestCase):
         self.assert_equal(len(actual[0]), 1)
         self.assert_allclose(actual[0][0], self.expected_00)
 
-    def test_manualhandler(self):
+    def test_manualhandler_Tifffile(self):
         exp = core.Experiment(
             self.images_dir,
             self.roi_zip_path,
             self.output_dir,
-            datahandler=DataHandlerTifffile(),
+            datahandler=extraction.DataHandlerTifffile(),
+        )
+        exp.separate()
+        actual = exp.result
+        self.assert_equal(len(actual), 1)
+        self.assert_equal(len(actual[0]), 1)
+        self.assert_allclose(actual[0][0], self.expected_00)
+
+    def test_manualhandler_TifffileLazy(self):
+        exp = core.Experiment(
+            self.images_dir,
+            self.roi_zip_path,
+            self.output_dir,
+            datahandler=extraction.DataHandlerTifffileLazy(),
+        )
+        exp.separate()
+        actual = exp.result
+        self.assert_equal(len(actual), 1)
+        self.assert_equal(len(actual[0]), 1)
+        self.assert_allclose(actual[0][0], self.expected_00)
+
+    def test_manualhandler_Pillow(self):
+        exp = core.Experiment(
+            self.images_dir,
+            self.roi_zip_path,
+            self.output_dir,
+            datahandler=extraction.DataHandlerPillow(),
         )
         exp.separate()
         actual = exp.result

--- a/fissa/tests/test_core.py
+++ b/fissa/tests/test_core.py
@@ -2,8 +2,6 @@
 
 from __future__ import division
 
-from datetime import datetime
-import random
 import os, os.path
 import shutil
 import unittest
@@ -22,13 +20,7 @@ class TestExperimentA(BaseTestCase):
         super(TestExperimentA, self).__init__(*args, **kwargs)
 
         self.resources_dir = os.path.join(self.test_directory, 'resources', 'a')
-        self.output_dir = os.path.join(
-            self.resources_dir,
-            'out-{}-{:06d}'.format(
-                datetime.now().strftime('%H%M%S%f'),
-                random.randrange(999999)
-            )
-        )
+        self.output_dir = self.tempdir
         self.images_dir = os.path.join(self.resources_dir, 'images')
         self.image_names = ['AVG_A01_R1_small.tif']
         self.roi_zip_path = os.path.join(self.resources_dir, 'rois.zip')
@@ -479,10 +471,7 @@ class TestExperimentA(BaseTestCase):
     def test_matlab_custom_fname(self):
         exp = core.Experiment(self.images_dir, self.roi_zip_path, self.output_dir)
         exp.separate()
-        fname = os.path.join(
-            self.output_dir,
-            'test_{}.mat'.format(random.randrange(999999))
-        )
+        fname = os.path.join(self.output_dir, "test_output.mat")
         exp.save_to_matlab(fname)
         self.assertTrue(os.path.isfile(fname))
         #TODO: Check contents of the .mat file

--- a/fissa/tests/test_extraction.py
+++ b/fissa/tests/test_extraction.py
@@ -6,6 +6,7 @@ from __future__ import division
 
 import functools
 import os
+import shutil
 import sys
 import tempfile
 
@@ -497,17 +498,19 @@ class TestRois2MasksTifffile(BaseTestCase, Rois2MasksBase):
 class TestRois2MasksTifffileLazy(BaseTestCase, Rois2MasksBase):
     """Tests for rois2masks using `~extraction.TestRois2MasksTifffileLazy`."""
 
-    def setup_class(self):
+    def setUp(self):
         self.expected = roitools.getmasks(self.polys, (176, 156))
         self.data = np.zeros((1, 176, 156))
-        self.file = tempfile.NamedTemporaryFile()
-        tifffile.imsave(self.file.name, self.data)
-        self.data = tifffile.TiffFile(self.file.name)
+        os.makedirs(self.tempdir)
+        self.filename = os.path.join(self.tempdir, "tmp.tif")
+        tifffile.imsave(self.filename, self.data)
+        self.data = tifffile.TiffFile(self.filename)
         self.datahandler = extraction.DataHandlerTifffileLazy()
 
-    def teardown_class(self):
+    def tearDown(self):
         self.data.close()
-        self.file.close()
+        if os.path.isdir(self.tempdir):
+            shutil.rmtree(self.tempdir)
 
 
 class TestRois2MasksPillow(BaseTestCase, Rois2MasksBase):

--- a/fissa/tests/test_extraction.py
+++ b/fissa/tests/test_extraction.py
@@ -54,7 +54,7 @@ def get_dtyped_expected(expected, dtype):
 @pytest.mark.parametrize("datahandler", [extraction.DataHandlerTifffile])
 def test_single_frame_3d(dtype, datahandler):
     """
-    Test loading a regular, single-frame TIFF using :~extraction.DataHandlerTifffile:.
+    Test loading a regular, single-frame TIFF using `~extraction.DataHandlerTifffile`.
 
     The return value be 3d ``(1, 3, 2)``, including an axis for time.
     """
@@ -84,12 +84,12 @@ def test_single_frame_3d(dtype, datahandler):
 @pytest.mark.parametrize("datahandler", [extraction.DataHandlerPillow])
 def test_single_frame_2d(dtype, datahandler):
     """
-    Test loading a regular, single-frame TIFF using :~extraction.DataHandlerPillow:.
+    Test loading a regular, single-frame TIFF using `~extraction.DataHandlerPillow`.
 
     When we cast the output of ``datahandler.image2array(fname)`` as a
     :class:`numpy.ndarray`, the return value will be 2d, shaped ``(3, 2)``
     without an axis for time. This is fine because the other methods in
-    :~extraction.DataHandlerPillow: do not interact with the :class:`PIL.Image`
+    `~extraction.DataHandlerPillow` do not interact with the :class:`PIL.Image`
     object in this way.
     """
     expected = np.array([[-11, 12], [14, 15], [17, 18]])
@@ -486,7 +486,7 @@ class Rois2MasksBase():
 
 
 class TestRois2MasksTifffile(BaseTestCase, Rois2MasksBase):
-    """Tests for rois2masks using :~extraction.DataHandlerTifffile:."""
+    """Tests for rois2masks using `~extraction.DataHandlerTifffile`."""
 
     def setup_class(self):
         self.expected = roitools.getmasks(self.polys, (176, 156))
@@ -495,7 +495,7 @@ class TestRois2MasksTifffile(BaseTestCase, Rois2MasksBase):
 
 
 class TestRois2MasksTifffileLazy(BaseTestCase, Rois2MasksBase):
-    """Tests for rois2masks using :~extraction.TestRois2MasksTifffileLazy:."""
+    """Tests for rois2masks using `~extraction.TestRois2MasksTifffileLazy`."""
 
     def setup_class(self):
         self.expected = roitools.getmasks(self.polys, (176, 156))
@@ -511,7 +511,7 @@ class TestRois2MasksTifffileLazy(BaseTestCase, Rois2MasksBase):
 
 
 class TestRois2MasksPillow(BaseTestCase, Rois2MasksBase):
-    """Tests for rois2masks using :~extraction.DataHandlerPillow:."""
+    """Tests for rois2masks using `~extraction.DataHandlerPillow`."""
 
     def setup_class(self):
         self.expected = roitools.getmasks(self.polys, (176, 156))


### PR DESCRIPTION
Add a new datahandler, DataHandlerTifffileLazy, which uses tifffile to handle TIFFs but does so in a lazy manner, loading the data frame-by-frame when determining the traces (like DataHandlerPillow).

The advantage over DataHandlerPillow is it can handle more dtypes and shapes in the TIFF files.

This replaces DataHandlerPillow as the lowmemory_mode datahandler.