### PR TITLE
BUG: De-synchronisation in shape

### DIFF
--- a/fissa/core.py
+++ b/fissa/core.py
@@ -727,7 +727,6 @@ class Experiment:
         self.max_iter = max_iter
         self.tol = tol
         self.max_tries = max_tries
-        self.nTrials = len(self.images)  # number of trials
         self.ncores_preparation = ncores_preparation
         self.ncores_separation = ncores_separation
         self.method = method
@@ -740,6 +739,18 @@ class Experiment:
             os.makedirs(folder)
         else:
             self.load()
+
+    @property
+    def nCell(self):
+        if getattr(self, "result", None) is not None:
+            return self.result.shape[0]
+        if getattr(self, "raw", None) is not None:
+            return self.raw.shape[0]
+        return None
+
+    @property
+    def nTrials(self):
+        return len(self.images)
 
     def __str__(self):
         if isinstance(self.images, basestring):
@@ -824,7 +835,7 @@ class Experiment:
         if verbosity is None:
             verbosity = self.verbosity - 1
 
-        keys = ["means", "nCell", "raw", "roi_polys", "deltaf_raw"]
+        keys = ["means", "raw", "roi_polys", "deltaf_raw"]
         # Wipe outputs
         keys_cleared = []
         for key in keys:
@@ -1046,7 +1057,6 @@ class Experiment:
                 raw[cell][trial] = outputs[trial][0][cell]
                 roi_polys[cell][trial] = outputs[trial][1][cell]
 
-        self.nCell = n_roi  # number of cells
         self.raw = raw
         self.roi_polys = roi_polys
 

--- a/fissa/core.py
+++ b/fissa/core.py
@@ -1012,7 +1012,7 @@ class Experiment:
                 _extract_cfg(image, rois, label=i)
                 for i, (image, rois) in tqdm(
                     enumerate(zip(self.images, self.rois)),
-                    total=self.nTrials,
+                    total=n_trial,
                     desc="Extracting traces",
                     disable=disable_progressbars,
                 )
@@ -1025,35 +1025,35 @@ class Experiment:
                 delayed(_extract_cfg)(image, rois, label=i)
                 for i, (image, rois) in tqdm(
                     enumerate(zip(self.images, self.rois)),
-                    total=self.nTrials,
+                    total=n_trial,
                     desc="Extracting traces",
                     disable=disable_progressbars,
                 )
             )
 
         # get number of cells
-        nCell = len(outputs[0][1])
+        n_roi = len(outputs[0][1])
 
         # predefine data structures
-        raw = np.empty((nCell, self.nTrials), dtype=object)
+        raw = np.empty((n_roi, n_trial), dtype=object)
         roi_polys = np.empty_like(raw)
 
         # Set outputs
         self.means = []
-        for trial in range(self.nTrials):
+        for trial in range(n_trial):
             self.means.append(outputs[trial][2])
-            for cell in range(nCell):
+            for cell in range(n_roi):
                 raw[cell][trial] = outputs[trial][0][cell]
                 roi_polys[cell][trial] = outputs[trial][1][cell]
 
