### PR TITLE
DOC: Remove elastic search from on readthedocs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -132,12 +132,6 @@ extensions = [
     "nbsphinx",  # Execute .ipynb files to generate html
 ]
 
-# Some extension features only available on later Python versions
-if sys.version_info >= (3, 6):
-    # Enables search as you type with Elasticsearch on readthedocs.com
-    # but only available on Python 3.6 and above.
-    extensions.append("sphinx_search.extension")
-
 # Napoleon settings
 napoleon_google_docstring = True
 napoleon_numpy_docstring = True

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -4,7 +4,6 @@ numpydoc>=0.7.0
 pydata-sphinx-theme; python_version>='3.6'
 pypandoc==1.3; python_version<'3.0'
 pypandoc>=1.6.3; python_version>='3.0'
-readthedocs-sphinx-search; python_version>='3.6'
 sphinx; python_version<'3.6'
 sphinx>=2; python_version>='3.6'
 sphinx-autobuild


### PR DESCRIPTION
This reverts commit 8ba523705caa97d81461223d152b86fd9c54b61d.

Elastic search is not working with the pydata theme.