### PR TITLE
ENH: use joblib instead of multiprocessing

### DIFF
--- a/fissa/core.py
+++ b/fissa/core.py
@@ -760,7 +760,7 @@ class Experiment:
 
         if use_multiprocessing:
             # run extraction
-            outputs = Parallel(n_jobs=self.ncores_separation, backend="threading")(
+            outputs = Parallel(n_jobs=self.ncores_preparation, backend="threading")(
                 delayed(_extract_cfg)(self.images[i], self.rois[i])
                 for i in tqdm.tqdm(
                     range(self.nTrials),

--- a/fissa/core.py
+++ b/fissa/core.py
@@ -17,16 +17,15 @@ import os.path
 import sys
 import warnings
 
-import tqdm
-from joblib import Parallel, delayed
-from past.builtins import basestring
-
 try:
     from collections import abc
 except ImportError:
     import collections as abc
 
 import numpy as np
+import tqdm
+from joblib import Parallel, delayed
+from past.builtins import basestring
 from scipy.io import savemat
 
 from . import deltaf, extraction

--- a/fissa/core.py
+++ b/fissa/core.py
@@ -290,7 +290,7 @@ class Experiment:
 
         .. versionadded:: 1.0.0
 
-    ncores_preparation : int or None, default=None
+    ncores_preparation : int or None, default=-1
         The number of parallel subprocesses to use during the data
         preparation steps of :meth:`separation_prep`.
         These are ROI and neuropil subregion definitions, and extracting
@@ -303,7 +303,7 @@ class Experiment:
         Note that this behaviour can, especially for the data preparation step,
         be very memory-intensive.
 
-    ncores_separation : int or None, default=None
+    ncores_separation : int or None, default=-1
         The number of parallel subprocesses to use during the signal
         separation steps of :meth:`separate`.
         The separation steps requires less memory per subprocess than
@@ -483,8 +483,8 @@ class Experiment:
         max_iter=20000,
         tol=1e-4,
         max_tries=1,
-        ncores_preparation=None,
-        ncores_separation=None,
+        ncores_preparation=-1,
+        ncores_separation=-1,
         method="nmf",
         lowmemory_mode=False,
         datahandler=None,

--- a/fissa/core.py
+++ b/fissa/core.py
@@ -775,9 +775,9 @@ class Experiment:
         else:
             # Use multiprocessing
             outputs = Parallel(n_jobs=n_jobs, backend="threading")(
-                delayed(_extract_cfg)(self.images[i], self.rois[i])
-                for i in tqdm.tqdm(
-                    range(self.nTrials),
+                delayed(_extract_cfg)(image, roi_stack)
+                for image, roi_stack in tqdm.tqdm(
+                    zip(self.images, self.rois),
                     total=self.nTrials,
                     desc="Extracting traces",
                     disable=disable_progressbars,
@@ -943,9 +943,9 @@ class Experiment:
         else:
             # Use multiprocessing
             outputs = Parallel(n_jobs=n_jobs, backend="threading")(
-                delayed(_separate_cfg)(self.raw[i], i)
-                for i in tqdm.tqdm(
-                    range(self.nCell),
+                delayed(_separate_cfg)(X, i)
+                for i, X in tqdm.tqdm(
+                    enumerate(self.raw),
                     total=self.nCell,
                     desc="Separating data",
                     disable=disable_progressbars,

--- a/fissa/core.py
+++ b/fissa/core.py
@@ -760,7 +760,7 @@ class Experiment:
 
         if use_multiprocessing:
             # run extraction
-            outputs = Parallel(n_jobs=self.ncores_separation)(
+            outputs = Parallel(n_jobs=self.ncores_separation, backend="threading")(
                 delayed(_extract_cfg)(self.images[i], self.rois[i])
                 for i in tqdm.tqdm(
                     range(self.nTrials),
@@ -926,7 +926,7 @@ class Experiment:
 
         # Do the extraction
         if use_multiprocessing:
-            outputs = Parallel(n_jobs=self.ncores_separation)(
+            outputs = Parallel(n_jobs=self.ncores_separation, backend="threading")(
                 delayed(_separate_cfg)(self.raw[i], i)
                 for i in tqdm.tqdm(
                     range(self.nCell),

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 future>=0.16.0
+joblib>=0.14.1
 numpy>=1.13.0
 Pillow>=4.3.0
 read-roi>=1.5.0; python_version>='3.0'


### PR DESCRIPTION
Multiprocessing was giving several issues (such as #147). This PR changes it to using joblib instead.

As a bonus, the code is now much more readable, and the same code is used for Python 2 and 3.

For now it's a draft request as there currently is a bug (known from joblib for a while) that stdout from jupyter notebooks only show up in the terminal, not the notebooks themselves. (See https://github.com/ipython/ipykernel/issues/402 and https://github.com/jupyter/notebook/issues/700). 

It can be fixed by using a different backend, but the whole point is to use the standard joblib backend which fixes our issues.