### PR TITLE
CI: Timeout tests that run too long

### DIFF
--- a/.github/workflows/test-release-candidate.yaml
+++ b/.github/workflows/test-release-candidate.yaml
@@ -100,7 +100,7 @@ jobs:
 
     - name: Test with pytest
       run: |
-        python -m pytest --cov=fissa --cov-report term --cov-report xml --junitxml=testresults.xml
+        python -m pytest --timeout=300 --cov=fissa --cov-report term --cov-report xml --junitxml=testresults.xml
 
     - name: Upload unittest coverage to Codecov
       uses: codecov/codecov-action@v1
@@ -126,10 +126,10 @@ jobs:
         python -m pip install --editable .[plotting]
 
     - name: "Notebooks: Lint check"
-      run: python -m pytest --nbsmoke-lint ./examples/
+      run: python -m pytest --timeout=300 --nbsmoke-lint ./examples/
 
     - name: "Notebooks: Smoke test"
-      run: python -m pytest --nbsmoke-run ./examples/ --cov=fissa --cov-report term --cov-report xml --junitxml=nbsmoke.xml
+      run: python -m pytest --timeout=300 --nbsmoke-run ./examples/ --cov=fissa --cov-report term --cov-report xml --junitxml=nbsmoke.xml
 
     - name: "Notebooks: Upload coverage to Codecov"
       uses: codecov/codecov-action@v1

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -82,7 +82,7 @@ jobs:
 
     - name: Test with pytest
       run: |
-        python -m pytest --cov=fissa --cov-report term --cov-report xml --junitxml=testresults.xml
+        python -m pytest --timeout=180 --cov=fissa --cov-report term --cov-report xml --junitxml=testresults.xml
 
     - name: Upload unittest coverage to Codecov
       uses: codecov/codecov-action@v1
@@ -108,10 +108,10 @@ jobs:
         python -m pip install --editable .[plotting]
 
     - name: "Notebooks: Lint check"
-      run: python -m pytest --nbsmoke-lint ./examples/
+      run: python -m pytest --timeout=180 --nbsmoke-lint ./examples/
 
     - name: "Notebooks: Smoke test"
-      run: python -m pytest --nbsmoke-run ./examples/ --cov=fissa --cov-report term --cov-report xml --junitxml=nbsmoke.xml
+      run: python -m pytest --timeout=180 --nbsmoke-run ./examples/ --cov=fissa --cov-report term --cov-report xml --junitxml=nbsmoke.xml
 
     - name: "Notebooks: Upload coverage to Codecov"
       uses: codecov/codecov-action@v1

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -3,3 +3,4 @@ nbsmoke>=0.2.0
 pytest>=3.5.0
 pytest-cov>=2.3.0
 pytest-flake8>=0.7.0
+pytest-timeout>=1.4.2


### PR DESCRIPTION
Any unit test that takes 3 minutes (which is as long as it usually takes to run the whole the test suite) gets killed. It is not expected to ever terminate if it takes longer than that. This prevents the CI queue being held up by zombie tests.