### PR TITLE
DOC: Don't need to specify version added for params in unreleased function

### DIFF
--- a/fissa/core.py
+++ b/fissa/core.py
@@ -145,22 +145,12 @@ def separate_trials(
         - ``0``: No outputs.
         - ``1``: Print separation progress.
 
-        .. versionadded:: 1.0.0
-
     max_iter : int, default=20000
         Number of maximally allowed iterations.
-
-        .. versionadded:: 1.0.0
-
     tol : float, default=1e-4
         Error tolerance for termination.
-
-        .. versionadded:: 1.0.0
-
     max_tries : int, default=1
         Maximum number of tries before algorithm should terminate.
-
-        .. versionadded:: 1.0.0
 
     Returns
     -------

--- a/fissa/neuropil.py
+++ b/fissa/neuropil.py
@@ -84,8 +84,6 @@ def separate(
         - ``0``: No outputs.
         - ``1``: Print separation progress.
 
-        .. versionadded:: 1.0.0
-
     Returns
     -------
     S_sep : :class:`numpy.ndarray` shaped (signals, observations)


### PR DESCRIPTION
When the function is added in v1.0.0, we don't need to describe its arguments as added in v1.0.0.