### PR TITLE
CI:GHA: Always run tests, don't skip based on content

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -12,10 +12,6 @@ name: tests
 
 on:
   push:
-    paths-ignore:
-      - 'docs/**'
-      - '**.rst'
-      - '**.md'
   pull_request:
   schedule:
     - cron:  "0 0 * * 1"


### PR DESCRIPTION
PR #193 and #194 only affected the documentation and not the codebase. When the master branch was updated, the test workflow did not trigger because only paths in paths-ignore were updated. This is a problem for our coverage report, which was expecting to see these results but instead only saw Appveyor Windows builds.

We change the test workflow to run on all pushes. I would like to always run on master and skip running the tests on pushes to other branches which don't affect the codebase, but it is not clear to me if this is actually possible using just the github workflow event triggers.