### PR TITLE
Sklearn compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ numpy>=1.13.0
 Pillow>=4.3.0
 read-roi>=1.5.0; python_version>='3.0'
 scikit-image>=0.13.0
-scikit-learn>=0.17.0,<1.2
+scikit-learn>=0.17.0
 scipy>=0.19.0
 shapely>=1.5.17
 six>=1.11.0


### PR DESCRIPTION
Added decorator to adjust the arguments to the sklearn's NMF constructor such that the >=1.0 implementation's objective is identical to <= 1.0 implementation. Specifically, it generates alpha_W & alpha_H from the passed alpha parameter such that the alpha's in the objective match after scaling (there is not option to turn off scaling the alpha's in the new implementation). Results match original implementation with 1e-7 tolerance. Not sure if fix is compatible with python 2.

Added option for MiniBatchNMF with decorator so that it is also compatible. 