### PR TITLE
API: Rename module ROI -> polygons

### DIFF
--- a/CREDITS.rst
+++ b/CREDITS.rst
@@ -18,7 +18,7 @@ Testing
 
 External Code
 -------------
-* `ROI.py <https://github.com/rochefort-lab/fissa/blob/master/fissa/ROI.py>`_
+* `polygons.py <https://github.com/rochefort-lab/fissa/blob/master/fissa/polygons.py>`_
   was adapted from code contained in the `SIMA <http://www.losonczylab.org/sima/>`_ package
   under the `GNU GPL v2 License <https://www.gnu.org/licenses/gpl-2.0.html>`_.
 * `NIH ImageJ ROI parsing <https://github.com/rochefort-lab/fissa/blob/master/fissa/readimagejrois.py>`_

--- a/fissa/polygons.py
+++ b/fissa/polygons.py
@@ -5,10 +5,11 @@ Polygon tools.
     Module renamed from ``fissa.ROI`` to ``fissa.polygons``.
 
 The functions below were adapted from the sima package
-http://www.losonczylab.org/sima version 1.3.0.
+http://www.losonczylab.org/sima, version 1.3.0.
+https://github.com/losonczylab/sima/blob/1.3.0/sima/ROI.py
 
-License
--------
+**License**
+
 This file is Copyright (C) 2014 The Trustees of Columbia University in the
 City of New York.
 

--- a/fissa/polygons.py
+++ b/fissa/polygons.py
@@ -1,6 +1,9 @@
 """
 Polygon tools.
 
+.. versionchanged:: 1.0.0
+    Module renamed from ``fissa.ROI`` to ``fissa.polygons``.
+
 The functions below were adapted from the sima package
 http://www.losonczylab.org/sima version 1.3.0.
 

--- a/fissa/polygons.py
+++ b/fissa/polygons.py
@@ -34,7 +34,7 @@ def poly2mask(polygons, im_size):
     """
     Convert polygons to a sparse binary mask.
 
-    >>> from fissa.ROI import poly2mask
+    >>> from fissa.polygons import poly2mask
     >>> poly1 = [[0, 0], [0, 1], [1, 1], [1, 0]]
     >>> poly2 = [[0, 1], [0, 2], [2, 2], [2, 1]]
     >>> mask = poly2mask([poly1, poly2], (3, 3))

--- a/fissa/roitools.py
+++ b/fissa/roitools.py
@@ -16,8 +16,8 @@ try:
 except ImportError:
     import collections as abc
 
+from .polygons import poly2mask
 from .readimagejrois import read_imagej_roi_zip
-from .ROI import poly2mask
 
 
 def get_mask_com(mask):

--- a/fissa/tests/test_polygons.py
+++ b/fissa/tests/test_polygons.py
@@ -2,8 +2,7 @@
 Tests for the polygons module.
 
 This test was taken from the sima package
-http://www.losonczylab.org/sima
-version 1.3.0
+http://www.losonczylab.org/sima, v1.3.0:
 https://github.com/losonczylab/sima/blob/6d2cd4f071e4/sima/tests/test_ROI.py
 
 License

--- a/fissa/tests/test_polygons.py
+++ b/fissa/tests/test_polygons.py
@@ -1,5 +1,5 @@
 """
-Tests for the ROI module.
+Tests for the polygons module.
 
 This test was taken from the sima package
 http://www.losonczylab.org/sima
@@ -34,13 +34,13 @@ import numpy as np
 # run properly, regardless of how python is started.
 from numpy.testing import assert_equal
 
-from .. import ROI
+from .. import polygons
 
 
 def test_poly2mask():
     poly1 = [[0, 0], [0, 1], [1, 1], [1, 0]]
     poly2 = [[0, 1], [0, 2], [2, 2], [2, 1]]
-    masks = ROI.poly2mask([poly1, poly2], (3, 3))
+    masks = polygons.poly2mask([poly1, poly2], (3, 3))
     assert_equal(
         masks[0].todense(),
         np.array(


### PR DESCRIPTION
We only kept functions related to polygons from the SIMA code, so the name doesn't fit what is in the module.