### PR TITLE
Add cap to numpy and shapely version support, fix tests, upgrade precommit

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -8,4 +8,5 @@ max-line-length = 99
 extend-ignore = E203,E402,F401,D100,D101,D102,D103,D104,D105,D106,D107,D200
 docstring-convention = numpy
 # Ignore missing docstrings within unit testing functions.
-per-file-ignores = **/tests/:D100,D101,D102,D103,D104,D105,D106,D107
+# Ignore C420 Unnecessary dict comprehension
+per-file-ignores = **/tests/:D100,D101,D102,D103,D104,D105,D106,D107,C420

--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -12,7 +12,7 @@ jobs:
   notebooks:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Determine default branch
       run: |
@@ -21,7 +21,7 @@ jobs:
         echo "default_branch_ref=refs/heads/$DEFAULT_BRANCH" >> $GITHUB_ENV
 
     - name: Set up Python 3.6
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: "3.6"
 

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -12,6 +12,6 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-python@v2
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
     - uses: pre-commit/action@v2.0.0

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -14,4 +14,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v5
-    - uses: pre-commit/action@v2.0.0
+      with:
+        python-version: "3.10"
+        cache: pip
+    - uses: pre-commit/action@v3.0.0

--- a/.github/workflows/test-release-candidate.yaml
+++ b/.github/workflows/test-release-candidate.yaml
@@ -65,10 +65,10 @@ jobs:
       PYTHON: ${{ matrix.python-version }}
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
 
@@ -103,7 +103,7 @@ jobs:
         python -m pytest --timeout=300 --cov=fissa --cov-report term --cov-report xml --junitxml=testresults.xml
 
     - name: Upload unittest coverage to Codecov
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v4
       with:
         flags: unittests
         env_vars: OS,PYTHON
@@ -132,7 +132,7 @@ jobs:
 
     - name: "Notebooks: Upload coverage to Codecov"
       if: ${{ env.OS != 'windows-latest' || env.PYTHON != '3.6' }}
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v4
       with:
         flags: nbsmoke
         env_vars: OS,PYTHON
