### PR TITLE
DOC: Improve core docstrings

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -220,6 +220,11 @@ latex_elements = {
     # Latex figure (float) alignment
     #
     # 'figure_align': 'htbp',
+
+    # Need to manually declare what the delta symbol (Δ) corresponds to.
+    "preamble": """
+\DeclareUnicodeCharacter{394}{$\Delta$}
+""",
 }
 
 # Grouping the document tree into LaTeX files. List of tuples

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -137,6 +137,9 @@ templates_path = ['_templates']
 # source_suffix = ['.rst', '.md']
 source_suffix = '.rst'
 
+# The encoding of source files.
+source_encoding = "utf-8"
+
 # The master toctree document.
 master_doc = 'index'
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -102,7 +102,7 @@ extensions = [
     'sphinx.ext.mathjax',
     'sphinx.ext.ifconfig',
     'sphinx.ext.viewcode',
-    'sphinx.ext.napoleon',
+    "numpydoc",  # handle NumPy documentation formatted docstrings
 ]
 
 # Some extension features only available on later Python versions

--- a/fissa/core.py
+++ b/fissa/core.py
@@ -586,21 +586,21 @@ class Experiment():
 
         After running ``separate``, data can be found as follows:
 
-        self.sep
+        experiment.sep
             Raw separation output, without being matched. Signal ``i`` for
             a specific cell and trial can be found as
-            ``self.sep[cell][trial][i,:]``.
-        self.result
+            ``experiment.sep[cell][trial][i,:]``.
+        experiment.result
             Final output, in order of presence in cell ROI.
             Signal ``i`` for a specific cell and trial can be found at
-            ``self.result[cell][trial][i, :]``.
+            ``experiment.result[cell][trial][i, :]``.
             Note that the ordering is such that ``i = 0`` is the signal
             most strongly present in the ROI, and subsequent entries
             are in diminishing order.
-        self.mixmat
-            The mixing matrix, which maps how to from ``self.raw`` to
-            ``self.separated``.
-        self.info
+        experiment.mixmat
+            The mixing matrix, which maps from ``experiment.raw`` to
+            ``experiment.sep``.
+        experiment.info
             Information about separation routine, iterations needed, etc.
 
         Parameters

--- a/fissa/core.py
+++ b/fissa/core.py
@@ -126,6 +126,11 @@ class Experiment():
     """
     FISSA Experiment.
 
+    Uses the methodology described in
+    `FISSA: A neuropil decontamination toolbox for calcium imaging signals <doi_>`_.
+
+    .. _doi: https://www.doi.org/10.1038/s41598-018-21640-2
+
     Parameters
     ----------
     images : str or list

--- a/fissa/core.py
+++ b/fissa/core.py
@@ -981,6 +981,10 @@ def run_fissa(
         trial ``t``. If ``return_deltaf=True``, this is Δf/f\ :sub:`0`;
         otherwise, it is the decontaminated signal scaled as per the raw
         signal.
+
+    See Also
+    --------
+    fissa.core.Experiment
     """
     # Parse arguments
     if export_to_matlab is None:

