### PR TITLE
API: Change outputs from extract func

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,5 @@
 [flake8]
-max-line-length = 96
+max-line-length = 99
 # E203: whitespace before ":". Sometimes violated by black.
 # E402: Module level import not at top of file. Violated by lazy imports.
 # F401: Module imported but unused.

--- a/fissa/core.py
+++ b/fissa/core.py
@@ -95,7 +95,7 @@ def extract(
 
     Parameters
     ----------
-    image : str or :term:`array_like` shaped (time, height, width)
+    image : str or :term:`array_like` shaped ``(time, height, width)``
         Either a path to a multipage TIFF file, or 3d :term:`array_like` data.
     rois : str or :term:`list` of :term:`array_like`
         Either a string containing a path to an ImageJ roi zip file,

--- a/fissa/core.py
+++ b/fissa/core.py
@@ -211,19 +211,18 @@ def extract(
     polys = []
 
     # get neuropil masks and extract signals
-    for cell in tqdm(
-        range(len(base_masks)),
+    for base_mask in tqdm(
+        base_masks,
         total=len(base_masks),
         desc="{}Neuropil extraction".format(mheader),
         disable=verbosity < 4,
     ):
         # neuropil masks
         npil_masks = roitools.getmasks_npil(
-            base_masks[cell], nNpil=nRegions, expansion=expansion
+            base_mask, nNpil=nRegions, expansion=expansion
         )
         # add all current masks together
-        masks = [base_masks[cell]] + npil_masks
-
+        masks = [base_mask] + npil_masks
         # extract traces
         traces.append(datahandler.extracttraces(curdata, masks))
         # store ROI outlines

--- a/fissa/core.py
+++ b/fissa/core.py
@@ -238,7 +238,7 @@ def separate_trials(
 
     Parameters
     ----------
-    raw : list of n_trials :term:`array_like`, each shaped (nRegions, observations)
+    raw : list of n_trials :term:`array_like`, each shaped ``(nRegions + 1, observations)``
         Raw signals.
         A list of 2-d arrays, each of which contains observations of mixed
         signals, mixed in the same way across all trials.
@@ -283,14 +283,14 @@ def separate_trials(
 
     Returns
     -------
-    Xsep : list of n_trials :class:`numpy.ndarray`, each shaped (nRegions, observations)
+    Xsep : list of n_trials :class:`numpy.ndarray`, each shaped ``(nRegions + 1, observations)``
         The separated signals, unordered.
 
-    Xmatch : list of n_trials :class:`numpy.ndarray`, each shaped (nRegions, observations)
+    Xmatch : list of n_trials :class:`numpy.ndarray`, each shaped ``(nRegions + 1, observations)``
         The separated traces, ordered by matching score against the raw ROI
         signal.
 
-    Xmixmat : :class:`numpy.ndarray`, shaped (nRegions, nRegions)
+    Xmixmat : :class:`numpy.ndarray`, shaped ``(nRegions + 1, nRegions + 1)``
         Mixing matrix.
 
     convergence : dict

--- a/fissa/core.py
+++ b/fissa/core.py
@@ -97,20 +97,25 @@ def extract(
     ----------
     image : str or :term:`array_like` shaped ``(time, height, width)``
         Either a path to a multipage TIFF file, or 3d :term:`array_like` data.
+
     rois : str or :term:`list` of :term:`array_like`
         Either a string containing a path to an ImageJ roi zip file,
         or a list of arrays encoding polygons, or list of binary arrays
         representing masks.
+
     nRegions : int, default=4
         Number of neuropil regions to draw. Use a higher number for
         densely labelled tissue. Default is ``4``.
+
     expansion : float, default=1
         Expansion factor for the neuropil region, relative to the
         ROI area. Default is ``1``. The total neuropil area will be
         ``nRegions * expansion * area(ROI)``.
+
     datahandler : fissa.extraction.DataHandlerAbstract, optional
         A datahandler object for handling ROIs and calcium data.
         The default is :class:`~fissa.extraction.DataHandlerTifffile`.
+
     verbosity : int, default=1
         Level of verbosity. The options are:
 
@@ -121,6 +126,7 @@ def extract(
 
     label : str or int, optional
         The label for the current trial. Only used for reporting progress.
+
     total : int, optional
         Total number of trials. Only used for reporting progress.
 

--- a/fissa/core.py
+++ b/fissa/core.py
@@ -526,15 +526,24 @@ class Experiment:
     roi_polys : :class:`numpy.ndarray`
         A :class:`numpy.ndarray` of shape ``(n_rois, n_trials)``, each element
         of which is itself a list of length ``nRegions + 1``, each element of
-        which is a list of length ``1``, containing a :class:`numpy.ndarray`
+        which is a list of length ``n_contour`` containing a :class:`numpy.ndarray`
         of shape ``(n_nodes, 2)``.
 
-        The nodes describe the polygon outline of each region as ``(y, x)``
-        points.
-        The outline of a ROI is given by
-        ``experiment.roi_polys[i_roi][i_trial][0][0]``,
-        and the :attr:`nRegions` neuropil regions by
-        ``experiment.roi_polys[i_roi][i_trial][1 + i_region][0]``.
+        Polygon contours describing the outline of each region.
+
+        For contiguous ROIs, the outline of the ``i_roi``-th ROI used in the
+        ``i_trial``-th trial is described by the array at
+        ``experiment.roi_polys[i_roi, i_trial][0][0]``.
+        This array consists of ``n_nodes`` rows, each representing the
+        coordinate of a node in ``(y, x)`` format.
+        For non-contiguous ROIs, a contour is needed for each disconnected
+        polygon making up the total aggregate ROI. These contours are found at
+        ``experiment.roi_polys[i_roi, i_trial][0][i_contour]``.
+
+        Similarly, the `nRegions` neuropil regions are each described by the
+        polygons
+        ``experiment.roi_polys[i_roi, i_trial][i_neurpil + 1][i_contour]``,
+        respectively.
 
     means : list of `n_trials` :class:`numpy.ndarray`, each shaped ``(height, width)``
         The temporal-mean image for each trial (i.e. for each TIFF file,

--- a/fissa/tests/test_core.py
+++ b/fissa/tests/test_core.py
@@ -1231,15 +1231,15 @@ class TestExtract(BaseTestCase):
             allow_pickle=True,
         )
         # Test against saved data for the first image only
-        self.expected_raw = {i: x for i, x in enumerate(cache["raw"][:, 0])}
-        self.expected_roi_polys = {i: x for i, x in enumerate(cache["roi_polys"][:, 0])}
+        self.expected_raw = np.stack(cache["raw"][:, 0], axis=0)
+        self.expected_roi_polys = list(cache["roi_polys"][:, 0])
         self.expected_mean = cache["means"][0]
 
     def compare_outputs(self, outputs):
         data, roi_polys, mean = outputs
         # Check contents are correct
-        self.assert_equal_dict_of_array(data, self.expected_raw)
-        self.assert_equal_dict_of_array(roi_polys, self.expected_roi_polys)
+        self.assert_allclose(data, self.expected_raw)
+        self.assert_allclose_ragged(roi_polys, self.expected_roi_polys)
         self.assert_equal(mean, self.expected_mean)
 
     def test_vanilla(self):


### PR DESCRIPTION
Change extract func from outputting OrderedDict for raw traces and polys to output a 3d numpy.ndarray and a list respectively.