### PR TITLE
JNB: Add verbosity control example to notebooks

### DIFF
--- a/examples/Basic usage - Functional.ipynb
+++ b/examples/Basic usage - Functional.ipynb
@@ -493,7 +493,41 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Customising FISSA parameters\n",
+    "## Customisation"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Controlling verbosity\n",
+    "\n",
+    "The level of verbosity of FISSA can be controlled with the `verbosity` parameter.\n",
+    "\n",
+    "The default is `verbosity=1`.\n",
+    "\n",
+    "If the verbosity parameter is higher, FISSA will print out more information while it is processing.\n",
+    "This can be helpful for debugging puproses.\n",
+    "The verbosity reaches its maximum at `verbosity=6`.\n",
+    "\n",
+    "If `verbosity=0`, FISSA will run silently."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Call FISSA with elevated verbosity\n",
+    "result = fissa.run_fissa(images_location, rois_location, verbosity=2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Analysis parameters\n",
     "\n",
     "FISSA has several user-definable settings, which can be set as optional arguments to `fissa.run_fissa`."
    ]

--- a/examples/Basic usage.ipynb
+++ b/examples/Basic usage.ipynb
@@ -685,9 +685,46 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### FISSA customisation settings\n",
+    "## FISSA customisation settings\n",
     "\n",
-    "FISSA has several user-definable settings, which can be set when defining the `experiment` object."
+    "FISSA has several user-definable settings, which can be set when defining the `fissa.Experiment` instance."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Controlling verbosity\n",
+    "\n",
+    "The level of verbosity of FISSA can be controlled with the `verbosity` parameter.\n",
+    "\n",
+    "The default is `verbosity=1`.\n",
+    "\n",
+    "If the verbosity parameter is higher, FISSA will print out more information while it is processing.\n",
+    "This can be helpful for debugging puproses.\n",
+    "The verbosity reaches its maximum at `verbosity=6`.\n",
+    "\n",
+    "If `verbosity=0`, FISSA will run silently."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Call FISSA with elevated verbosity\n",
+    "experiment = fissa.Experiment(images_location, rois_location, verbosity=2)\n",
+    "experiment.separate()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Analysis parameters\n",
+    "\n",
+    "The analysis performed by FISSA can be controlled with several parameters."
    ]
   },
   {


### PR DESCRIPTION
Add example of changing verbosity to notebooks. Split out from #238.