### PR TITLE
DOC: Change theme to pydata

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -161,7 +161,14 @@ pygments_style = None
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = 'sphinx_rtd_theme'
+try:
+    # Use pydata on Python 3.6 and above
+    import pydata_sphinx_theme
+
+    html_theme = "pydata_sphinx_theme"
+except ImportError:
+    # Use readthedocs theme
+    html_theme = "sphinx_rtd_theme"
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the

--- a/requirements_docs.txt
+++ b/requirements_docs.txt
@@ -1,4 +1,5 @@
+pydata-sphinx-theme; python_version>='3.6'
 readthedocs-sphinx-search; python_version>='3.6'
 sphinx
 sphinx-autobuild
-sphinx_rtd_theme
+sphinx_rtd_theme; python_version<'3.6'


### PR DESCRIPTION
[pydata](https://pydata-sphinx-theme.readthedocs.io/) is the theme developed by pandas and now also used by numpy, scipy, bokeh and jupyter hub.

Since the pydata theme is only available for Python 3.5+, and only working for us with Python 3.6+, we are still using the readthedocs theme when deploying the documentation on Python 2.7 and 3.5.