### PR TITLE
JNB+DEV: Updates to nbqa for notebook pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,9 +37,16 @@ repos:
   - repo: https://github.com/nbQA-dev/nbQA
     rev: 1.0.0
     hooks:
-       - id: nbqa-black
-         args: [--nbqa-mutate]
-         additional_dependencies: [black==21.7b0]
+      - id: nbqa-black
+        args:
+            - "--nbqa-mutate"
+            - "--target-version=py27"
+            - "--target-version=py35"
+            - "--target-version=py36"
+            - "--target-version=py37"
+            - "--target-version=py38"
+            - "--target-version=py39"
+        additional_dependencies: [black==21.7b0]
 
   - repo: https://github.com/pre-commit/pygrep-hooks
     rev: v1.9.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,6 +47,7 @@ repos:
             - "--target-version=py38"
             - "--target-version=py39"
         additional_dependencies: [black==21.7b0]
+      - id: nbqa-flake8
 
   - repo: https://github.com/pre-commit/pygrep-hooks
     rev: v1.9.0

--- a/examples/Basic usage - Functional.ipynb
+++ b/examples/Basic usage - Functional.ipynb
@@ -477,7 +477,7 @@
     "        # Labels and boiler plate\n",
     "        plt.ylim([-0.05 * roi_max[i_roi], roi_max[i_roi] * 1.05])\n",
     "        if i_roi == 0:\n",
-    "            plt.ylabel(\"Trial {}\\n\\n $\\Delta f\\,/\\,f_0$\".format(i_trial + 1))\n",
+    "            plt.ylabel(\"Trial {}\\n\\n\".format(i_trial + 1) + r\"$\\Delta f\\,/\\,f_0$\")\n",
     "        if i_trial == 0:\n",
     "            plt.title(\"ROI {}\".format(i_roi))\n",
     "            plt.legend()\n",

--- a/examples/Basic usage.ipynb
+++ b/examples/Basic usage.ipynb
@@ -565,7 +565,7 @@
     "\n",
     "plt.title(\"ROI {},  Trial {}\".format(roi, trial), fontsize=15)\n",
     "plt.xlabel(\"Time (s)\", fontsize=15)\n",
-    "plt.ylabel(\"$\\Delta f\\,/\\,f_0$\", fontsize=15)\n",
+    "plt.ylabel(r\"$\\Delta f\\,/\\,f_0$\", fontsize=15)\n",
     "plt.grid()\n",
     "plt.legend()\n",
     "plt.show()"
@@ -622,7 +622,7 @@
     "        # Labels and boiler plate\n",
     "        plt.ylim([-0.05 * roi_max[i_roi], roi_max[i_roi] * 1.05])\n",
     "        if i_roi == 0:\n",
-    "            plt.ylabel(\"Trial {}\\n\\n $\\Delta f\\,/\\,f_0$\".format(i_trial + 1))\n",
+    "            plt.ylabel(\"Trial {}\\n\\n\".format(i_trial + 1) + r\"$\\Delta f\\,/\\,f_0$\")\n",
     "        if i_trial == 0:\n",
     "            plt.title(\"ROI {}\".format(i_roi))\n",
     "            plt.legend()\n",

--- a/examples/SIMA example.ipynb
+++ b/examples/SIMA example.ipynb
@@ -76,7 +76,7 @@
     "sequences = [sima.Sequence.create(\"TIFF\", tiff) for tiff in tiffs[:1]]\n",
     "try:\n",
     "    dataset = sima.ImagingDataset(sequences, \"example.sima\")\n",
-    "except:\n",
+    "except BaseException:\n",
     "    dataset = sima.ImagingDataset.load(\"example.sima\")"
    ]
   },


### PR DESCRIPTION
- Specify that notebooks should be blackened targeting python 2.7, and >=3.5.
- Sanity check notebooks with flake8.
- Fix some flake8 errors in the notebooks.