-        self.nCell = nCell  # number of cells
+        self.nCell = n_roi  # number of cells
         self.raw = raw
         self.roi_polys = roi_polys
 
         if self.verbosity >= 1:
             print(
                 "Finished extracting raw signals from {} ROIs across {} trials in {}.".format(
-                    nCell,
+                    n_roi,
                     n_trial,
                     _pretty_timedelta(seconds=time.time() - t0),
                 )
@@ -1210,7 +1210,7 @@ class Experiment:
                 _separate_cfg(X, label=i)
                 for i, X in tqdm(
                     enumerate(self.raw),
-                    total=self.nCell,
+                    total=len(self.raw),
                     desc="Separating data",
                     disable=disable_progressbars,
                 )
@@ -1223,7 +1223,7 @@ class Experiment:
                 delayed(_separate_cfg)(X, label=i)
                 for i, X in tqdm(
                     enumerate(self.raw),
-                    total=self.nCell,
+                    total=len(self.raw),
                     desc="Separating data",
                     disable=disable_progressbars,
                 )
@@ -1375,10 +1375,14 @@ class Experiment:
         # Can't include Δ in the tqdm description on Python2
         desc = "Calculating {}f/f0".format("d" if sys.version_info < (3, 0) else "Δ")
 
+        # Check size of the input arrays
+        n_roi = len(self.result)
+        n_trial = len(self.result[0])
+
         # Loop over cells
         for cell in tqdm(
-            range(self.nCell),
-            total=self.nCell,
+            range(n_roi),
+            total=n_roi,
             desc=desc,
             disable=self.verbosity < 1,
         ):
@@ -1399,7 +1403,7 @@ class Experiment:
 
                 # store Δf/f0
                 curTrial = 0
-                for trial in range(self.nTrials):
+                for trial in range(n_trial):
                     nextTrial = curTrial + self.raw[cell][trial].shape[1]
                     signal = raw_conc[curTrial:nextTrial]
                     deltaf_raw[cell][trial] = np.expand_dims(signal, axis=0)
@@ -1408,7 +1412,7 @@ class Experiment:
                     curTrial = nextTrial
             else:
                 # loop across trials
-                for trial in range(self.nTrials):
+                for trial in range(n_trial):
                     # get current signals
                     raw_sig = self.raw[cell][trial][0, :]
                     result_sig = self.result[cell][trial]
@@ -1493,12 +1497,12 @@ class Experiment:
         def reformat_dict_for_matlab(orig_dict):
             new_dict = collections.OrderedDict()
             # loop over cells and trial
-            for cell in range(self.nCell):
+            for cell in range(len(self.result)):
                 # get current cell label
                 c_lab = "cell" + str(cell)
                 # update dictionary
                 new_dict[c_lab] = collections.OrderedDict()
-                for trial in range(self.nTrials):
+                for trial in range(len(self.result[0])):
                     # get current trial label
                     t_lab = "trial" + str(trial)
                     # update dictionary

--- a/fissa/core.py
+++ b/fissa/core.py
@@ -890,6 +890,7 @@ class Experiment:
             provided when the object was initialised is used
             (``experiment.folder``).
         """
+        dynamic_properties = ["nCell", "nTrials"]
         if path is None:
             if self.folder is None:
                 raise ValueError(
@@ -907,6 +908,8 @@ class Experiment:
             print("Reloading data from cache {}".format(path))
         cache = np.load(path, allow_pickle=True)
         for field in cache.files:
+            if field in dynamic_properties:
+                continue
             value = cache[field]
             if np.array_equal(value, None):
                 value = None

--- a/fissa/tests/test_core.py
+++ b/fissa/tests/test_core.py
@@ -76,6 +76,8 @@ class ExperimentTestMixin:
         expected_shape = len(self.roi_paths), len(self.image_names)
         self.assert_equal(np.shape(actual.raw), expected_shape)
         self.assert_equal(len(actual.means), len(self.image_names))
+        self.assert_equal(actual.nCell, len(actual.raw))
+        self.assert_equal(actual.nTrials, len(actual.raw[0]))
         # Check contents are correct
         self.assert_allclose_ragged(actual.raw, self.expected["raw"])
         self.assert_equal(actual.means, self.expected["means"])
@@ -83,7 +85,6 @@ class ExperimentTestMixin:
         # Check parameters match
         self.assert_equal(actual.expansion, self.expected["expansion"])
         self.assert_equal(actual.nRegions, self.expected["nRegions"])
-        self.assert_equal(actual.nCell, len(actual.raw))
         if separated:
             # Check sizes are correct
             self.assert_equal(np.shape(actual.sep), expected_shape)

--- a/fissa/tests/test_core.py
+++ b/fissa/tests/test_core.py
@@ -311,6 +311,12 @@ class ExperimentTestMixin:
         exp2 = eval(actual)
         self.compare_experiments(exp, exp2)
 
+    def test_initial_shapes(self):
+        """Check nCell and nTrials are correct after init, before extracting data."""
+        exp = core.Experiment(self.images_dir, self.roi_zip_path)
+        self.assert_equal(exp.nCell, None)
+        self.assert_equal(exp.nTrials, len(self.image_names))
+
     def test_imagedir_roizip(self):
         exp = core.Experiment(self.images_dir, self.roi_zip_path)
         exp.separate()


### PR DESCRIPTION
If the images or raw attributes are changed after initialising the array, the nTrials and nCell properties can become de-synced with the actual number of images and ROIs. c.f. pakanlab@4f136e7

We stop relying on these properties and dynamically get the values from the current size of result/raw/images.