### PR TITLE
API: Expose three separation parameters to fissa UI

### DIFF
--- a/fissa/core.py
+++ b/fissa/core.py
@@ -149,14 +149,17 @@ def separate_trials(
 
     maxiter : int, optional
         Number of maximally allowed iterations.
+
         .. versionadded:: 1.0.0
 
     tol : float, optional
         Error tolerance for termination.
+
         .. versionadded:: 1.0.0
 
     maxtries : int, optional
         Maximum number of tries before algorithm should terminate.
+
         .. versionadded:: 1.0.0
 
     Returns
@@ -291,14 +294,17 @@ class Experiment:
 
     maxiter : int, optional
         Number of maximally allowed iterations of separation algorithm.
+
         .. versionadded:: 1.0.0
 
     tol : float, optional
         Error tolerance for termination of separation algorithm.
+
         .. versionadded:: 1.0.0
 
     maxtries : int, optional
         Maximum number of tries before separation algorithm should terminate.
+
         .. versionadded:: 1.0.0
 
     ncores_preparation : int or None, default=None
@@ -618,6 +624,7 @@ class Experiment:
         Clear prepared data, and all data downstream of prepared data.
 
         .. versionadded:: 1.0.0
+
         """
         # Wipe outputs
         self.means = []
@@ -634,6 +641,7 @@ class Experiment:
         Clear separated data, and all data downstream of separated data.
 
         .. versionadded:: 1.0.0
+
         """
         # Wipe outputs
         self.info = None
@@ -648,6 +656,7 @@ class Experiment:
         Load data from cache file in npz format.
 
         .. versionadded:: 1.0.0
+
 
         Parameters
         ----------

--- a/fissa/core.py
+++ b/fissa/core.py
@@ -100,7 +100,16 @@ def extract(image, rois, nRegions=4, expansion=1, datahandler=None):
     return data, roi_polys, mean
 
 
-def separate_trials(raw, roi_label=None, alpha=0.1, method="nmf", verbosity=1):
+def separate_trials(
+    raw,
+    roi_label=None,
+    alpha=0.1,
+    maxiter=20000,
+    tol=1e-4,
+    maxtries=1,
+    method="nmf",
+    verbosity=1,
+):
     r"""
     Separate signals within a set of 2d arrays.
 
@@ -137,6 +146,18 @@ def separate_trials(raw, roi_label=None, alpha=0.1, method="nmf", verbosity=1):
             - ``1``: Print per-cell progress
 
             .. versionadded:: 1.0.0
+
+    maxiter : int, optional
+        Number of maximally allowed iterations.
+        .. versionadded:: 1.0.0
+
+    tol : float, optional
+        Error tolerance for termination.
+        .. versionadded:: 1.0.0
+
+    maxtries : int, optional
+        Maximum number of tries before algorithm should terminate.
+        .. versionadded:: 1.0.0
 
     Returns
     -------
@@ -182,7 +203,13 @@ def separate_trials(raw, roi_label=None, alpha=0.1, method="nmf", verbosity=1):
 
     # Separate the signals
     Xsep, Xmatch, Xmixmat, convergence = npil.separate(
-        X, method, maxiter=20000, tol=1e-4, maxtries=1, alpha=alpha, verbosity=verbosity
+        X,
+        method,
+        maxiter=maxiter,
+        tol=tol,
+        maxtries=maxtries,
+        alpha=alpha,
+        verbosity=verbosity,
     )
     # Unravel observations from multiple trials into a list of arrays
     trial_lengths = [r.shape[1] for r in raw]
@@ -261,6 +288,18 @@ class Experiment:
     alpha : float, default=0.1
         Sparsity regularizaton weight for NMF algorithm. Set to zero to
         remove regularization. Default is ``0.1``.
+
+    maxiter : int, optional
+        Number of maximally allowed iterations of separation algorithm.
+        .. versionadded:: 1.0.0
+
+    tol : float, optional
+        Error tolerance for termination of separation algorithm.
+        .. versionadded:: 1.0.0
+
+    maxtries : int, optional
+        Maximum number of tries before separation algorithm should terminate.
+        .. versionadded:: 1.0.0
 
     ncores_preparation : int or None, default=None
         The number of parallel subprocesses to use during the data
@@ -450,6 +489,9 @@ class Experiment:
         nRegions=4,
         expansion=1,
         alpha=0.1,
+        maxiter=20000,
+        tol=1e-4,
+        maxtries=1,
         ncores_preparation=None,
         ncores_separation=None,
         method="nmf",
@@ -494,6 +536,9 @@ class Experiment:
         self.nRegions = nRegions
         self.expansion = expansion
         self.alpha = alpha
+        self.maxiter = maxiter
+        self.tol = tol
+        self.maxtries = maxtries
         self.nTrials = len(self.images)  # number of trials
         self.ncores_preparation = ncores_preparation
         self.ncores_separation = ncores_separation
@@ -891,6 +936,9 @@ class Experiment:
         _separate_cfg = functools.partial(
             separate_trials,
             alpha=self.alpha,
+            maxiter=self.maxiter,
+            tol=self.tol,
+            maxtries=self.maxtries,
             method=self.method,
             verbosity=self.verbosity - 2,
         )
@@ -917,6 +965,9 @@ class Experiment:
                             self.raw,
                             range(n_roi),
                             itertools.repeat(self.alpha, n_roi),
+                            itertools.repeat(self.maxiter, n_roi),
+                            itertools.repeat(self.tol, n_roi),
+                            itertools.repeat(self.maxtries, n_roi),
                             itertools.repeat(self.method, n_roi),
                             itertools.repeat(self.verbosity, n_roi),
                         ),


### PR DESCRIPTION
separate_trials and Experiment now allow the user to change the maximum number of iterations, the maximum number of tries from different seeds, and the error tolerance of the separation algorithm.

This is useful when a user experiences a lot of non-convergence across cells.

This would close #149