### PR TITLE
ENH: Automatically wipe output properties when parameter attributes change

### DIFF
--- a/fissa/core.py
+++ b/fissa/core.py
@@ -772,6 +772,15 @@ class Experiment:
     def nTrials(self):
         return len(self.images)
 
+    def __setattr__(self, name, value):
+        if name in ["images", "rois"]:
+            self.clear()
+        elif hasattr(self, "_preparation_params") and name in self._preparation_params:
+            self.clear()
+        elif hasattr(self, "_separation_params") and name in self._separation_params:
+            self.clear_separated()
+        self.__dict__[name] = value
+
     def __str__(self):
         if isinstance(self.images, basestring):
             str_images = repr(self.images)
@@ -835,7 +844,7 @@ class Experiment:
             By default, the object's :attr:`verbosity` attribute is used.
         """
         if verbosity is None:
-            verbosity = self.verbosity - 1
+            verbosity = getattr(self, "verbosity", 1) - 1
 
         keys = self._preparation_outputs + ["deltaf_raw"]
         # Wipe outputs
@@ -864,7 +873,7 @@ class Experiment:
             By default, the object's :attr:`verbosity` attribute is used.
         """
         if verbosity is None:
-            verbosity = self.verbosity - 1
+            verbosity = getattr(self, "verbosity", 1) - 1
 
         keys = self._separation_outputs + ["deltaf_result"]
         # Wipe outputs

--- a/fissa/core.py
+++ b/fissa/core.py
@@ -683,8 +683,8 @@ class Experiment:
         "tol": 1e-4,
         "max_tries": 1,
     }
-    _preparation_params = ["expansion", "nRegions"]
-    _separation_params = ["alpha", "max_iter", "max_tries", "method", "tol"]
+    _preparation_params = ["nRegions", "expansion"]
+    _separation_params = ["method", "alpha", "max_iter", "tol", "max_tries"]
     _preparation_outputs = ["means", "raw", "roi_polys"]
     _separation_outputs = ["info", "mixmat", "result", "sep"]
     _deltaf_outputs = ["deltaf_raw", "deltaf_result"]