@@ -144,7 +144,7 @@ jobs:
         python setup.py sdist bdist_wheel
 
     - name: Store wheel artifacts
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: wheel-${{ matrix.os }}-${{ matrix.python-version }}
         path: dist/*
@@ -166,16 +166,16 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Download wheel artifacts
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v4
       with:
         name: wheel-*
         path: dist/
 
     - name: Store aggregated wheel artifacts
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: wheels
         path: dist/*

--- a/.github/workflows/test-release-candidate.yaml
+++ b/.github/workflows/test-release-candidate.yaml
@@ -52,14 +52,12 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: ["3.5", "3.6", "3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10"]
         include:
-          - os: ubuntu-latest
-            python-version: "2.7"
           - os: macos-latest
-            python-version: "3.5"
+            python-version: "3.8"
           - os: macos-latest
-            python-version: "3.9"
+            python-version: "3.10"
     env:
       OS: ${{ matrix.os }}
       PYTHON: ${{ matrix.python-version }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -30,7 +30,7 @@ jobs:
         python-version: ["3.8", "3.10"]
         include:
           - os: windows-latest
-            python-version: "3.10"
+            python-version: "3.8"
     env:
       OS: ${{ matrix.os }}
       PYTHON: ${{ matrix.python-version }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ["2.7", "3.5", "3.10"]
+        python-version: ["3.8", "3.10"]
         include:
           - os: windows-latest
             python-version: "3.10"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -36,10 +36,10 @@ jobs:
       PYTHON: ${{ matrix.python-version }}
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
 
@@ -85,7 +85,7 @@ jobs:
         python -m pytest --timeout=180 --cov=fissa --cov-report term --cov-report xml --junitxml=testresults.xml
 
     - name: Upload unittest coverage to Codecov
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v4
       with:
         flags: unittests
         env_vars: OS,PYTHON
@@ -110,7 +110,7 @@ jobs:
       run: python -m pytest --timeout=180 --nbsmoke-run ./examples/ --cov=fissa --cov-report term --cov-report xml --junitxml=nbsmoke.xml
 
     - name: "Notebooks: Upload coverage to Codecov"
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v4
       with:
         flags: nbsmoke
         env_vars: OS,PYTHON

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/PyCQA/isort
-    rev: 5.10.1
+    rev: 5.13.2
     hooks:
       - id: isort
         name: isort
@@ -11,7 +11,7 @@ repos:
         args: ["--profile=black"]
 
   - repo: https://github.com/psf/black
-    rev: 21.12b0
+    rev: 24.8.0
     hooks:
       - id: black
         args:
@@ -25,19 +25,19 @@ repos:
         types: [python]
 
   - repo: https://github.com/asottile/blacken-docs
-    rev: v1.12.1
+    rev: 1.18.0
     hooks:
       - id: blacken-docs
         additional_dependencies: [black==21.12b0]
 
   - repo: https://github.com/kynan/nbstripout
-    rev: 0.5.0
+    rev: 0.7.1
     hooks:
       - id: nbstripout
         args: ["--keep-count"]
 
   - repo: https://github.com/nbQA-dev/nbQA
-    rev: 1.3.1
+    rev: 1.8.7
     hooks:
       - id: nbqa-black
         args:
@@ -53,7 +53,7 @@ repos:
       - id: nbqa-flake8
 
   - repo: https://github.com/pre-commit/pygrep-hooks
-    rev: v1.9.0
+    rev: v1.10.0
     hooks:
       - id: python-check-blanket-noqa
       - id: python-check-blanket-type-ignore
@@ -66,7 +66,7 @@ repos:
         types: [text]
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.1.0
+    rev: v4.6.0
     hooks:
       - id: check-added-large-files
       - id: check-ast
@@ -93,7 +93,7 @@ repos:
         exclude: \.(html|svg)$
 
   - repo: https://github.com/PyCQA/flake8
-    rev: 4.0.1
+    rev: 7.1.1
     hooks:
       - id: flake8
         additional_dependencies:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -75,6 +75,7 @@ repos:
         exclude: ^LICENSE|\.(html|csv|txt|svg|py)$
       - id: pretty-format-json
         args: ["--autofix", "--no-ensure-ascii", "--no-sort-keys"]
+        exclude_types: [jupyter]
       - id: requirements-txt-fixer
       - id: trailing-whitespace
         args: [--markdown-linebreak-ext=md]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,20 +15,14 @@ repos:
     hooks:
       - id: black
         args:
-            - "--target-version=py27"
             - "--target-version=py35"
-            - "--target-version=py36"
-            - "--target-version=py37"
-            - "--target-version=py38"
-            - "--target-version=py39"
-            - "--target-version=py310"
         types: [python]
 
   - repo: https://github.com/asottile/blacken-docs
     rev: 1.18.0
     hooks:
       - id: blacken-docs
-        additional_dependencies: [black==21.12b0]
+        additional_dependencies: [black==24.8.0]
 
   - repo: https://github.com/kynan/nbstripout
     rev: 0.7.1
@@ -42,14 +36,8 @@ repos:
       - id: nbqa-black
         args:
             - "--nbqa-mutate"
-            - "--target-version=py27"
             - "--target-version=py35"
-            - "--target-version=py36"
-            - "--target-version=py37"
-            - "--target-version=py38"
-            - "--target-version=py39"
-            - "--target-version=py310"
-        additional_dependencies: [black==21.12b0]
+        additional_dependencies: [black==24.8.0]
       - id: nbqa-flake8
 
   - repo: https://github.com/pre-commit/pygrep-hooks

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -57,7 +57,6 @@ def ensure_pandoc_installed(_):
         os.environ["PATH"] += os.pathsep + pandoc_dir
     if hasattr(pypandoc, "ensure_pandoc_installed"):
         pypandoc.ensure_pandoc_installed(
-            quiet=True,
             targetfolder=pandoc_dir,
             delete_installer=True,
         )

--- a/docs/examples/SIMA example.ipynb
+++ b/docs/examples/SIMA example.ipynb
@@ -76,7 +76,7 @@
     "sequences = [sima.Sequence.create(\"TIFF\", tiff) for tiff in tiffs[:1]]\n",
     "try:\n",
     "    dataset = sima.ImagingDataset(sequences, \"example.sima\")\n",
-    "except BaseException:\n",
+    "except Exception:\n",
     "    dataset = sima.ImagingDataset.load(\"example.sima\")"
    ]
   },

--- a/examples/SIMA example.ipynb
+++ b/examples/SIMA example.ipynb
@@ -76,7 +76,7 @@
     "sequences = [sima.Sequence.create(\"TIFF\", tiff) for tiff in tiffs[:1]]\n",
     "try:\n",
     "    dataset = sima.ImagingDataset(sequences, \"example.sima\")\n",
-    "except BaseException:\n",
+    "except Exception:\n",
     "    dataset = sima.ImagingDataset.load(\"example.sima\")"
    ]
   },

--- a/fissa/core.py
+++ b/fissa/core.py
@@ -383,7 +383,9 @@ def separate_trials(
             message_extra = " for ROI {}".format(label)
         warnings.warn(
             "{}Found values below zero in raw signal{}. Offsetting so minimum is 0."
-            "".format(header, message_extra)
+            "".format(header, message_extra),
+            UserWarning,
+            stacklevel=2,
         )
         X -= X.min()
 
@@ -1177,7 +1179,7 @@ class Experiment:
                 self.load(fname)
                 if self.raw is not None:
                     return
-            except BaseException as err:
+            except Exception as err:
                 print("An error occurred while loading {}".format(fname))
                 print(err)
                 print("Extraction will be redone and {} overwritten".format(fname))
@@ -1379,7 +1381,7 @@ class Experiment:
                 self.load(fname)
                 if self.result is not None:
                     return
-            except BaseException as err:
+            except Exception as err:
                 print("An error occurred while loading {}".format(fname))
                 print(err)
                 print(
@@ -1859,6 +1861,7 @@ class Experiment:
             "The experiment.save_to_matlab() method is deprecated."
             " Please use experiment.to_matfile() instead.",
             DeprecationWarning,
+            stacklevel=2,
         )
         return self.to_matfile(fname=fname, legacy=True)
 

--- a/fissa/core.py
+++ b/fissa/core.py
@@ -1321,7 +1321,7 @@ class Experiment:
                 field: getattr(self, field)
                 for field in fields
                 if getattr(self, field) is not None
-            }
+            },
         )
 
     def separate(self, redo_prep=False, redo_sep=False):
@@ -1539,7 +1539,7 @@ class Experiment:
                 field: getattr(self, field)
                 for field in fields
                 if getattr(self, field) is not None
-            }
+            },
         )
 
     def calc_deltaf(self, freq, use_raw_f0=True, across_trials=True):

--- a/fissa/extraction.py
+++ b/fissa/extraction.py
@@ -191,7 +191,9 @@ class DataHandlerTifffile(DataHandlerAbstract):
                         " with {} dimensions (page shaped {})."
                         " All dimensions before the final two (height and"
                         " width) will be treated as time-like and flattened."
-                        "".format(image, n_pages, page.ndim, page.shape)
+                        "".format(image, n_pages, page.ndim, page.shape),
+                        UserWarning,
+                        stacklevel=2,
                     )
                 elif page.ndim > 3 and (np.array(page.shape[:-2]) > 1).sum() > 1:
                     warnings.warn(
@@ -199,7 +201,9 @@ class DataHandlerTifffile(DataHandlerAbstract):
                         " (page shaped {})."
                         " All dimensions before the final two (height and"
                         " width) will be treated as time-like and flattened."
-                        "".format(image, page.ndim, page.shape)
+                        "".format(image, page.ndim, page.shape),
+                        UserWarning,
+                        stacklevel=2,
                     )
                 shp = [-1] + list(page.shape[-2:])
                 frames.append(page.reshape(shp))
@@ -327,7 +331,9 @@ class DataHandlerTifffileLazy(DataHandlerAbstract):
                     " with {} dimensions (page shaped {})."
                     " All dimensions before the final two (height and"
                     " width) will be treated as time-like and flattened."
-                    "".format("", n_pages, page.ndim, page.shape)
+                    "".format("", n_pages, page.ndim, page.shape),
+                    UserWarning,
+                    stacklevel=2,
                 )
             elif page.ndim > 3 and (np.array(page.shape[:-2]) > 1).sum() > 1:
                 warnings.warn(
@@ -335,7 +341,9 @@ class DataHandlerTifffileLazy(DataHandlerAbstract):
                     " (page shaped {})."
                     " All dimensions before the final two (height and"
                     " width) will be treated as time-like and flattened."
-                    "".format("", page.ndim, page.shape)
+                    "".format("", page.ndim, page.shape),
+                    UserWarning,
+                    stacklevel=2,
                 )
             shp = [-1] + list(page.shape[-2:])
             page = page.reshape(shp)

--- a/fissa/neuropil.py
+++ b/fissa/neuropil.py
@@ -245,7 +245,7 @@ def separate(
                 print("{}Trying a new random state.".format(prefix))
             # Change to a new random_state
             if random_state is not None:
-                random_state = (random_state + 1) % 2 ** 32
+                random_state = (random_state + 1) % 2**32
 
     if estimator.n_iter_ == max_iter:
         if verbosity >= 1:

--- a/fissa/readimagejrois.py
+++ b/fissa/readimagejrois.py
@@ -275,7 +275,7 @@ def _parse_roi_file_py2(roi_obj):
             coords = _getcoords(z)
             coords = coords.astype("float")
             return {"polygons": coords}
-        except BaseException:
+        except Exception:
             raise ValueError(
                 "read_imagej_roi: ROI type {} not supported".format(roi_type)
             )

--- a/fissa/tests/base_test.py
+++ b/fissa/tests/base_test.py
@@ -79,7 +79,7 @@ def assert_starts_with(actual, desired):
     """
     try:
         assert len(actual) >= len(desired)
-    except BaseException:
+    except Exception:
         print(
             "Actual string too short ({} < {} characters)".format(
                 len(actual), len(desired)
@@ -89,7 +89,7 @@ def assert_starts_with(actual, desired):
         raise
     try:
         return assert_equal(str(actual)[: len(desired)], desired)
-    except BaseException as err:
+    except Exception as err:
         msg = "ACTUAL: {}".format(actual)
         if isinstance(getattr(err, "args", None), str):
             err.args += "\n" + msg

--- a/fissa/tests/generate_downsampled_resources.py
+++ b/fissa/tests/generate_downsampled_resources.py
@@ -318,7 +318,7 @@ def downscale_roi(source_file, dest_file, downsamp=None, offsets=None):
                 _writecoords(coords)
                 coords = coords.astype("float")
                 # return {'polygons': coords}
-            except BaseException:
+            except Exception:
                 raise ValueError(
                     "read_imagej_roi: ROI type {} not supported".format(roi_type)
                 )

--- a/fissa/tests/test_core.py
+++ b/fissa/tests/test_core.py
@@ -1251,7 +1251,7 @@ class ExperimentTestMixin:
         # Make a save file which contains values set to `None`
         fname = os.path.join(self.output_dir, "dummy.npz")
         os.makedirs(self.output_dir)
-        np.savez_compressed(fname, **{field: None for field in fields})
+        np.savez_compressed(fname, **{field: None for field in fields})  # noqa: C420
         # Load the file and check the data appears as None, not np.array(None)
         exp.load(fname, force=True)
         for field in fields:
@@ -1281,7 +1281,7 @@ class ExperimentTestMixin:
         # Make a save file which contains values set to a scalar
         fname = os.path.join(self.output_dir, "dummy.npz")
         os.makedirs(self.output_dir)
-        np.savez_compressed(fname, **{field: 1337 for field in fields})
+        np.savez_compressed(fname, **{field: 1337 for field in fields})  # noqa: C420
         # Load the file and check the data appears correctly
         exp.load(fname, force=True)
         for field in fields:

--- a/fissa/tests/test_polygons.py
+++ b/fissa/tests/test_polygons.py
@@ -23,6 +23,7 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
+
 # Unit tests for sima/ROI.py
 # Tests follow conventions for NumPy/SciPy available at
 # https://github.com/numpy/numpy/blob/master/doc/TESTS.rst.txt

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,2 @@
-black==21.12b0; python_version>='3.6'
+black==24.8.0; python_version>='3.6'
 pre-commit

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 future>=0.16.0
 joblib>=0.14.1
-numpy>=1.13.0
+numpy>=1.13.0,<2.0
 Pillow>=4.3.0
 read-roi>=1.5.0; python_version>='3.0'
 scikit-image>=0.13.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ read-roi>=1.5.0; python_version>='3.0'
 scikit-image>=0.13.0
 scikit-learn>=0.17.0,<1.2
 scipy>=0.19.0
-shapely>=1.5.17
+shapely>=1.5.17,<2.0
 six>=1.11.0
 tifffile>=0.10.0; python_version>='3.6'
 tifffile>=0.10.0,<=2019.7.26; python_version<'3.6'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 future>=0.16.0
 joblib>=0.14.1
-numpy>=1.13.0,<2.0
+numpy>=1.13.0,<1.24
 Pillow>=4.3.0
 read-roi>=1.5.0; python_version>='3.0'
 scikit-image>=0.13.0


### PR DESCRIPTION
- Upgrade outdated tests
- Constrain requirements with upper bounds `numpy>=1.13.0,<1.24` and `shapely>=1.5.17,<2.0` as we do not currently support newer versions of these dependencies. Numpy 1.24 [stopped automatically detecting ragged arrays](https://numpy.org/neps/nep-0034-infer-dtype-is-object.html), which now need to be specified with `dtype=object`. Shapely 2.0 has some backward-incompatible API changes.

Closes #285. Closes #290.