### PR TITLE
MNT: Suppress warnings

### DIFF
--- a/fissa/core.py
+++ b/fissa/core.py
@@ -1477,7 +1477,12 @@ class Experiment:
         if getattr(self, "deltaf_result", None) is not None:
             M["df_result"] = reformat_dict_for_matlab(self.deltaf_result)
 
-        savemat(fname, M)
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore",
+                message="Creating an ndarray from ragged nested sequences",
+            )
+            savemat(fname, M)
 
 
 def run_fissa(

--- a/fissa/tests/base_test.py
+++ b/fissa/tests/base_test.py
@@ -15,6 +15,11 @@ import tempfile
 import unittest
 from inspect import getsourcefile
 
+try:
+    from collections import abc
+except ImportError:
+    import collections as abc
+
 import numpy as np
 import pytest
 from numpy.testing import (
@@ -30,9 +35,15 @@ TEST_DIRECTORY = os.path.dirname(os.path.abspath(getsourcefile(lambda: 0)))
 
 
 def assert_allclose_ragged(actual, desired):
-    assert_equal(np.shape(actual), np.shape(desired))
+    assert_equal(
+        np.array(actual, dtype=object).shape,
+        np.array(desired, dtype=object).shape,
+    )
     for desired_i, actual_i in zip(desired, actual):
-        if np.asarray(desired).dtype == object:
+        if (
+            getattr(desired, "dtype", None) == object
+            or np.asarray(desired).dtype == object
+        ):
             assert_allclose_ragged(actual_i, desired_i)
         else:
             assert_allclose(actual_i, desired_i)

--- a/fissa/tests/test_core.py
+++ b/fissa/tests/test_core.py
@@ -1040,7 +1040,11 @@ class ExperimentTestMixin:
     def test_calcdeltaf_notrawf0(self):
         exp = core.Experiment(self.images_dir, self.roi_zip_path, verbosity=4)
         exp.separate()
-        exp.calc_deltaf(self.fs, use_raw_f0=False)
+        # Ignore division by zero, which is likely to occur now and something
+        # we want to alert the user to.
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", message="divide by zero")
+            exp.calc_deltaf(self.fs, use_raw_f0=False)
         # We did not use this setting to generate the expected values, so can't
         # compare the output against the target.
         self.compare_output(exp, compare_deltaf=False)
@@ -1062,7 +1066,11 @@ class ExperimentTestMixin:
     def test_calcdeltaf_notrawf0_notacrosstrials(self):
         exp = core.Experiment(self.images_dir, self.roi_zip_path, verbosity=4)
         exp.separate()
-        exp.calc_deltaf(self.fs, use_raw_f0=False, across_trials=False)
+        # Ignore division by zero, which is likely to occur now and something
+        # we want to alert the user to.
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", message="divide by zero")
+            exp.calc_deltaf(self.fs, use_raw_f0=False, across_trials=False)
         # We did not use this setting to generate the expected values, so can't
         # compare the output against the target.
         self.compare_output(exp, compare_deltaf=False)


### PR DESCRIPTION
- Avoid implicit ragged numpy.ndarray creation when comparing shapes.
- Suppress unavoidable warnings about ragged numpy.ndarray when saving matfile.
- Suppress expected division by zero warnings during unit test suite.