### PR TITLE
DEV: Drop sima from GHA as it no longer builds

### DIFF
--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -40,7 +40,6 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         python -m pip install .[plotting]
-        python -m pip install sima
 
     - name: Build notebooks
       run: |


### PR DESCRIPTION
See gh-pages/notebooks action here: https://github.com/rochefort-lab/fissa/actions/runs/13506739558