### PR TITLE
RF: Don't do init as list of strings

### DIFF
--- a/fissa/core.py
+++ b/fissa/core.py
@@ -80,9 +80,9 @@ def extract_func(inputs):
         data[cell] = datahandler.extracttraces(curdata, masks)
 
         # store ROI outlines
-        roi_polys[cell] = [''] * len(masks)
+        roi_polys[cell] = []
         for i in range(len(masks)):
-            roi_polys[cell][i] = roitools.find_roi_edge(masks[i])
+            roi_polys[cell].append(roitools.find_roi_edge(masks[i]))
 
     return data, roi_polys, mean
 

--- a/fissa/core.py
+++ b/fissa/core.py
@@ -80,9 +80,7 @@ def extract_func(inputs):
         data[cell] = datahandler.extracttraces(curdata, masks)
 
         # store ROI outlines
-        roi_polys[cell] = []
-        for i in range(len(masks)):
-            roi_polys[cell].append(roitools.find_roi_edge(masks[i]))
+        roi_polys[cell] = [roitools.find_roi_edge(mask) for mask in masks]
 
     return data, roi_polys, mean
 

--- a/fissa/roitools.py
+++ b/fissa/roitools.py
@@ -384,7 +384,7 @@ def getmasks(rois, shpe):
     nrois = len(rois)
 
     # start empty mask list
-    masks = [''] * nrois
+    masks = []
 
     for i in range(nrois):
         # transpose if array of 2 by n
@@ -394,7 +394,7 @@ def getmasks(rois, shpe):
         # transform current roi to mask
         mask = poly2mask(rois[i], shpe)
         # store in list
-        masks[i] = np.array(mask[0].todense())
+        masks.append(np.array(mask[0].todense()))
 
     return masks
 


### PR DESCRIPTION
AFAIK, initialising a list as the correct length but composed solely of empty strings offers no noticeable speed advantage. A python list is composed of a double-linked list of pointers to objects, and pointers take up very little memory so you don't need to preallocate the memory for the pointers to go in. See [here](https://stackoverflow.com/questions/311775/create-a-list-with-initial-capacity-in-python). More pythonic code is to use a generator or list  comprehensions where-ever possible. Moreover, initialising the list with contents that have the wrong object type makes for confusing code.

Preallocating memory for numpy arrays is very useful because the object is large.

I've changed these inits to be list comprehension and (for now) just an empty list which is appended to.