### PR TITLE
JNB:BUG:ENH: Fix Suite2p example, and update Binder environment for Python 3.9

### DIFF
--- a/.binder/environment.yml
+++ b/.binder/environment.yml
@@ -3,28 +3,25 @@ channels:
   - defaults
   - conda-forge
 dependencies:
-  - numpy==1.18.4
-  - mkl=2020.0=166
-  - mkl_fft=1.0.15=py36ha843d7b_0
-  - pip==20.1
-  - python=3.6.10=hcf32534_1
-  - scipy=1.4.1=py36h0b6359f_0
-  - six=1.14.0=py36_0
+  - python=3.9.5
+  - numpy==1.21.0
+  - scipy==1.7.0
+  - pip=21.1.2
+  - six==1.16.0
+  - holoviews==1.13.2
   - pip:
-    - bokeh==2.0.2
+    - bokeh==2.3.2
     - fissa[plotting]
     - future==0.18.2
-    - h5py==2.10.0
-    - holoviews==1.13.2
-    - imagecodecs==2020.2.18
-    - imageio==2.8.0
-    - numba==0.49.0
-    - pandas==1.0.3
-    - pillow==7.1.2
-    - read-roi==1.5.2
-    - scikit-image==0.16.2
-    - scikit-learn==0.22.2.post1
-    - shapely==1.7.0
-    - sima==1.3.2
-    - suite2p==0.7.1
-    - tifffile==2020.2.16
+    - h5py==3.3.0
+    - imageio==2.9.0
+    - numba==0.53.1
+    - pandas==1.2.5
+    - pillow==8.2.0
+    - read-roi==1.6.0
+    - scikit-image==0.18.1
+    - scikit-learn==0.24.2
+    - shapely==1.7.1
+    - suite2p==0.10.0
+    - tifffile==2021.6.14
+    - pyqt5==5.15.4

--- a/.binder/environment.yml
+++ b/.binder/environment.yml
@@ -18,10 +18,10 @@ dependencies:
     - numba==0.53.1
     - pandas==1.2.5
     - pillow==8.2.0
+    - pyqt5==5.15.4
     - read-roi==1.6.0
     - scikit-image==0.18.1
     - scikit-learn==0.24.2
     - shapely==1.7.1
     - suite2p==0.10.0
     - tifffile==2021.6.14
-    - pyqt5==5.15.4

--- a/README.rst
+++ b/README.rst
@@ -68,8 +68,8 @@ workflows where FISSA needs to interact with the outputs of other two-photon
 calcium imaging toolboxes which can be used to automatically detect cells.
 
 You can try out each of the example notebooks interactively in your browser on
-Binder_ (note that it may take 10 minutes for Binder to boot up). Our binder
-environment runs in Python 3.9, which to our knowledge is not supported by SIMA.
+Binder_ (note that it may take 10 minutes for Binder to boot up).
+Note that our binder environment runs in Python 3.9, which is not supported by SIMA.
 As such, the SIMA notebook can be viewed but not run on Binder.
 
 +---------------------------+-------------------------------------------------------------------------------------+---------------------------------------------------------------+

--- a/README.rst
+++ b/README.rst
@@ -68,7 +68,9 @@ workflows where FISSA needs to interact with the outputs of other two-photon
 calcium imaging toolboxes which can be used to automatically detect cells.
 
 You can try out each of the example notebooks interactively in your browser on
-Binder_ (note that it may take 10 minutes for Binder to boot up).
+Binder_ (note that it may take 10 minutes for Binder to boot up). Our binder
+environment runs in Python 3.9, which to our knowledge is not supported by SIMA.
+As such, the SIMA notebook can be viewed but not run on Binder.
 
 +---------------------------+-------------------------------------------------------------------------------------+---------------------------------------------------------------+
 | Workflow                  |                                  Jupyter Notebook                                   |                            Script                             |
@@ -79,7 +81,7 @@ Binder_ (note that it may take 10 minutes for Binder to boot up).
 +---------------------------+--------------------------+-------------------------------+--------------------------+--------------------------------+------------------------------+
 | With suite2p_             | `NBViewer <suitehtml_>`_ | `Launch Binder <suitebind_>`_ | `Download <suitedown_>`_ |                                |                              |
 +---------------------------+--------------------------+-------------------------------+--------------------------+--------------------------------+------------------------------+
