### PR TITLE
RF: Use Mixin class for extraction tests

### DIFF
--- a/fissa/tests/test_extraction.py
+++ b/fissa/tests/test_extraction.py
@@ -428,9 +428,6 @@ class Rois2MasksTestMixin:
         np.array([[72., 107.], [78., 130.], [100., 110.]]),
     ]
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
     def setUp(self):
         self.expected = roitools.getmasks(self.polys, (176, 156))
         self.data = np.zeros((1, 176, 156))
@@ -489,7 +486,7 @@ class Rois2MasksTestMixin:
             self.datahandler.rois2masks(polys3d, self.data)
 
 
-class TestRois2MasksTifffile(Rois2MasksTestMixin, BaseTestCase):
+class TestRois2MasksTifffile(BaseTestCase, Rois2MasksTestMixin):
     """Tests for rois2masks using `~extraction.DataHandlerTifffile`."""
 
     def setUp(self):
@@ -498,7 +495,7 @@ class TestRois2MasksTifffile(Rois2MasksTestMixin, BaseTestCase):
         self.datahandler = extraction.DataHandlerTifffile()
 
 
-class TestRois2MasksTifffileLazy(Rois2MasksTestMixin, BaseTestCase):
+class TestRois2MasksTifffileLazy(BaseTestCase, Rois2MasksTestMixin):
     """Tests for rois2masks using `~extraction.DataHandlerTifffileLazy`."""
 
     def setUp(self):
@@ -516,7 +513,7 @@ class TestRois2MasksTifffileLazy(Rois2MasksTestMixin, BaseTestCase):
             shutil.rmtree(self.tempdir)
 
 
-class TestRois2MasksPillow(Rois2MasksTestMixin, BaseTestCase):
+class TestRois2MasksPillow(BaseTestCase, Rois2MasksTestMixin):
     """Tests for rois2masks using `~extraction.DataHandlerPillow`."""
 
     def setUp(self):

--- a/fissa/tests/test_extraction.py
+++ b/fissa/tests/test_extraction.py
@@ -499,7 +499,7 @@ class TestRois2MasksTifffile(Rois2MasksTestMixin, BaseTestCase):
 
 
 class TestRois2MasksTifffileLazy(Rois2MasksTestMixin, BaseTestCase):
-    """Tests for rois2masks using `~extraction.TestRois2MasksTifffileLazy`."""
+    """Tests for rois2masks using `~extraction.DataHandlerTifffileLazy`."""
 
     def setUp(self):
         self.expected = roitools.getmasks(self.polys, (176, 156))

--- a/fissa/tests/test_extraction.py
+++ b/fissa/tests/test_extraction.py
@@ -420,13 +420,16 @@ def test_multiframe_mean_higherdim_pillow(base_fname, shp, dtype, datahandler):
     )
 
 
-class Rois2MasksBase():
+class Rois2MasksTestMixin:
     """Tests for rois2masks."""
 
     polys = [
         np.array([[39., 62.], [60., 45.], [48., 71.]]),
         np.array([[72., 107.], [78., 130.], [100., 110.]]),
     ]
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
 
     def setup_class(self):
         self.expected = roitools.getmasks(self.polys, (176, 156))
@@ -486,7 +489,7 @@ class Rois2MasksBase():
             self.datahandler.rois2masks(polys3d, self.data)
 
 
-class TestRois2MasksTifffile(BaseTestCase, Rois2MasksBase):
+class TestRois2MasksTifffile(Rois2MasksTestMixin, BaseTestCase):
     """Tests for rois2masks using `~extraction.DataHandlerTifffile`."""
 
     def setup_class(self):
@@ -495,7 +498,7 @@ class TestRois2MasksTifffile(BaseTestCase, Rois2MasksBase):
         self.datahandler = extraction.DataHandlerTifffile()
 
 
-class TestRois2MasksTifffileLazy(BaseTestCase, Rois2MasksBase):
+class TestRois2MasksTifffileLazy(Rois2MasksTestMixin, BaseTestCase):
     """Tests for rois2masks using `~extraction.TestRois2MasksTifffileLazy`."""
 
     def setUp(self):
@@ -513,7 +516,7 @@ class TestRois2MasksTifffileLazy(BaseTestCase, Rois2MasksBase):
             shutil.rmtree(self.tempdir)
 
 
