### PR TITLE
DOC+BUG: Missing : separator on readthedocs

### DIFF
--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,4 +1,4 @@
-numpydoc
+numpydoc>=0.7.0
 pydata-sphinx-theme; python_version>='3.6'
 readthedocs-sphinx-search; python_version>='3.6'
 sphinx; python_version<'3.6'

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,6 +1,7 @@
 numpydoc
 pydata-sphinx-theme; python_version>='3.6'
 readthedocs-sphinx-search; python_version>='3.6'
-sphinx
+sphinx; python_version<'3.6'
+sphinx>=2; python_version>='3.6'
 sphinx-autobuild
 sphinx_rtd_theme; python_version<'3.6'


### PR DESCRIPTION
The latest documentation was building correctly locally, but was missing a `:` separator between parameters and they values on readthedocs (since #204 was merged, which migrated from napoleon to numpydoc).

It turned out the issue was coming from using numpydoc (with newer themes) that expect a CSS entry which was added to the core stylesheet (basic.css) in Sphinx 2:

```css
.classifier:before {
    font-style: normal;
    margin: 0.5em;
    content: ":";
}
```

Before sphinx 2, the `:` separator was added to the HTML in its own span.

Consequently, newer versions of numpydoc/themes don't add `:` to the HTML because they expect the sphinx CSS to add it. But somewhere the requirements weren't updated to say `sphinx>2`, so you can end up working with sphinx extensions that expect the sphinx 2 style sheet and don't render correctly without it.

As part of its default build process, readthedocs first installs `sphinx<2` and then installs your requirements. That means that you don't get the latest version of sphinx unless you specify a minimum sphinx version higher than that in your requirements. Hence we were getting a version mismatch.

This is solved by requiring `sphinx>=2` when building the documentation on python>=3.6 using numpydoc and pydata-sphinx-theme.