-| With SIMA_                | `NBViewer <sima_html_>`_ | `Launch Binder <sima_bind_>`_ | `Download <sima_down_>`_ |                                |                              |
+| With SIMA_                | `NBViewer <sima_html_>`_ |                               | `Download <sima_down_>`_ |                                |                              |
 +---------------------------+--------------------------+-------------------------------+--------------------------+--------------------------------+------------------------------+
 | With `CNMF (MATLAB)`_     | `NBViewer <cnmf_html_>`_ | `Launch Binder <cnmf_bind_>`_ | `Download <cnmf_down_>`_ |                                |                              |
 +---------------------------+--------------------------+-------------------------------+--------------------------+--------------------------------+------------------------------+

--- a/examples/SIMA example.ipynb
+++ b/examples/SIMA example.ipynb
@@ -9,6 +9,9 @@
     "[SIMA](http://www.losonczylab.org/sima/) is a toolbox for motion correction and cell detection.\n",
     "Here we illustrate how to create a workflow which uses SIMA to detect cells and FISSA to extract decontaminated signals from those cells.\n",
     "\n",
+    "Our binder environment runs in Python 3.9, which to our knowledge is not supported by SIMA.\n",
+    "As such, the SIMA notebook can be viewed but not run on Binder.\n",
+    "\n",
     "**Reference:**\n",
     "Kaifosh, P., Zaremba, J. D., Danielson, N. B., Losonczy, A., 2014. SIMA: Python software for analysis of dynamic fluorescence imaging data. Frontiers in neuroinformatics 8 (80). doi:&nbsp;[10.3389/fninf.2014.00080](https://doi.org/10.3389/fninf.2014.00080)"
    ]

--- a/examples/Suite2p example.ipynb
+++ b/examples/Suite2p example.ipynb
@@ -26,6 +26,26 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "! Important note: if you want to run Suite2p and FISSA in the same python instance (as we do in this notebook), you have to make sure multiprocessing pools are started using the 'spawn' context, by having the following on top of your code: See here for more information: https://docs.python.org/3/library/multiprocessing.html"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from multiprocessing import set_start_method\n",
+    "\n",
+    "set_start_method(\n",
+    "    \"spawn\"\n",
+    ")  # this is necessary to make FISSA's multiprocessing play nicely with Suite2p's"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},

--- a/examples/Suite2p example.ipynb
+++ b/examples/Suite2p example.ipynb
@@ -55,7 +55,7 @@
     "import fissa\n",
     "\n",
     "# suite2p toolbox\n",
-    "import suite2p.run_s2p\n",
+    "import suite2p\n",
     "\n",
     "# numpy toolbox\n",
     "import numpy as np\n",
@@ -81,7 +81,7 @@
    "outputs": [],
    "source": [
     "# Set your options for running\n",
-    "ops = suite2p.run_s2p.default_ops()  # populates ops with the default options\n",
+    "ops = suite2p.default_ops()  # populates ops with the default options\n",
     "\n",
     "# Provide an h5 path in 'h5py' or a tiff path in 'data_path'\n",
     "# db overwrites any ops (allows for experiment specific settings)\n",
@@ -102,7 +102,7 @@
     "}\n",
     "\n",
     "# Run one experiment\n",
-    "opsEnd = suite2p.run_s2p.run_s2p(ops=ops, db=db)"
+    "opsEnd = suite2p.run_s2p(ops=ops, db=db)"
    ]
   },
   {


### PR DESCRIPTION
With this PR (which replaces an earlier PR which I accidentally botched a bit) I:

- Update the Suite2p notebook to work with the latest Suite2p API changes
- Update the Suite2p notebook to fix the bug in which multiprocessing freezes (fixing #147)
- Update the binder environment to work with the current Suite2p in Python 3.9
- Removed the link to the Sima notebook in binder, and clarified that it does not currently work in Python 3.9