### PR TITLE
DOC+BUG: Prevent nbconvert error missing jinja2.utils.escape

### DIFF
--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,3 +1,4 @@
+Jinja2<3.1.0
 nbsphinx
 numpydoc>=0.7.0
 pydata-sphinx-theme; python_version>='3.6'


### PR DESCRIPTION
The removal of jinja2.utils.escape in Jinja2 v3.1.0 breaks nbconvert, which was relying on this deprecated function.

For more details, see issue here: https://github.com/jupyter/nbconvert/issues/1736