--- a/fissa/core.py
+++ b/fissa/core.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """
 Main FISSA user interface.
 

--- a/fissa/core.py
+++ b/fissa/core.py
@@ -123,7 +123,7 @@ def separate_func(inputs):
 
 
 class Experiment():
-    """
+    r"""
     FISSA Experiment.
 
     Uses the methodology described in
@@ -385,7 +385,7 @@ class Experiment():
             self.load()
 
     def clear(self):
-        """
+        r"""
         Clear prepared data, and all data downstream of prepared data.
 
         .. versionadded:: 1.0.0
@@ -401,7 +401,7 @@ class Experiment():
         self.clear_separated()
 
     def clear_separated(self):
-        """
+        r"""
         Clear separated data, and all data downstream of separated data.
 
         .. versionadded:: 1.0.0
@@ -415,7 +415,7 @@ class Experiment():
         self.deltaf_result = None
 
     def load(self, path=None):
-        """
+        r"""
         Load data from cache file in npz format.
 
         .. versionadded:: 1.0.0
@@ -451,7 +451,8 @@ class Experiment():
             setattr(self, field, value)
 
     def separation_prep(self, redo=False):
-        """Prepare and extract the data to be separated.
+        r"""
+        Prepare and extract the data to be separated.
 
         For each trial, performs the following steps:
 
@@ -554,7 +555,7 @@ class Experiment():
             self.save_prep()
 
     def save_prep(self, destination=None):
-        """
+        r"""
         Save prepared raw signals, extracted from images, to an npz file.
 
         .. versionadded:: 1.0.0
@@ -586,7 +587,7 @@ class Experiment():
         )
 
     def separate(self, redo_prep=False, redo_sep=False):
-        """
+        r"""
         Separate all the trials with FISSA algorithm.
 
         After running ``separate``, data can be found as follows:
@@ -717,7 +718,7 @@ class Experiment():
             self.save_separated()
 
     def save_separated(self, destination=None):
-        """
+        r"""
         Save separated signals to an npz file.
 
         .. versionadded:: 1.0.0
@@ -749,7 +750,7 @@ class Experiment():
         )
 
     def calc_deltaf(self, freq, use_raw_f0=True, across_trials=True):
-        """
+        r"""
         Calculate deltaf/f0 for raw and result traces.
 
         The outputs are found in the :attr:`deltaf_raw` and
@@ -834,7 +835,8 @@ class Experiment():
             self.save_separated()
 
     def save_to_matlab(self, fname=None):
-        """Save the results to a MATLAB file.
+        r"""
+        Save the results to a MATLAB file.
 
         This will generate a .mat file which can be loaded into MATLAB to
         provide structs: ROIs, result, raw.
@@ -912,7 +914,7 @@ def run_fissa(
     export_to_matlab=False,
     **kwargs
 ):
-    """
+    r"""
     Functional interface to run FISSA.
 
     .. versionadded:: 1.0.0

--- a/fissa/core.py
+++ b/fissa/core.py
@@ -248,6 +248,8 @@ class Experiment():
     def clear(self):
         """
         Clear prepared data, and all data downstream of prepared data.
+
+        .. versionadded:: 1.0.0
         """
         # Wipe outputs
         self.means = []
@@ -262,6 +264,8 @@ class Experiment():
     def clear_separated(self):
         """
         Clear prepared data, and all data downstream of prepared data.
+
+        .. versionadded:: 1.0.0
         """
         # Wipe outputs
         self.info = None
@@ -274,6 +278,8 @@ class Experiment():
     def load(self, path=None):
         """
         Load data from cache file in npz format.
+
+        .. versionadded:: 1.0.0
 
         Parameters
         ----------
@@ -410,6 +416,8 @@ class Experiment():
     def save_prep(self, destination=None):
         """
         Save prepared raw signals, extracted from images, to an npz file.
+
+        .. versionadded:: 1.0.0
 
         Parameters
         ----------
@@ -571,6 +579,8 @@ class Experiment():
     def save_separated(self, destination=None):
         """
         Save separated signals to an npz file.
+
+        .. versionadded:: 1.0.0
 
         Parameters
         ----------

--- a/fissa/neuropil.py
+++ b/fissa/neuropil.py
@@ -84,6 +84,10 @@ def separate(
     ``sum(column) = 1``.
     This results in a relative score of how strongly each separated signal
     is represented in each ROI signal.
+
+    See Also
+    --------
+    sklearn.decomposition.NMF, sklearn.decomposition.FastICA
     """
     # TODO for edge cases, reduce the number of npil regions according to
     #      possible orientations

--- a/fissa/roitools.py
+++ b/fissa/roitools.py
@@ -414,6 +414,10 @@ def find_roi_edge(mask):
     -------
     outline : :term:`list` of (n,2)-:class:`~numpy.ndarray`
         Array with coordinates of pixels in the outline of the mask.
+
+    See Also
+    --------
+    skimage.measure.find_contours
     """
     # Ensure array_like input is a numpy.ndarray
     mask = np.asarray(mask)

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,3 +1,4 @@
+numpydoc
 pydata-sphinx-theme; python_version>='3.6'
 readthedocs-sphinx-search; python_version>='3.6'
 sphinx


### PR DESCRIPTION
- Move parameters from `__init__` to `Experiment` docstring.
- Add Attributes section covering output attributes.
- Change the Sphinx settings to use numpydoc instead of napolean, which generates better attributes sections in particular.
- Change df/f0 to Δf/f<sub>0</sub>.
- Add link to FISSA paper in Experiment docstring
- Add versionadded directive to the new methods introduced in #177.