--- a/fissa/core.py
+++ b/fissa/core.py
@@ -1285,7 +1285,7 @@ class Experiment:
             ``"prepared.npz"`` within the cache directory
             ``experiment.folder``.
         """
-        fields = ["expansion", "means", "nCell", "nRegions", "raw", "roi_polys"]
+        fields = ["expansion", "means", "nRegions", "raw", "roi_polys"]
         if destination is None:
             if self.folder is None:
                 raise ValueError(
@@ -1799,7 +1799,6 @@ class Experiment:
                 "means",
                 "method",
                 "mixmat",
-                "nCell",
                 "nRegions",
                 "raw",
                 "result",

--- a/fissa/core.py
+++ b/fissa/core.py
@@ -773,12 +773,26 @@ class Experiment:
         return len(self.images)
 
     def __setattr__(self, name, value):
+        def check_same_value():
+            if not hasattr(self, name):
+                return False
+            current = getattr(self, name)
+            if type(current) is not type(value):
+                return False
+            if isinstance(current, np.ndarray):
+                return np.array_equal(current, value)
+            return current == value
+
         if name in ["images", "rois"]:
-            self.clear()
+            if not check_same_value():
+                self.clear()
         elif hasattr(self, "_preparation_params") and name in self._preparation_params:
-            self.clear()
+            if not check_same_value():
+                self.clear()
         elif hasattr(self, "_separation_params") and name in self._separation_params:
-            self.clear_separated()
+            if not check_same_value():
+                self.clear_separated()
+
         self.__dict__[name] = value
 
     def __str__(self):

--- a/fissa/core.py
+++ b/fissa/core.py
@@ -783,7 +783,10 @@ class Experiment:
                 return np.array_equal(current, value)
             return current == value
 
-        if name in ["images", "rois"]:
+        if getattr(self, name, None) is None:
+            # No need to clear if the current value is None
+            pass
+        elif name in ["images", "rois"]:
             if not check_same_value():
                 self.clear()
         elif hasattr(self, "_preparation_params") and name in self._preparation_params:

--- a/fissa/tests/test_core.py
+++ b/fissa/tests/test_core.py
@@ -811,6 +811,126 @@ class ExperimentTestMixin:
         self.assertTrue("Doing" in capture_post.out)
         self.compare_output(exp)
 
+    def test_autoclear_images_param(self):
+        """Test output attributes are cleared when image data changes."""
+        exp = core.Experiment(self.images_dir, self.roi_zip_path)
+        exp.separate()
+        # Check values are set correctly
+        self.compare_output(exp)
+        # Change images directory
+        exp.images = "some/new/path/"
+        # Check preparation outputs are wiped
+        self.assertIs(exp.means, None)
+        self.assertIs(exp.raw, None)
+        self.assertIs(exp.roi_polys, None)
+        # Check separation outputs are wiped
+        self.assertIs(exp.info, None)
+        self.assertIs(exp.mixmat, None)
+        self.assertIs(exp.result, None)
+        self.assertIs(exp.sep, None)
+
+    def test_autoclear_rois_param(self):
+        """Test output attributes are cleared when roi data changes."""
+        exp = core.Experiment(self.images_dir, self.roi_zip_path)
+        # Assign dummy values
+        exp.means = [2819, 12893, 12378]
+        exp.raw = 101
+        exp.result = 42
+        exp.info = {"foo": 1, "bar": 2}
+        self.assert_equal(exp.raw, 101)
+        # Change roi directory
+        exp.rois = "some/new/path/"
+        # Check preparation outputs are wiped
+        self.assertIs(exp.means, None)
+        self.assertIs(exp.raw, None)
+        # Check separation outputs are wiped
+        self.assertIs(exp.info, None)
+        self.assertIs(exp.result, None)
+
+    def test_autoclear_prep_param(self):
+        """Test output attributes are cleared when prep parameters change."""
+        exp = core.Experiment(self.images_dir, self.roi_zip_path, expansion=1)
+        # Assign dummy values
+        exp.means = [2819, 12893, 12378]
+        exp.raw = 101
+        exp.result = 42
+        exp.info = {"foo": 1, "bar": 2}
+        # Change preparation parameter
+        exp.expansion = exp.expansion + 1
+        # Check preparation outputs are wiped
+        self.assertIs(exp.means, None)
+        self.assertIs(exp.raw, None)
+        # Check separation outputs are wiped
+        self.assertIs(exp.info, None)
+        self.assertIs(exp.result, None)
+
+    def test_autoclear_sep_param(self):
+        """Test output attributes are cleared when sep parameters change."""
+        exp = core.Experiment(self.images_dir, self.roi_zip_path)
+        exp.separate()
+        # Check values are set correctly
+        self.compare_output(exp)
+        # Change separation parameter
+        exp.method = "bespoke_method"
+        # Check separation outputs are wiped
+        self.assertIs(exp.info, None)
+        self.assertIs(exp.mixmat, None)
+        self.assertIs(exp.result, None)
+        self.assertIs(exp.sep, None)
+        # Check prepared values are still set correctly
+        self.compare_output(exp, separated=False)
+
+    def test_autoclear_sensitivity_unset(self):
+        """Test autoclear sensitivity."""
+        exp = core.Experiment(self.images_dir, self.roi_zip_path)
+        # Initial value
+        exp.raw = 101
+        self.assert_equal(exp.raw, 101)
+        self.assertIs(exp.expansion, None)
+        # Test not cleared when setting unset parameter
+        exp.expansion = 1.2345678
+        self.assert_equal(exp.raw, 101)
+
+    def test_autoclear_sensitivity_scalar(self):
+        """Test autoclear sensitivityto changing scalar values."""
+        exp = core.Experiment(self.images_dir, self.roi_zip_path)
+        # Initial value
+        exp.expansion = 1.2345678
+        exp.raw = 101
+        # Test cleared when parameter is changed
+        exp.expansion = 0.2345678
+        self.assert_equal(exp.raw, None)
+
+    def test_autoclear_sensitivity_str(self):
+        """Test autoclear sensitivity to changing string values."""
+        exp = core.Experiment(self.images_dir, self.roi_zip_path)
+        # Initial value
+        exp.method = "foo"
+        exp.result = 101
+        # Test cleared when parameter is changed
+        exp.method = "bar"
+        self.assert_equal(exp.result, None)
+
+    def test_autoclear_sensitivity_array(self):
+        """Test autoclear sensitive to changing array values."""
+        exp = core.Experiment(self.images_dir, self.roi_zip_path)
+        # Initial value
+        exp.expansion = np.zeros((2, 3))
+        exp.raw = 101
+        # Test cleared when parameter is changed
+        exp.expansion = np.ones((3, 4))
+        self.assert_equal(exp.raw, None)
+
+    def test_autoclear_sensitivity_type(self):
+        """Test autoclear sensitivity when changing type."""
+        exp = core.Experiment(self.images_dir, self.roi_zip_path)
+        # Initial value
+        exp.expansion = 1.2345678
+        exp.raw = 101
+        # Test cleared when parameter is changed to a non-comparable type
+        exp.expansion = "foobar"
+        self.assert_equal(exp.raw, None)
+
     def test_load_cache(self):
         """Test whether cached output is loaded during init."""
         image_path = self.images_dir

--- a/fissa/tests/test_core.py
+++ b/fissa/tests/test_core.py
@@ -811,6 +811,13 @@ class ExperimentTestMixin:
         self.assertTrue("Doing" in capture_post.out)
         self.compare_output(exp)
 
+    def test_setattr_new(self):
+        """Test we can set new attributes arbitrarily."""
+        exp = core.Experiment(self.images_dir, self.roi_zip_path)
+        exp.baz = True
+        exp.foobar = "ipsum lorem"
+        exp.meaning_of_life = 42
+
     def test_autoclear_images_param(self):
         """Test output attributes are cleared when image data changes."""
         exp = core.Experiment(self.images_dir, self.roi_zip_path)

--- a/fissa/tests/test_core.py
+++ b/fissa/tests/test_core.py
@@ -255,7 +255,6 @@ class ExperimentTestMixin:
         expected_shape = len(self.roi_paths), len(self.image_names)
         self.assert_equal(np.shape(M["raw"]), expected_shape)
         self.assert_equal(len(M["means"]), len(self.image_names))
-        self.assert_equal(M["nCell"], len(M["raw"]))
         # self.assert_equal(M["nTrials"], len(M["raw[0]"]))
         # Check contents are correct
         self.assert_allclose_ragged(M["raw"], self.expected["raw"])


### PR DESCRIPTION
Set Experiment output attributes to `None` when parameters change.

Example 1:
```python
experiment = fissa.Experiment("path/to/images1", "path/to/rois")
experiment.separate()
# Change images directory
experiment.images = "path/to/images2"
# All experiment outputs are deleted from the object
```

Example 2:
```python
experiment = fissa.Experiment("path/to/images1", "path/to/rois", expansion=1.2)
experiment.separate()
# Change expansion parameter (used during extraction step)
experiment.expansion = 0.8
# All experiment outputs are deleted from the object
```

Example 3:
```python
experiment = fissa.Experiment("path/to/images1", "path/to/rois", alpha=0.1)
experiment.separate()
# Change alpha parameter (used during separation step)
experiment.alpha = 0.05
# result and other separate() outputs are removed, but raw and other prep outputs are not
```