### PR TITLE
ENH: Add __repr__ and __str__ methods

### DIFF
--- a/fissa/core.py
+++ b/fissa/core.py
@@ -388,6 +388,66 @@ class Experiment():
         else:
             self.load()
 
+    def __str__(self):
+        if isinstance(self.images, basestring):
+            str_images = repr(self.images)
+        elif isinstance(self.images, abc.Sequence):
+            str_images = "<{} of length {}>".format(
+                self.images.__class__.__name__, len(self.images)
+            )
+        else:
+            str_images = repr(self.images)
+
+        if isinstance(self.rois, basestring):
+            str_rois = repr(self.rois)
+        elif isinstance(self.rois, abc.Sequence):
+            str_rois = "<{} of length {}>".format(
+                self.rois.__class__.__name__, len(self.rois)
+            )
+        else:
+            str_images = repr(self.rois)
+
+        fields = [
+            "folder",
+            "nRegions",
+            "expansion",
+            "alpha",
+            "ncores_preparation",
+            "ncores_separation",
+            "method",
+            "datahandler",
+        ]
+        str_parts = [
+            "{}={}".format(field, repr(getattr(self, field))) for field in fields
+        ]
+        return "{}.{}(images={}, rois={}, {})".format(
+            __name__,
+            self.__class__.__name__,
+            str_images,
+            str_rois,
+            ", ".join(str_parts),
+        )
+
+    def __repr__(self):
+        fields = [
+            "images",
+            "rois",
+            "folder",
+            "nRegions",
+            "expansion",
+            "alpha",
+            "ncores_preparation",
+            "ncores_separation",
+            "method",
+            "datahandler",
+        ]
+        repr_parts = [
+            "{}={}".format(field, repr(getattr(self, field))) for field in fields
+        ]
+        return "{}.{}({})".format(
+            __name__, self.__class__.__name__, ", ".join(repr_parts)
+        )
+
     def clear(self):
         r"""
         Clear prepared data, and all data downstream of prepared data.

--- a/fissa/extraction.py
+++ b/fissa/extraction.py
@@ -37,6 +37,9 @@ class DataHandlerAbstract():
     --------
     DataHandlerTifffile, DataHandlerPillow
     """
+    def __repr__(self):
+        return "{}.{}()".format(__name__, self.__class__.__name__)
+
     @staticmethod
     def image2array(image):
         """

--- a/fissa/tests/test_core.py
+++ b/fissa/tests/test_core.py
@@ -91,7 +91,14 @@ class ExperimentTestMixin:
         if compare_deltaf and separated:
             self.compare_deltaf_result(actual.deltaf_result)
 
-    def compare_experiments(self, actual, expected, prepared=True, separated=True):
+    def compare_experiments(
+            self,
+            actual,
+            expected,
+            folder=True,
+            prepared=True,
+            separated=True,
+        ):
         """
         Compare attributes of two experiments.
 
@@ -101,6 +108,8 @@ class ExperimentTestMixin:
             Actual experiment.
         expected : fissa.Experiment
             Expected experiment.
+        folder : bool
+            Whether to compare the folder values. Default is ``True``.
         prepared : bool
             Whether to compare results of :meth:`fissa.Experiment.separation_prep`.
             Default is ``True``.
@@ -108,6 +117,22 @@ class ExperimentTestMixin:
             Whether to compare results of :meth:`fissa.Experiment.separate`.
             Default is ``True``.
         """
+        # We do all these comparisons explicitly one-by-one instead of in a
+        # for loop so you can see which one is failing.
+
+        # Check the parameters are the same
+        self.assert_equal(actual.images, expected.images)
+        self.assert_equal(actual.rois, expected.rois)
+        if folder:
+            self.assert_equal(actual.folder, expected.folder)
+        self.assert_equal(actual.nRegions, expected.nRegions)
+        self.assert_equal(actual.expansion, expected.expansion)
+        self.assert_equal(actual.alpha, expected.alpha)
+        self.assert_equal(actual.ncores_preparation, expected.ncores_preparation)
+        self.assert_equal(actual.ncores_separation, expected.ncores_separation)
+        self.assert_equal(actual.method, expected.method)
+        # self.assert_equal(actual.datahandler, expected.datahandler)
+
         if prepared:
             if expected.raw is None:
                 self.assertIs(actual.raw, expected.raw)
@@ -569,7 +594,7 @@ class ExperimentTestMixin:
         exp = core.Experiment(image_path, roi_path, new_folder)
         exp.load(os.path.join(prev_folder, "preparation.npz"))
         # Cached prep should now be loaded correctly
-        self.compare_experiments(exp, exp1)
+        self.compare_experiments(exp, exp1, folder=False)
 
     def test_load_manual_sep(self):
         """Loading prep results from a different folder."""
@@ -584,7 +609,7 @@ class ExperimentTestMixin:
         exp = core.Experiment(image_path, roi_path, new_folder)
         exp.load(os.path.join(prev_folder, "separated.npz"))
         # Cached results should now be loaded correctly
-        self.compare_experiments(exp, exp1, prepared=False)
+        self.compare_experiments(exp, exp1, folder=False, prepared=False)
 
     def test_load_manual_directory(self):
         """Loading results from a different folder."""
@@ -599,7 +624,7 @@ class ExperimentTestMixin:
         exp = core.Experiment(image_path, roi_path, new_folder)
         exp.load(prev_folder)
         # Cache should now be loaded correctly
-        self.compare_experiments(exp, exp1)
+        self.compare_experiments(exp, exp1, folder=False)
 
     def test_load_manual(self):
         """Loading results from a different folder."""
@@ -618,7 +643,7 @@ class ExperimentTestMixin:
         # Manually trigger loading the new cache
         exp.load()
         # Cache should now be loaded correctly
-        self.compare_experiments(exp, exp1)
+        self.compare_experiments(exp, exp1, folder=False)
 
     def test_load_empty_prep(self):
         """Behaviour when loading a prep cache that is empty."""

--- a/fissa/tests/test_extraction.py
+++ b/fissa/tests/test_extraction.py
@@ -419,6 +419,23 @@ def test_multiframe_mean_higherdim_pillow(base_fname, shp, dtype, datahandler):
         datahandler=datahandler,
     )
 
+class TestDataHandlerRepr(BaseTestCase):
+    """String representations of DataHandler are correct."""
+
+    def test_repr_tifffile(self):
+        datahandler = extraction.DataHandlerTifffile()
+        self.assert_equal(repr(datahandler), "fissa.extraction.DataHandlerTifffile()")
+
+    def test_repr_tifffile_lazy(self):
+        datahandler = extraction.DataHandlerTifffileLazy()
+        self.assert_equal(
+            repr(datahandler), "fissa.extraction.DataHandlerTifffileLazy()"
+        )
+
+    def test_repr_pillow(self):
+        datahandler = extraction.DataHandlerPillow()
+        self.assert_equal(repr(datahandler), "fissa.extraction.DataHandlerPillow()")
+
 
 class Rois2MasksTestMixin:
     """Tests for rois2masks."""


### PR DESCRIPTION
So you can see all the details of a fissa.Experiment instance when you print it.

Tests are also added to ensure the str and repr outputs contain the right information, and that `eval(repr(experiment))` produces a new experiment with the same parameters.