### PR TITLE
REL: Set maximum tifffile version, as 2025.2.18 removed imsave

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,6 @@ scikit-learn>=0.17.0,<1.2
 scipy>=0.19.0
 shapely>=1.5.17,<2.0
 six>=1.11.0
-tifffile>=0.10.0; python_version>='3.6'
+tifffile>=0.10.0,<=2025.1.10; python_version>='3.6'
 tifffile>=0.10.0,<=2019.7.26; python_version<'3.6'
 tqdm>=4.59.0


### PR DESCRIPTION
See tifffile changelog here: https://github.com/cgohlke/tifffile/blob/f1d053c1f9922a207b84df615eefa52c6fbae3bb/CHANGES.rst#L9

I think imsave was renamed to imwrite, but I'm not 100% sure.