### PR TITLE
REL: Fix dependency rot of pytest-flake8 for Python 2.7

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -3,4 +3,5 @@ nbsmoke>=0.2.0
 pytest>=3.5.0
 pytest-cov>=2.3.0
 pytest-flake8>=0.7.0
+pytest-flake8<1.1.0; python_version<'3.0'
 pytest-timeout>=1.4.2


### PR DESCRIPTION
It seems that pytest-flake8 v1.1.0 doesn't support python 2.7 but doesn't declare this, so we have to manually tell pip to avoid it.