### PR TITLE
RF: Refactor neuropil.separate

### DIFF
--- a/fissa/neuropil.py
+++ b/fissa/neuropil.py
@@ -115,7 +115,7 @@ def separate(
 
     for i_try in range(maxtries):
 
-        if sep_method.lower() == "ica":
+        if sep_method.lower() in {"ica", "fastica"}:
             # Use sklearn's implementation of ICA.
 
             # Make an instance of the FastICA class. We can do whitening of
@@ -147,6 +147,23 @@ def separate(
             # Perform NMF and find separated signals
             S_sep = estimator.fit_transform(S.T, W=W0, H=H0)
 
+        elif hasattr(sklearn.decomposition, sep_method):
+
+            print(
+                "Using ad hoc signal decomposition method"
+                " sklearn.decomposition.{}. Only NMF and ICA are officially"
+                " supported.".format(sep_method)
+            )
+
+            # Load up arbitrary decomposition algorithm from sklearn
+            estimator = getattr(sklearn.decomposition, sep_method)(
+                n_components=n,
+                tol=tol,
+                max_iter=maxiter,
+                random_state=random_state,
+            )
+            S_sep = estimator.fit_transform(S.T)
+
         else:
             raise ValueError('Unknown separation method "{}".'.format(sep_method))
 
@@ -154,7 +171,7 @@ def separate(
         if estimator.n_iter_ < maxiter:
             print(
                 "{} converged after {} iterations.".format(
-                    sep_method.upper(), estimator.n_iter_
+                    sep_method, estimator.n_iter_
                 )
             )
             break

--- a/fissa/neuropil.py
+++ b/fissa/neuropil.py
@@ -103,7 +103,7 @@ def separate(
 
     # estimate number of signals to find, if not given
     if n is None:
-        if sep_method == 'ica':
+        if sep_method.lower() == "ica":
             # Perform PCA
             pca = PCA(whiten=False)
             pca.fit(S.T)
@@ -115,7 +115,7 @@ def separate(
 
     for i_try in range(maxtries):
 
-        if sep_method == "ica":
+        if sep_method.lower() == "ica":
             # Use sklearn's implementation of ICA.
 
             # Make an instance of the FastICA class. We can do whitening of
@@ -131,7 +131,7 @@ def separate(
             # Perform ICA and find separated signals
             S_sep = estimator.fit_transform(S.T)
 
-        elif sep_method == "nmf":
+        elif sep_method.lower() == "nmf":
 
             # Make an instance of the sklearn NMF class
             estimator = NMF(

--- a/fissa/neuropil.py
+++ b/fissa/neuropil.py
@@ -14,8 +14,17 @@ import sklearn.decomposition
 
 
 def separate(
-        S, sep_method='nmf', n=None, maxiter=10000, tol=1e-4,
-        random_state=892, maxtries=10, W0=None, H0=None, alpha=0.1):
+    S,
+    sep_method="nmf",
+    n=None,
+    maxiter=10000,
+    tol=1e-4,
+    random_state=892,
+    maxtries=10,
+    W0=None,
+    H0=None,
+    alpha=0.1,
+):
     """
     Find independent signals, sorted by matching score against the first input signal.
 
@@ -191,13 +200,15 @@ def separate(
             print("Trying a new random state.")
             # Change to a new random_state
             if random_state is not None:
-                random_state = (random_state + 1) % 2**32
+                random_state = (random_state + 1) % 2 ** 32
 
     if estimator.n_iter_ == maxiter:
-        print((
-            'Warning: maximum number of allowed tries reached at {} '
-            'iterations for {} tries of different random seed states.'
-        ).format(estimator.n_iter_, i_try + 1))
+        print(
+            "Warning: maximum number of allowed tries reached at {} iterations"
+            " for {} tries of different random seed states.".format(
+                estimator.n_iter_, i_try + 1
+            )
+        )
 
     if hasattr(estimator, "mixing_"):
         A_sep = estimator.mixing_

--- a/fissa/neuropil.py
+++ b/fissa/neuropil.py
@@ -21,11 +21,11 @@ def separate(
 
     Parameters
     ----------
-    S : :term:`array_like`
+    S : :term:`array_like`, shaped (signal, time)
         2-d array containing mixed input signals.
         Each column of `S` should be a different signal, and each row an
-        observation of the signals. For ``S[i,j]``, `j` = each signal,
-        ``i`` = signal content.
+        observation of the signals. For ``S[i, j]``, ``j`` is a signal, and
+        ``i`` is an observation.
         The first column, ``j = 0``, is considered the primary signal and the
         one for which we will try to extract a decontaminated equivalent.
 
@@ -36,13 +36,14 @@ def separate(
         - ``"nmf"``: Non-negative Matrix Factorization
 
     n : int, optional
-        How many components to estimate. If ``None`` (default), use PCA to
-        estimate how many components would explain at least 99% of the
-        variance and adopt this value for ``n``.
+        How many components to estimate. If ``None`` (default), for the NMF
+        method, ``n`` is the number of input signals; for the ICA method,
+        we use PCA to estimate how many components would explain at least 99%
+        of the variance and adopt this value for ``n``.
     maxiter : int, optional
-        Number of maximally allowed iterations. Default is ``500``.
+        Number of maximally allowed iterations. Default is ``10000``.
     tol : float, optional
-        Error tolerance for termination. Default is ``1e-5``.
+        Error tolerance for termination. Default is ``1e-4``.
     random_state : int or None, optional
         Initial state for the random number generator. Set to ``None`` to use
         the numpy.random default. Default seed is ``892``.
@@ -62,11 +63,11 @@ def separate(
 
     Returns
     -------
-    S_sep : numpy.ndarray
+    S_sep : numpy.ndarray, shaped (signal, time)
         The raw separated traces.
-    S_matched : numpy.ndarray
+    S_matched : numpy.ndarray, shaped (signal, time)
         The separated traces matched to the primary signal, in order
-        of matching quality (see Methods below).
+        of matching quality (see Notes below).
     A_sep : numpy.ndarray
         Mixing matrix.
     convergence : dict

--- a/fissa/neuropil.py
+++ b/fissa/neuropil.py
@@ -131,7 +131,7 @@ def separate(
             # Perform ICA and find separated signals
             S_sep = estimator.fit_transform(S.T)
 
-        elif sep_method.lower() == "nmf":
+        elif sep_method.lower() in {"nmf", "nnmf"}:
 
             # Make an instance of the sklearn NMF class
             estimator = sklearn.decomposition.NMF(

--- a/fissa/neuropil.py
+++ b/fissa/neuropil.py
@@ -204,9 +204,6 @@ def separate(
     else:
         A_sep = estimator.components_.T
 
-    # make empty matched structure
-    S_matched = np.zeros(np.shape(S_sep))
-
     # Normalize the columns in A so that sum(column)=1 (can be done in one line
     # too).
     # This results in a relative score of how strongly each separated signal
@@ -229,10 +226,11 @@ def separate(
     # contribution is sorted first.
     order = np.argsort(scores)[::-1]
 
-    # order the signals according to their scores
+    # Order the signals according to their scores, and scale the magnitude
+    # back to the original magnitude.
+    S_matched = np.zeros_like(S_sep)
     for j in range(n):
-        s_ = A_sep[0, order[j]] * S_sep[:, order[j]]
-        S_matched[:, j] = s_
+        S_matched[:, j] = A_sep[0, order[j]] * S_sep[:, order[j]]
 
     # save the algorithm convergence info
     convergence = {}

--- a/fissa/neuropil.py
+++ b/fissa/neuropil.py
@@ -186,7 +186,7 @@ def separate(
         if estimator.n_iter_ < maxiter:
             print(
                 "{} converged after {} iterations.".format(
-                    sep_method, estimator.n_iter_
+                    repr(estimator).split("(")[0], estimator.n_iter_
                 )
             )
             break

--- a/fissa/neuropil.py
+++ b/fissa/neuropil.py
@@ -10,7 +10,7 @@ Created:
 
 import numpy as np
 import numpy.random as rand
-from sklearn.decomposition import FastICA, NMF, PCA
+import sklearn.decomposition
 
 
 def separate(
@@ -105,7 +105,7 @@ def separate(
     if n is None:
         if sep_method.lower() == "ica":
             # Perform PCA
-            pca = PCA(whiten=False)
+            pca = sklearn.decomposition.PCA(whiten=False)
             pca.fit(S.T)
 
             # find number of components with at least x percent explained var
@@ -120,7 +120,7 @@ def separate(
 
             # Make an instance of the FastICA class. We can do whitening of
             # the data now.
-            estimator = FastICA(
+            estimator = sklearn.decomposition.FastICA(
                 n_components=n,
                 whiten=True,
                 max_iter=maxiter,
@@ -134,7 +134,7 @@ def separate(
         elif sep_method.lower() == "nmf":
 
             # Make an instance of the sklearn NMF class
-            estimator = NMF(
+            estimator = sklearn.decomposition.NMF(
                 init="nndsvdar" if W0 is None and H0 is None else "custom",
                 n_components=n,
                 alpha=alpha,

--- a/fissa/tests/test_neuropil.py
+++ b/fissa/tests/test_neuropil.py
@@ -3,6 +3,9 @@
 Author: Sander Keemink (swkeemink@scimail.eu)
 Created: 2015-11-06
 """
+
+import warnings
+
 import numpy as np
 
 from .base_test import BaseTestCase
@@ -46,12 +49,14 @@ class NeuropilMixin:
         self.run_method(self.method, expected_converged=True, maxtries=1, n=2)
 
     def test_manual_seed(self):
-        self.run_method(
-            self.method,
-            expected_converged=True,
-            maxtries=1,
-            random_state=0,
-        )
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            self.run_method(
+                self.method,
+                expected_converged=True,
+                maxtries=1,
+                random_state=0,
+            )
 
     def test_retry(self):
         self.run_method(self.method, maxiter=1, maxtries=3)

--- a/fissa/tests/test_neuropil.py
+++ b/fissa/tests/test_neuropil.py
@@ -46,7 +46,7 @@ class TestNeuropilFuns(BaseTestCase):
 
         # Run tests
         i_subtest = 0
-        for method in ['nmf', 'ica']:
+        for method in ["nmf", "ica", "FactorAnalysis"]:
             with self.subTest(i_subtest):
                 run_method(method, expected_converged=True, maxtries=1, n=2)
             i_subtest += 1

--- a/fissa/tests/test_neuropil.py
+++ b/fissa/tests/test_neuropil.py
@@ -9,13 +9,14 @@ from .base_test import BaseTestCase
 from .. import neuropil as npil
 
 
-class TestNeuropilFuns(BaseTestCase):
+class NeuropilMixin:
     """Neuropil functions testing class."""
 
-    def setup_class(self):
+    def setUp(self):
         """Set up the basic variables."""
         # length of arrays in tests
         self.l = 100
+        self.shape_desired = (2, self.l)
         # setup basic x values for fake data
         self.x = np.linspace(0, np.pi * 2, self.l)
         # Generate simple source data
@@ -24,46 +25,61 @@ class TestNeuropilFuns(BaseTestCase):
         self.W = np.array([[0.2, 0.8], [0.8, 0.2]])
         self.S = np.dot(self.W, self.data)
 
-    def test_separate(self):
-        """Tests the separate function data format."""
-        # desired shapes
-        shape_desired = (2, self.l)
+    def run_method(self, method, expected_converged=None, **kwargs):
+        """Test a single method, with specific parameters."""
+        # Run the separation routine
+        S_sep, S_matched, A_sep, convergence = npil.separate(
+            self.S, sep_method=method, **kwargs
+        )
+        # Ensure output shapes are as expected
+        self.assert_equal(S_sep.shape, self.shape_desired)
+        self.assert_equal(S_matched.shape, self.shape_desired)
+        self.assert_equal(S_sep.shape, self.shape_desired)
+        # If specified, assert that the result is as expected
+        if expected_converged is not None:
+            self.assert_equal(convergence['converged'], expected_converged)
 
-        # function for testing a method
-        def run_method(method, expected_converged=None, **kwargs):
-            """Test a single method, with specific parameters."""
-            # Run the separation routine
-            S_sep, S_matched, A_sep, convergence = npil.separate(
-                self.S, sep_method=method, **kwargs
-            )
-            # Ensure output shapes are as expected
-            self.assert_equal(S_sep.shape, shape_desired)
-            self.assert_equal(S_matched.shape, shape_desired)
-            self.assert_equal(S_sep.shape, shape_desired)
-            # If specified, assert that the result is as expected
-            if expected_converged is not None:
-                self.assert_equal(convergence['converged'], expected_converged)
+    def test_method(self):
+        self.run_method(self.method, expected_converged=True, maxtries=1)
 
-        # Run tests
-        i_subtest = 0
-        for method in ["nmf", "ica", "FactorAnalysis"]:
-            with self.subTest(i_subtest):
-                run_method(method, expected_converged=True, maxtries=1, n=2)
-            i_subtest += 1
-            with self.subTest(i_subtest):
-                run_method(method, expected_converged=True, maxtries=1)
-            i_subtest += 1
-            with self.subTest(i_subtest):
-                run_method(method, expected_converged=True, maxtries=1, random_state=0)
-            i_subtest += 1
-            with self.subTest(i_subtest):
-                run_method(method, maxiter=1, maxtries=3)
-            i_subtest += 1
+    def test_reduce_dim(self):
+        self.run_method(self.method, expected_converged=True, maxtries=1, n=2)
 
-        with self.subTest(i_subtest):
-            run_method('nmf', expected_converged=True, alpha=.2)
-        i_subtest += 1
+    def test_manual_seed(self):
+        self.run_method(
+            self.method,
+            expected_converged=True,
+            maxtries=1,
+            random_state=0,
+        )
+
+    def test_retry(self):
+        self.run_method(self.method, maxiter=1, maxtries=3)
+
+
+class TestNeuropilNMF(BaseTestCase, NeuropilMixin):
+
+    def setUp(self):
+        NeuropilMixin.setUp(self)
+        self.method = "nmf"
+
+    def test_nmf_manual_alpha(self):
+        self.run_method(self.method, expected_converged=True, alpha=.2)
 
     def test_badmethod(self):
         with self.assertRaises(ValueError):
             npil.separate(self.S, sep_method='bogus_method')
+
+
+class TestNeuropilICA(BaseTestCase, NeuropilMixin):
+
+    def setUp(self):
+        NeuropilMixin.setUp(self)
+        self.method = "ica"
+
+
+class TestNeuropilFA(BaseTestCase, NeuropilMixin):
+
+    def setUp(self):
+        NeuropilMixin.setUp(self)
+        self.method = "FactorAnalysis"


### PR DESCRIPTION
- Remove duplicated code by refactoring so we have common logic only once
- By generalising the code, we enable working with arbitrary [sklearn.decomposition](https://scikit-learn.org/stable/modules/classes.html#module-sklearn.decomposition) classes (e.g. [FactorAnalysis](https://scikit-learn.org/stable/modules/generated/sklearn.decomposition.FactorAnalysis.html)), though this feature is undocumented.
- Documentation is improved.

@swkeemink Would be great if you could double-check my descriptions of the methodology for normalising the mixing matrix to rank the signals.