### PR TITLE
MNT: sklearn deprecation of alpha parameter to NMF

### DIFF
--- a/fissa/neuropil.py
+++ b/fissa/neuropil.py
@@ -8,6 +8,8 @@ Created:
     2015-05-15
 """
 
+import warnings
+
 import numpy as np
 import numpy.random as rand
 import sklearn.decomposition
@@ -180,15 +182,17 @@ def separate(
         elif sep_method.lower() in {"nmf", "nnmf"}:
 
             # Make an instance of the sklearn NMF class
-            estimator = sklearn.decomposition.NMF(
-                init="nndsvdar" if W0 is None and H0 is None else "custom",
-                n_components=n,
-                alpha=alpha,
-                l1_ratio=0.5,
-                tol=tol,
-                max_iter=max_iter,
-                random_state=random_state,
-            )
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", DeprecationWarning)
+                estimator = sklearn.decomposition.NMF(
+                    init="nndsvdar" if W0 is None and H0 is None else "custom",
+                    n_components=n,
+                    alpha=alpha,
+                    l1_ratio=0.5,
+                    tol=tol,
+                    max_iter=max_iter,
+                    random_state=random_state,
+                )
 
             # Perform NMF and find separated signals
             S_sep = estimator.fit_transform(S.T, W=W0, H=H0)

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ numpy>=1.13.0
 Pillow>=4.3.0
 read-roi>=1.5.0; python_version>='3.0'
 scikit-image>=0.13.0
-scikit-learn>=0.17.0
+scikit-learn>=0.17.0,<1.2
 scipy>=0.19.0
 shapely>=1.5.17
 six>=1.11.0


### PR DESCRIPTION
In version 1.0.0, sklearn deprecated the `alpha` argument to [NMF](https://scikit-learn.org/stable/modules/generated/sklearn.decomposition.NMF.html) in favour of the `alpha_W` and `alpha_H` arguments, which were added in v1.0.0. The deprecation warning declares that `alpha` will be removed in v1.2.0.

We can't simply swap to using `alpha_W` instead of `alpha` because the behaviour is different:

> When using alpha instead of alpha_W and alpha_H, the regularization terms are not scaled by the n_features (resp. n_samples) factors for W (resp. H).

I imagine the new method where the alphas scale against the number of features/samples is better... but we selected `alpha=0.1` without any such scaling and it is not clear to me without running some tests that we should use `alpha_W=alpha_H=0.1`.

Another issue is that v1.0.0 which added `alpha_W` and `alpha_H` only support python >= 3.7, so we would have to cut support for python <= 3.6 to move to the new versions of alpha.

Until someone investigates a new appropriate value of alpha, for the meantime we will carry on using the old version of alpha, suppress the deprecation warning so that end-users do not have to tolerate it, and declare that FISSA requires sklearn<1.2.