### PR TITLE
DOC: Correct path to conf.py for readthedocs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -10,4 +10,4 @@ python:
     - requirements: docs/requirements.txt
 
 sphinx:
-  configuration: docs/source/conf.py
+  configuration: docs/conf.py


### PR DESCRIPTION
Forgot to commit this in #296, so the path to conf.py was wrong.