-class TestRois2MasksPillow(BaseTestCase, Rois2MasksBase):
+class TestRois2MasksPillow(Rois2MasksTestMixin, BaseTestCase):
     """Tests for rois2masks using `~extraction.DataHandlerPillow`."""
 
     def setup_class(self):

--- a/fissa/tests/test_extraction.py
+++ b/fissa/tests/test_extraction.py
@@ -431,7 +431,7 @@ class Rois2MasksTestMixin:
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-    def setup_class(self):
+    def setUp(self):
         self.expected = roitools.getmasks(self.polys, (176, 156))
         self.data = np.zeros((1, 176, 156))
         self.datahandler = None
@@ -492,7 +492,7 @@ class Rois2MasksTestMixin:
 class TestRois2MasksTifffile(Rois2MasksTestMixin, BaseTestCase):
     """Tests for rois2masks using `~extraction.DataHandlerTifffile`."""
 
-    def setup_class(self):
+    def setUp(self):
         self.expected = roitools.getmasks(self.polys, (176, 156))
         self.data = np.zeros((1, 176, 156))
         self.datahandler = extraction.DataHandlerTifffile()
@@ -519,7 +519,7 @@ class TestRois2MasksTifffileLazy(Rois2MasksTestMixin, BaseTestCase):
 class TestRois2MasksPillow(Rois2MasksTestMixin, BaseTestCase):
     """Tests for rois2masks using `~extraction.DataHandlerPillow`."""
 
-    def setup_class(self):
+    def setUp(self):
         self.expected = roitools.getmasks(self.polys, (176, 156))
         self.data = np.zeros((1, 176, 156))
         self.data = Image.fromarray(self.data.reshape(self.data.shape[-2:]).astype(np.uint8))

--- a/fissa/tests/test_extraction.py
+++ b/fissa/tests/test_extraction.py
@@ -431,7 +431,7 @@ class Rois2MasksTestMixin:
     def setUp(self):
         self.expected = roitools.getmasks(self.polys, (176, 156))
         self.data = np.zeros((1, 176, 156))
-        self.datahandler = None
+        # Child class must declare self.datahandler
 
     def test_imagej_zip(self):
         # load zip of rois
@@ -490,8 +490,7 @@ class TestRois2MasksTifffile(BaseTestCase, Rois2MasksTestMixin):
     """Tests for rois2masks using `~extraction.DataHandlerTifffile`."""
 
     def setUp(self):
-        self.expected = roitools.getmasks(self.polys, (176, 156))
-        self.data = np.zeros((1, 176, 156))
+        Rois2MasksTestMixin.setUp(self)
         self.datahandler = extraction.DataHandlerTifffile()
 
 
@@ -499,8 +498,7 @@ class TestRois2MasksTifffileLazy(BaseTestCase, Rois2MasksTestMixin):
     """Tests for rois2masks using `~extraction.DataHandlerTifffileLazy`."""
 
     def setUp(self):
-        self.expected = roitools.getmasks(self.polys, (176, 156))
-        self.data = np.zeros((1, 176, 156))
+        Rois2MasksTestMixin.setUp(self)
         os.makedirs(self.tempdir)
         self.filename = os.path.join(self.tempdir, "tmp.tif")
         tifffile.imsave(self.filename, self.data)
@@ -517,7 +515,6 @@ class TestRois2MasksPillow(BaseTestCase, Rois2MasksTestMixin):
     """Tests for rois2masks using `~extraction.DataHandlerPillow`."""
 
     def setUp(self):
-        self.expected = roitools.getmasks(self.polys, (176, 156))
-        self.data = np.zeros((1, 176, 156))
+        Rois2MasksTestMixin.setUp(self)
         self.data = Image.fromarray(self.data.reshape(self.data.shape[-2:]).astype(np.uint8))
         self.datahandler = extraction.DataHandlerPillow()


### PR DESCRIPTION
When we have tests which are common across multiple objects to test, a handy way of doing this is to make multiple subclasses with different setup but the same test methods. When making the parent subclass, we want it to contain a list of all the tests to run and no set up, and not actually get run itself. We can't subclass BaseTestCase directly because then it is a subclass of unittest.TestCase and will automatically be collected by pytest. Our solution is to use multiple inheritance with a Mixin class. However, the previous way of doing this was not quite doing Mixin classes correctly and it wasn't triggering both parent's `__init__` methods. This resolves the situation into a correct Mixin class. c.f. https://stackoverflow.com/a/50465583/1960959