### PR TITLE
DOC+REL: Require more recent sphinx and Jinja2 versions

### DIFF
--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,10 +1,11 @@
-Jinja2<3.1.0
+Jinja2<3.1.0; python_version<'3.6'
+Jinja2>=3.0; python_version>='3.6'
 nbsphinx
 numpydoc>=0.7.0
 pydata-sphinx-theme; python_version>='3.6'
 pypandoc==1.3; python_version<'3.0'
 pypandoc>=1.6.3; python_version>='3.0'
 sphinx; python_version<'3.6'
-sphinx>=2; python_version>='3.6'
+sphinx>=6.0.0; python_version>='3.6'
 sphinx-autobuild
 sphinx_rtd_theme; python_version<'3.6'


### PR DESCRIPTION
This bump to the documentation builder versions ~should~ might fix the GHA docs build.